### PR TITLE
Ado 2007 bug fix

### DIFF
--- a/app/Filament/Exports/FormExporter.php
+++ b/app/Filament/Exports/FormExporter.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Filament\Exports;
+
+use App\Models\Form;
+use Filament\Actions\Exports\ExportColumn;
+use Filament\Actions\Exports\Exporter;
+use Filament\Actions\Exports\Models\Export;
+use Illuminate\Support\Facades\Log;
+
+class FormExporter extends Exporter
+{
+    protected static ?string $model = Form::class;
+
+    public static function getColumns(): array
+    {
+        try {
+            return [
+                ExportColumn::make('form_id')
+                    ->label('Form ID'),
+                ExportColumn::make('form_title')
+                    ->label('Form Title'),
+                ExportColumn::make('ministry.short_name')
+                    ->label('Ministry'),
+                ExportColumn::make('businessAreas.name')
+                    ->label('Business Areas'),
+                ExportColumn::make('program'),
+                ExportColumn::make('form_purpose')
+                    ->label('Form Purpose'),
+                ExportColumn::make('notes'),
+                ExportColumn::make('decommissioned')
+                    ->label('Decommissioned')
+                    ->formatStateUsing(fn($state) => $state ? 'Yes' : 'No'),
+                ExportColumn::make('icm_generated')
+                    ->label('ICM Generated')
+                    ->formatStateUsing(fn($state) => $state ? 'Yes' : 'No'),
+                ExportColumn::make('icm_non_interactive')
+                    ->label('ICM Non-Interactive')
+                    ->formatStateUsing(fn($state) => $state ? 'Yes' : 'No'),
+                ExportColumn::make('formSoftwareSources.name')
+                    ->label('Form Software Sources'),
+                ExportColumn::make('formLocations.name')
+                    ->label('Form Locations'),
+                ExportColumn::make('formRepositories.name')
+                    ->label('Form Repositories'),
+                ExportColumn::make('formTags.name')
+                    ->label('Form Tags'),
+                ExportColumn::make('fillType.name')
+                    ->label('Fill Type'),
+                ExportColumn::make('formFrequency.name')
+                    ->label('Form Frequency'),
+                ExportColumn::make('formReach.name')
+                    ->label('Form Reach'),
+                ExportColumn::make('userTypes.name')
+                    ->label('User Types'),
+                ExportColumn::make('print_reason')
+                    ->label('Print Reason'),
+                ExportColumn::make('orbeon_functions')
+                    ->label('Orbeon Functions'),
+                ExportColumn::make('retention_needs')
+                    ->label('Retention Needs (years)'),
+                ExportColumn::make('relatedForms.form_title')
+                    ->label('Related Forms'),
+                ExportColumn::make('footer_fragment_path')
+                    ->label('Footer Fragment Path'),
+                ExportColumn::make('workbenchPaths.workbench_path')
+                    ->label('Workbench Paths'),
+                ExportColumn::make('dcv_material_number')
+                    ->label('DCV Material Number'),
+            ];
+        } catch (\Exception $e) {
+            return [];
+        }
+    }
+
+    public static function getCompletedNotificationBody(Export $export): string
+    {
+        $body = 'Your form export has completed and ' . number_format($export->successful_rows) . ' ' . str('row')->plural($export->successful_rows) . ' exported.';
+
+        if ($failedRowsCount = $export->getFailedRowsCount()) {
+            $body .= ' ' . number_format($failedRowsCount) . ' ' . str('row')->plural($failedRowsCount) . ' failed to export.';
+        }
+
+        return $body;
+    }
+}

--- a/app/Filament/Forms/Resources/FormResource.php
+++ b/app/Filament/Forms/Resources/FormResource.php
@@ -30,10 +30,13 @@ class FormResource extends Resource
             ->schema([
                 Forms\Components\TextInput::make('form_id')
                     ->required()
-                    ->maxLength(255),
+                    ->maxLength(255)
+                    ->unique(ignoreRecord: true)
+                    ->label('Form ID'),
                 Forms\Components\TextInput::make('form_title')
                     ->required()
-                    ->maxLength(255),
+                    ->maxLength(255)
+                    ->label('Form Title'),
                 Forms\Components\Select::make('ministry_id')
                     ->relationship('ministry', 'name'),
                 Forms\Components\Select::make('business_areas')

--- a/app/Filament/Forms/Resources/FormResource.php
+++ b/app/Filament/Forms/Resources/FormResource.php
@@ -87,10 +87,19 @@ class FormResource extends Resource
                     ->label('Retention Needs (years)')
                     ->numeric()
                     ->nullable(),
-                Forms\Components\Select::make('related_forms')
-                    ->multiple()
-                    ->preload()
-                    ->relationship('relatedForms', 'form_title'),
+                Forms\Components\MultiSelect::make('related_forms')
+                    ->relationship('relatedForms', 'id')
+                    ->searchable()
+                    ->getSearchResultsUsing(function (string $searchQuery) {
+                        return Form::query()
+                            ->where('form_id', 'like', "%{$searchQuery}%")
+                            ->orWhere('form_title', 'like', "%{$searchQuery}%")
+                            ->limit(50)
+                            ->pluck('form_id', 'id');
+                    })
+                    ->getOptionLabelsUsing(function ($values) {
+                        return Form::whereIn('id', $values)->pluck('form_id', 'id');
+                    }),
                 Forms\Components\Repeater::make('links')
                     ->relationship('links')
                     ->schema([

--- a/app/Filament/Forms/Resources/FormResource.php
+++ b/app/Filament/Forms/Resources/FormResource.php
@@ -125,12 +125,11 @@ class FormResource extends Resource
             ->columns([
                 Tables\Columns\TextColumn::make('form_id')->searchable()->sortable(),
                 Tables\Columns\TextColumn::make('form_title')->searchable()->sortable(),
-                Tables\Columns\TextColumn::make('ministry.name'),
+                Tables\Columns\TextColumn::make('ministry.short_name'),
                 Tables\Columns\TagsColumn::make('businessAreas.name'),
                 Tables\Columns\TextColumn::make('form_purpose')->searchable(['notes', 'form_purpose']),
                 Tables\Columns\TagsColumn::make('formLocations.name'),
                 Tables\Columns\TagsColumn::make('formSoftwareSources.name'),
-                Tables\Columns\BooleanColumn::make('decommissioned'),
             ])
             ->filters([
                 Tables\Filters\Filter::make('decommissioned')

--- a/app/Filament/Forms/Resources/FormResource.php
+++ b/app/Filament/Forms/Resources/FormResource.php
@@ -15,6 +15,8 @@ use Filament\Tables\Actions\DeleteAction;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Actions\ActionGroup;
+use App\Filament\Exports\FormExporter;
+use Filament\Tables\Actions\ExportAction;
 
 class FormResource extends Resource
 {
@@ -154,6 +156,10 @@ class FormResource extends Resource
                     ->relationship('businessAreas', 'name')
                     ->preload()
                     ->label('Business Area'),
+            ])
+            ->headerActions([
+                ExportAction::make()
+                    ->exporter(FormExporter::class)
             ])
             ->actions([
                 ActionGroup::make([

--- a/app/Filament/Forms/Resources/FormResource.php
+++ b/app/Filament/Forms/Resources/FormResource.php
@@ -38,7 +38,7 @@ class FormResource extends Resource
                     ->multiple()
                     ->preload()
                     ->relationship('businessAreas', 'name'),
-                // todo: program area
+                Forms\Components\TextInput::make(name: 'program'),
                 Forms\Components\Textarea::make('form_purpose'),
                 Forms\Components\Textarea::make('notes'),
                 Forms\Components\Toggle::make('decommissioned'),

--- a/app/Filament/Forms/Resources/FormResource.php
+++ b/app/Filament/Forms/Resources/FormResource.php
@@ -34,49 +34,24 @@ class FormResource extends Resource
                     ->maxLength(255),
                 Forms\Components\Select::make('ministry_id')
                     ->relationship('ministry', 'name'),
-                Forms\Components\Textarea::make('form_purpose'),
-                Forms\Components\Textarea::make('notes'),
-                Forms\Components\Select::make('fill_type_id')
-                    ->relationship('fillType', 'name'),
-                Forms\Components\Toggle::make('decommissioned'),
-                Forms\Components\Select::make('form_frequency_id')
-                    ->relationship('formFrequency', 'name'),
-                Forms\Components\Select::make('form_reach_id')
-                    ->relationship('formReach', 'name'),
-                Forms\Components\TextInput::make('print_reason')
-                    ->label('Print Reason')
-                    ->nullable()
-                    ->maxLength(255),
-                Forms\Components\TextInput::make('retention_needs')
-                    ->label('Retention Needs (years)')
-                    ->numeric()
-                    ->nullable(),
-                Forms\Components\Toggle::make('icm_non_interactive')
-                    ->label('ICM Non-Interactive')
-                    ->nullable(),
-                Forms\Components\Toggle::make('icm_generated')
-                    ->label('ICM Generated')
-                    ->nullable(),
-                Forms\Components\TextInput::make('footer_fragment_path')
-                    ->label('Footer Fragment Path')
-                    ->nullable()
-                    ->maxLength(255),
-                Forms\Components\TextInput::make('dcv_material_number')
-                    ->label('DCV Material Number')
-                    ->nullable()
-                    ->minLength(10)
-                    ->maxLength(10),
-                Forms\Components\Textarea::make('orbeon_functions')
-                    ->label('Orbeon Functions')
-                    ->nullable(),
                 Forms\Components\Select::make('business_areas')
                     ->multiple()
                     ->preload()
                     ->relationship('businessAreas', 'name'),
-                Forms\Components\Select::make('form_tags')
+                // todo: program area
+                Forms\Components\Textarea::make('form_purpose'),
+                Forms\Components\Textarea::make('notes'),
+                Forms\Components\Toggle::make('decommissioned'),
+                Forms\Components\Toggle::make('icm_generated')
+                    ->label('ICM Generated')
+                    ->nullable(),
+                Forms\Components\Toggle::make('icm_non_interactive')
+                    ->label('ICM Non-Interactive')
+                    ->nullable(),
+                Forms\Components\Select::make('form_software_sources')
                     ->multiple()
                     ->preload()
-                    ->relationship('formTags', 'name'),
+                    ->relationship('formSoftwareSources', 'name'),
                 Forms\Components\Select::make('form_locations')
                     ->multiple()
                     ->preload()
@@ -85,14 +60,31 @@ class FormResource extends Resource
                     ->multiple()
                     ->preload()
                     ->relationship('formRepositories', 'name'),
-                Forms\Components\Select::make('form_software_sources')
+                Forms\Components\Select::make('form_tags')
                     ->multiple()
                     ->preload()
-                    ->relationship('formSoftwareSources', 'name'),
+                    ->relationship('formTags', 'name'),
+                Forms\Components\Select::make('fill_type_id')
+                    ->relationship('fillType', 'name'),
+                Forms\Components\Select::make('form_frequency_id')
+                    ->relationship('formFrequency', 'name'),
+                Forms\Components\Select::make('form_reach_id')
+                    ->relationship('formReach', 'name'),
                 Forms\Components\Select::make('user_types')
                     ->multiple()
                     ->preload()
                     ->relationship('userTypes', 'name'),
+                Forms\Components\TextInput::make('print_reason')
+                    ->label('Print Reason')
+                    ->nullable()
+                    ->maxLength(255),
+                Forms\Components\Textarea::make('orbeon_functions')
+                    ->label('Orbeon Functions')
+                    ->nullable(),
+                Forms\Components\TextInput::make('retention_needs')
+                    ->label('Retention Needs (years)')
+                    ->numeric()
+                    ->nullable(),
                 Forms\Components\Select::make('related_forms')
                     ->multiple()
                     ->preload()
@@ -106,6 +98,10 @@ class FormResource extends Resource
                     ->columns(1)
                     ->defaultItems(0)
                     ->createItemButtonLabel('Add Link'),
+                Forms\Components\TextInput::make('footer_fragment_path')
+                    ->label('Footer Fragment Path')
+                    ->nullable()
+                    ->maxLength(255),
                 Forms\Components\Repeater::make('workbench_paths')
                     ->relationship('workbenchPaths')
                     ->schema([
@@ -115,6 +111,11 @@ class FormResource extends Resource
                     ->columns(1)
                     ->defaultItems(0)
                     ->createItemButtonLabel('Add Workbench Path'),
+                Forms\Components\TextInput::make('dcv_material_number')
+                    ->label('DCV Material Number')
+                    ->nullable()
+                    ->minLength(10)
+                    ->maxLength(10),
             ]);
     }
 

--- a/app/Models/Form.php
+++ b/app/Models/Form.php
@@ -18,6 +18,7 @@ class Form extends Model
         'ministry_id',
         'form_purpose',
         'notes',
+        'program',
         'fill_type_id',
         'decommissioned',
         'form_frequency_id',

--- a/app/Providers/Filament/FormsPanelProvider.php
+++ b/app/Providers/Filament/FormsPanelProvider.php
@@ -32,6 +32,7 @@ class FormsPanelProvider extends PanelProvider
             ->darkModeBrandLogo(asset('svg/klamm-logo-dark.svg'))
             ->homeUrl('/welcome')
             ->login()
+            ->databaseNotifications()
             ->colors([
                 'primary' => Color::Blue,
             ])

--- a/database/migrations/2024_10_11_011958_add_form_program_to_forms_table.php
+++ b/database/migrations/2024_10_11_011958_add_form_program_to_forms_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->string('program')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->dropColumn([
+                'program',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2024_10_11_024036_create_notifications_table.php
+++ b/database/migrations/2024_10_11_024036_create_notifications_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('type');
+            $table->morphs('notifiable');
+            $table->json('data');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};

--- a/database/migrations/2024_10_11_024309_create_imports_table.php
+++ b/database/migrations/2024_10_11_024309_create_imports_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('imports', function (Blueprint $table) {
+            $table->id();
+            $table->timestamp('completed_at')->nullable();
+            $table->string('file_name');
+            $table->string('file_path');
+            $table->string('importer');
+            $table->unsignedInteger('processed_rows')->default(0);
+            $table->unsignedInteger('total_rows');
+            $table->unsignedInteger('successful_rows')->default(0);
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('imports');
+    }
+};

--- a/database/migrations/2024_10_11_024310_create_exports_table.php
+++ b/database/migrations/2024_10_11_024310_create_exports_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('exports', function (Blueprint $table) {
+            $table->id();
+            $table->timestamp('completed_at')->nullable();
+            $table->string('file_disk');
+            $table->string('file_name')->nullable();
+            $table->string('exporter');
+            $table->unsignedInteger('processed_rows')->default(0);
+            $table->unsignedInteger('total_rows');
+            $table->unsignedInteger('successful_rows')->default(0);
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('exports');
+    }
+};

--- a/database/migrations/2024_10_11_024311_create_failed_import_rows_table.php
+++ b/database/migrations/2024_10_11_024311_create_failed_import_rows_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('failed_import_rows', function (Blueprint $table) {
+            $table->id();
+            $table->json('data');
+            $table->foreignId('import_id')->constrained()->cascadeOnDelete();
+            $table->text('validation_error')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('failed_import_rows');
+    }
+};


### PR DESCRIPTION
## What changes did you make? 

Bug: duplicate form_id returns 500 not a warning when trying to edit/create

In the Form List Viewer:

- “Ministry” column show the short name ("MCFD") to save space.

- “Decommissioned” column can be removed, since there is a universal on/off filter for this value

 

Add new field/property to a form:

- “Program” – text field -- it is useful for when a large business area like SDD wants to list a specific Program.

 

Weird behaviour the "Related Forms" field. It’s a small list and I don't recognize them. It doesn't seem to be the ID or title.

 

Feature request: (let me know if this is reasonable)

- export the form list as CSV, with all fields

 

Update form viewer/editor layout order to:

- Form ID

- Form Title

- Ministry

- Business Area

- Program

- Form Purpose

- Notes

- Decommissioned

- ICM Generated

- ICM Non-Interactive

- Form Software Sources

- Form Locations

- Form Repositories

- Form Tags

- Fill Type

- Form Frequency

- Form Reach

- User Types

- Print Reason

- Orbeon Functions

- Retention Needs (Years)

- Related Forms

- Links

- Footer Fragment Paths

- Workbench Paths

