### PR TITLE
Form groups for form versions

### DIFF
--- a/app/Filament/Forms/Resources/FormResource.php
+++ b/app/Filament/Forms/Resources/FormResource.php
@@ -132,15 +132,21 @@ class FormResource extends Resource
                 Tables\Columns\BooleanColumn::make('decommissioned'),
             ])
             ->filters([
-                Tables\Filters\Filter::make('decommissioned')
+                Tables\Filters\Filter::make('status')
                     ->form([
+                        Forms\Components\Checkbox::make('active')
+                            ->label('Active')
+                            ->default(false),
                         Forms\Components\Checkbox::make('decommissioned')
                             ->label('Decommissioned')
                             ->default(false),
                     ])
                     ->query(function (Builder $query, array $data): Builder {
-                        if (isset($data['decommissioned'])) {
-                            return $query->where('decommissioned', $data['decommissioned']);
+                        if (!empty($data['decommissioned'])) {
+                            return $query->where('decommissioned', true);
+                        }
+                        if (!empty($data['active'])) {
+                            return $query->where('decommissioned', false);
                         }
                         return $query;
                     }),

--- a/app/Filament/Forms/Resources/FormVersionResource.php
+++ b/app/Filament/Forms/Resources/FormVersionResource.php
@@ -4,7 +4,8 @@ namespace App\Filament\Forms\Resources;
 
 use App\Filament\Forms\Resources\FormVersionResource\Pages;
 use App\Models\FormVersion;
-use Filament\Forms;
+use App\Models\FormField;
+use App\Models\FieldGroup;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
@@ -16,6 +17,10 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Actions;
+use Filament\Forms\Components\Actions\Action;
+use Filament\Forms\Get;
+use Filament\Forms\Set;
 
 
 class FormVersionResource extends Resource
@@ -26,8 +31,20 @@ class FormVersionResource extends Resource
 
     protected static bool $shouldRegisterNavigation = false;
 
+    public $availableFields = [];
+
     public static function form(Form $form): Form
     {
+        $availableFields = [
+            'Fields' => FormField::all()->mapWithKeys(function ($item) {
+                return ['fld_' . $item->id => $item->label];
+            })->toArray(),
+            'Groups' => FieldGroup::all()->mapWithKeys(function ($group) {
+                return ['grp_' . $group->id => $group->label];
+            })->toArray(),
+        ];
+        $selectedFields = [];
+
         return $form
             ->schema([
                 Select::make('form_id')
@@ -77,73 +94,38 @@ class FormVersionResource extends Resource
                 DateTimePicker::make('deployed_at')
                     ->label('Deployment Date'),
 
-                Repeater::make('form_instance_fields')
-                    ->label('Form Fields')
-                    ->relationship('formInstanceFields')
+                Repeater::make('selectedFields')
+                    ->label('Form Fields/Groups')
                     ->columnSpan(2)
                     ->reorderable(true)
                     ->defaultItems(0)
-                    ->itemLabel(
-                        fn($state) => $state['label'] ?? \App\Models\FormField::find($state['form_field_id'])->label ?? 'Unknown Field'
-                    )
+                    ->addActionLabel("Add Another Form Field / Group")
+                    ->collapsed()
                     ->schema([
-                        Select::make('form_field_id')
-                            ->label('Form Field')
-                            ->relationship('formField', 'label')
-                            ->required(),
-                        TextInput::make('label')
-                            ->label("Custom Label")
-                            ->placeholder(fn($get) => \App\Models\FormField::find($get('form_field_id'))->label ?? null),
-                        TextInput::make('data_binding')
-                            ->label("Custom Data Binding")
-                            ->placeholder(fn($get) => \App\Models\FormField::find($get('form_field_id'))->data_binding ?? null),
-                        Repeater::make('validations')
-                            ->label('Validations')
-                            ->relationship('validations')
-                            ->collapsible()
-                            ->schema([
-                                Select::make('type')
-                                    ->label('Validation Type')
-                                    ->options([
-                                        'minValue' => 'Minimum Value',
-                                        'maxValue' => 'Maximum Value',
-                                        'minLength' => 'Minimum Length',
-                                        'maxLength' => 'Maximum Length',
-                                        'required' => 'Required',
-                                        'email' => 'Email',
-                                        'phone' => 'Phone Number',
-                                        'javascript' => 'JavaScript',
-                                    ])
-                                    ->reactive()
-                                    ->required(),
-                                TextInput::make('value')
-                                    ->label('Value'),
-                                TextInput::make('error_message')
-                                    ->label('Error Message'),
-                            ]),
-                        Textarea::make('conditional_logic')
-                            ->label("Custom Conditional Logic")
-                            ->placeholder(fn($get) => \App\Models\FormField::find($get('form_field_id'))->conditional_logic ?? null),
-                        Textarea::make('styles')
-                            ->label("Custom Styles")
-                            ->placeholder(fn($get) => \App\Models\FormField::find($get('form_field_id'))->styles ?? null),
+                        Select::make("field")
+                            ->label("Form Field / Group")
+                            ->options($availableFields)
+                            ->required()
+                            ->live()
+                            ->reactive()
+                            ->searchable(),
                     ])
                     ->collapsed(),
-                Forms\Components\Actions::make([
-                    Forms\Components\Actions\Action::make('Generate Form Template')
-                        ->action(function (Forms\Get $get, Forms\Set $set) {
+                Actions::make([
+                    Action::make('Generate Form Template')
+                        ->action(function (Get $get, Set $set) {
                             $formId = $get('id');
                             $jsonTemplate = \App\Helpers\FormTemplateHelper::generateJsonTemplate($formId);
                             $set('generated_text', $jsonTemplate);
                         }),
-                    Forms\Components\Actions\Action::make('Preview Form Template')
-                        ->url(function (Forms\Get $get) {
+                    Action::make('Preview Form Template')
+                        ->url(function (Get $get) {
                             $jsonTemplate = $get('generated_text');
                             $encodedJson = base64_encode($jsonTemplate);
                             return route('forms.rendered_forms.preview', ['json' => $encodedJson]);
                         })
                         ->openUrlInNewTab()
-                        ->disabled(fn(Forms\Get $get) => empty($get('generated_text'))),
+                        ->disabled(fn(Get $get) => empty($get('generated_text'))),
                 ]),
                 Textarea::make('generated_text')
                     ->label('Generated Form Template')

--- a/app/Filament/Forms/Resources/FormVersionResource.php
+++ b/app/Filament/Forms/Resources/FormVersionResource.php
@@ -17,6 +17,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Toggle;
 use Filament\Forms\Components\Actions;
 use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Get;
@@ -83,6 +84,7 @@ class FormVersionResource extends Resource
                     ->label('Deployment Date'),
                 Repeater::make('components')
                     ->label('Form Components')
+                    ->reorderable()
                     ->schema([
                         Select::make('component_type')
                             ->options([
@@ -93,18 +95,67 @@ class FormVersionResource extends Resource
                             ->required(),
                         Select::make('form_field_id')
                             ->label('Form Field')
-                            ->options(FormField::all()->pluck('name', 'id'))
+                            ->options(FormField::pluck('label', 'id'))
+                            ->searchable()
                             ->visible(fn($get) => $get('component_type') === 'form_field')
                             ->required(fn($get) => $get('component_type') === 'form_field'),
                         Select::make('field_group_id')
                             ->label('Field Group')
-                            ->options(FieldGroup::all()->pluck('name', 'id'))
+                            ->options(FieldGroup::pluck('label', 'id'))
+                            ->searchable()
                             ->visible(fn($get) => $get('component_type') === 'field_group')
                             ->required(fn($get) => $get('component_type') === 'field_group'),
+
+                        TextInput::make('label')
+                            ->label("Custom Label")
+                            ->placeholder(fn($get) => FormField::find($get('form_field_id'))->label ?? null)
+                            ->visible(fn($get) => $get('component_type') === 'form_field'),
+                        TextInput::make('data_binding')
+                            ->label("Custom Data Binding")
+                            ->placeholder(fn($get) => FormField::find($get('form_field_id'))->data_binding ?? null)
+                            ->visible(fn($get) => $get('component_type') === 'form_field'),
+                        Textarea::make('conditional_logic')
+                            ->label("Custom Conditional Logic")
+                            ->placeholder(fn($get) => FormField::find($get('form_field_id'))->conditional_logic ?? null)
+                            ->visible(fn($get) => $get('component_type') === 'form_field'),
+                        Textarea::make('styles')
+                            ->label("Custom Styles")
+                            ->placeholder(fn($get) => FormField::find($get('form_field_id'))->styles ?? null)
+                            ->visible(fn($get) => $get('component_type') === 'form_field'),
+                        Repeater::make('validations')
+                            ->label('Validations')
+                            ->schema([
+                                Select::make('type')
+                                    ->label('Validation Type')
+                                    ->options([
+                                        'minValue' => 'Minimum Value',
+                                        'maxValue' => 'Maximum Value',
+                                        'minLength' => 'Minimum Length',
+                                        'maxLength' => 'Maximum Length',
+                                        'required' => 'Required',
+                                        'email' => 'Email',
+                                        'phone' => 'Phone Number',
+                                        'javascript' => 'JavaScript',
+                                    ])
+                                    ->reactive()
+                                    ->required(),
+                                TextInput::make('value')
+                                    ->label('Value'),
+                                TextInput::make('error_message')
+                                    ->label('Error Message'),
+                            ])
+                            ->visible(fn($get) => $get('component_type') === 'form_field'),
+
+                        TextInput::make('group_label')
+                            ->label("Group Label")
+                            ->placeholder(fn($get) => FieldGroup::find($get('field_group_id'))->label ?? null)
+                            ->visible(fn($get) => $get('component_type') === 'field_group'),
+                        Toggle::make('repeater')
+                            ->label('Repeater')
+                            ->visible(fn($get) => $get('component_type') === 'field_group'),
                     ])
-                    ->createItemButtonLabel('Add Form Field or Field Group')
-                    ->columnSpan(2)
-                    ->reorderable(),
+                    ->addActionLabel('Add Form Field or Field Group')
+                    ->columnSpan(2),
                 Actions::make([
                     Action::make('Generate Form Template')
                         ->action(function (Get $get, Set $set) {

--- a/app/Filament/Forms/Resources/FormVersionResource.php
+++ b/app/Filament/Forms/Resources/FormVersionResource.php
@@ -117,6 +117,7 @@ class FormVersionResource extends Resource
                                 Repeater::make('validations')
                                     ->label('Validations')
                                     ->collapsible()
+                                    ->defaultItems(0)
                                     ->schema([
                                         Select::make('type')
                                             ->label('Validation Type')
@@ -194,6 +195,7 @@ class FormVersionResource extends Resource
                                         Repeater::make('validations')
                                             ->label('Validations')
                                             ->collapsible()
+                                            ->defaultItems(0)
                                             ->schema([
                                                 Select::make('type')
                                                     ->label('Validation Type')
@@ -228,7 +230,7 @@ class FormVersionResource extends Resource
                             $jsonTemplate = \App\Helpers\FormTemplateHelper::generateJsonTemplate($formId);
                             $set('generated_text', $jsonTemplate);
                         })
-                        ->hidden(fn() => request()->routeIs('filament.forms.resources.form-versions.create') || request()->routeIs('filament.forms.resources.form-versions.edit')),
+                        ->hidden(fn($livewire) => ! ($livewire instanceof \Filament\Resources\Pages\ViewRecord)),
                     Action::make('Preview Form Template')
                         ->url(function (Get $get) {
                             $jsonTemplate = $get('generated_text');
@@ -237,13 +239,13 @@ class FormVersionResource extends Resource
                         })
                         ->openUrlInNewTab()
                         ->disabled(fn(Get $get) => empty($get('generated_text')))
-                        ->hidden(fn() => request()->routeIs('filament.forms.resources.form-versions.create') || request()->routeIs('filament.forms.resources.form-versions.edit')),
+                        ->hidden(fn($livewire) => ! ($livewire instanceof \Filament\Resources\Pages\ViewRecord)),
                 ]),
                 Textarea::make('generated_text')
                     ->label('Generated Form Template')
                     ->columnSpan(2)
                     ->rows(15)
-                    ->hidden(fn() => request()->routeIs('filament.forms.resources.form-versions.create') || request()->routeIs('filament.forms.resources.form-versions.edit')),
+                    ->hidden(fn($livewire) => ! ($livewire instanceof \Filament\Resources\Pages\ViewRecord)),
             ]);
     }
 

--- a/app/Filament/Forms/Resources/FormVersionResource.php
+++ b/app/Filament/Forms/Resources/FormVersionResource.php
@@ -117,7 +117,8 @@ class FormVersionResource extends Resource
                             $formId = $get('id');
                             $jsonTemplate = \App\Helpers\FormTemplateHelper::generateJsonTemplate($formId);
                             $set('generated_text', $jsonTemplate);
-                        }),
+                        })
+                        ->hidden(fn() => request()->routeIs('filament.forms.resources.form-versions.create') || request()->routeIs('filament.forms.resources.form-versions.edit')),
                     Action::make('Preview Form Template')
                         ->url(function (Get $get) {
                             $jsonTemplate = $get('generated_text');
@@ -125,12 +126,14 @@ class FormVersionResource extends Resource
                             return route('forms.rendered_forms.preview', ['json' => $encodedJson]);
                         })
                         ->openUrlInNewTab()
-                        ->disabled(fn(Get $get) => empty($get('generated_text'))),
+                        ->disabled(fn(Get $get) => empty($get('generated_text')))
+                        ->hidden(fn() => request()->routeIs('filament.forms.resources.form-versions.create') || request()->routeIs('filament.forms.resources.form-versions.edit')),
                 ]),
                 Textarea::make('generated_text')
                     ->label('Generated Form Template')
                     ->columnSpan(2)
-                    ->rows(15),
+                    ->rows(15)
+                    ->hidden(fn() => request()->routeIs('filament.forms.resources.form-versions.create') || request()->routeIs('filament.forms.resources.form-versions.edit')),
             ]);
     }
 

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/CreateFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/CreateFormVersion.php
@@ -25,6 +25,11 @@ class CreateFormVersion extends CreateRecord
         return $data;
     }
 
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('view', ['record' => $this->record->id]);
+    }
+
     public function mount(): void
     {
         parent::mount();

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/CreateFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/CreateFormVersion.php
@@ -90,19 +90,28 @@ class CreateFormVersion extends CreateRecord
                     'repeater' => $component['repeater'] ?? false,
                 ]);
 
-                $fieldGroup = $fieldGroupInstance->fieldGroup;
-
-                foreach ($fieldGroup->formFields as $fieldOrder => $formField) {
-                    FormInstanceField::create([
+                $formFields = $component['form_fields'] ?? [];
+                foreach ($formFields as $fieldOrder => $fieldData) {
+                    $formInstanceField = FormInstanceField::create([
                         'form_version_id' => $formVersion->id,
-                        'form_field_id' => $formField->id,
+                        'form_field_id' => $fieldData['form_field_id'],
                         'field_group_instance_id' => $fieldGroupInstance->id,
                         'order' => $fieldOrder,
-                        'label' => $formField->label,
-                        'data_binding' => $formField->data_binding,
-                        'conditional_logic' => $formField->conditional_logic,
-                        'styles' => $formField->styles,
+                        'label' => $fieldData['label'] ?? null,
+                        'data_binding' => $fieldData['data_binding'] ?? null,
+                        'conditional_logic' => $fieldData['conditional_logic'] ?? null,
+                        'styles' => $fieldData['styles'] ?? null,
                     ]);
+
+                    $validations = $fieldData['validations'] ?? [];
+                    foreach ($validations as $validationData) {
+                        FormInstanceFieldValidation::create([
+                            'form_instance_field_id' => $formInstanceField->id,
+                            'type' => $validationData['type'],
+                            'value' => $validationData['value'] ?? null,
+                            'error_message' => $validationData['error_message'] ?? null,
+                        ]);
+                    }
                 }
             }
         }

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/CreateFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/CreateFormVersion.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use App\Models\FormInstanceField;
 use App\Models\FieldGroupInstance;
+use App\Models\FormInstanceFieldValidation;
 
 class CreateFormVersion extends CreateRecord
 {
@@ -61,16 +62,32 @@ class CreateFormVersion extends CreateRecord
 
         foreach ($components as $order => $component) {
             if ($component['component_type'] === 'form_field') {
-                FormInstanceField::create([
+                $formInstanceField = FormInstanceField::create([
                     'form_version_id' => $formVersion->id,
                     'form_field_id' => $component['form_field_id'],
                     'order' => $order,
+                    'label' => $component['label'] ?? null,
+                    'data_binding' => $component['data_binding'] ?? null,
+                    'conditional_logic' => $component['conditional_logic'] ?? null,
+                    'styles' => $component['styles'] ?? null,
                 ]);
+
+                $validations = $component['validations'] ?? [];
+                foreach ($validations as $validationData) {
+                    FormInstanceFieldValidation::create([
+                        'form_instance_field_id' => $formInstanceField->id,
+                        'type' => $validationData['type'],
+                        'value' => $validationData['value'] ?? null,
+                        'error_message' => $validationData['error_message'] ?? null,
+                    ]);
+                }
             } elseif ($component['component_type'] === 'field_group') {
                 $fieldGroupInstance = FieldGroupInstance::create([
                     'form_version_id' => $formVersion->id,
                     'field_group_id' => $component['field_group_id'],
                     'order' => $order,
+                    'label' => $component['group_label'] ?? null,
+                    'repeater' => $component['repeater'] ?? false,
                 ]);
 
                 $fieldGroup = $fieldGroupInstance->fieldGroup;
@@ -81,6 +98,10 @@ class CreateFormVersion extends CreateRecord
                         'form_field_id' => $formField->id,
                         'field_group_instance_id' => $fieldGroupInstance->id,
                         'order' => $fieldOrder,
+                        'label' => $formField->label,
+                        'data_binding' => $formField->data_binding,
+                        'conditional_logic' => $formField->conditional_logic,
+                        'styles' => $formField->styles,
                     ]);
                 }
             }

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/CreateFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/CreateFormVersion.php
@@ -6,6 +6,8 @@ use App\Filament\Forms\Resources\FormVersionResource;
 use Filament\Resources\Pages\CreateRecord;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
+use App\Models\FormInstanceField;
+use App\Models\FieldGroupInstance;
 
 class CreateFormVersion extends CreateRecord
 {
@@ -22,6 +24,8 @@ class CreateFormVersion extends CreateRecord
         $data['updater_name'] = $user->name;
         $data['updater_email'] = $user->email;
 
+        unset($data['components']);
+
         return $data;
     }
 
@@ -37,6 +41,49 @@ class CreateFormVersion extends CreateRecord
         $formId = request()->query('form_id');
         if ($formId) {
             $this->form->fill(['form_id' => $formId]);
+        }
+    }
+
+    protected function beforeSave(): void
+    {
+        //
+    }
+
+    protected function afterSave(): void
+    {
+        $formVersion = $this->record;
+        $components = $this->form->getState()['components'] ?? [];
+
+        if (method_exists($this, 'getRecord')) {
+            $formVersion->formInstanceFields()->delete();
+            $formVersion->fieldGroupInstances()->delete();
+        }
+
+        foreach ($components as $order => $component) {
+            if ($component['component_type'] === 'form_field') {
+                FormInstanceField::create([
+                    'form_version_id' => $formVersion->id,
+                    'form_field_id' => $component['form_field_id'],
+                    'order' => $order,
+                ]);
+            } elseif ($component['component_type'] === 'field_group') {
+                $fieldGroupInstance = FieldGroupInstance::create([
+                    'form_version_id' => $formVersion->id,
+                    'field_group_id' => $component['field_group_id'],
+                    'order' => $order,
+                ]);
+
+                $fieldGroup = $fieldGroupInstance->fieldGroup;
+
+                foreach ($fieldGroup->formFields as $fieldOrder => $formField) {
+                    FormInstanceField::create([
+                        'form_version_id' => $formVersion->id,
+                        'form_field_id' => $formField->id,
+                        'field_group_instance_id' => $fieldGroupInstance->id,
+                        'order' => $fieldOrder,
+                    ]);
+                }
+            }
         }
     }
 }

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/EditFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/EditFormVersion.php
@@ -20,6 +20,11 @@ class EditFormVersion extends EditRecord
         return $data;
     }
 
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('view', ['record' => $this->record->id]);
+    }
+
     protected function getHeaderActions(): array
     {
         return [

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/EditFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/EditFormVersion.php
@@ -6,6 +6,8 @@ use App\Filament\Forms\Resources\FormVersionResource;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
 use Illuminate\Support\Facades\Auth;
+use App\Models\FormInstanceField;
+use App\Models\FieldGroupInstance;
 
 class EditFormVersion extends EditRecord
 {
@@ -16,6 +18,8 @@ class EditFormVersion extends EditRecord
         $user = Auth::user();
         $data['updater_name'] = $user->name;
         $data['updater_email'] = $user->email;
+
+        unset($data['components']);
 
         return $data;
     }
@@ -31,5 +35,95 @@ class EditFormVersion extends EditRecord
             Actions\ViewAction::make(),
             Actions\DeleteAction::make(),
         ];
+    }
+
+    protected function afterSave(): void
+    {
+        $formVersion = $this->record;
+        $components = $this->form->getState()['components'] ?? [];
+
+        if (method_exists($this, 'getRecord')) {
+            $formVersion->formInstanceFields()->delete();
+            $formVersion->fieldGroupInstances()->delete();
+        }
+
+        foreach ($components as $order => $component) {
+            if ($component['component_type'] === 'form_field') {
+                FormInstanceField::create([
+                    'form_version_id' => $formVersion->id,
+                    'form_field_id' => $component['form_field_id'],
+                    'order' => $order,
+                ]);
+            } elseif ($component['component_type'] === 'field_group') {
+                $fieldGroupInstance = FieldGroupInstance::create([
+                    'form_version_id' => $formVersion->id,
+                    'field_group_id' => $component['field_group_id'],
+                    'order' => $order,
+                ]);
+
+                $fieldGroup = $fieldGroupInstance->fieldGroup;
+
+                foreach ($fieldGroup->formFields as $fieldOrder => $formField) {
+                    FormInstanceField::create([
+                        'form_version_id' => $formVersion->id,
+                        'form_field_id' => $formField->id,
+                        'field_group_instance_id' => $fieldGroupInstance->id,
+                        'order' => $fieldOrder,
+                    ]);
+                }
+            }
+        }
+    }
+
+
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        $data = array_merge($this->record->toArray(), $data);
+
+        $components = [];
+
+        $formFields = $this->record->formInstanceFields()
+            ->whereNull('field_group_instance_id')
+            ->get();
+
+        $fieldGroups = $this->record->fieldGroupInstances()->get();
+
+        $items = collect();
+
+        foreach ($formFields as $field) {
+            $items->push([
+                'component_type' => 'form_field',
+                'form_field_id' => $field->form_field_id,
+                'order' => $field->order,
+            ]);
+        }
+
+        foreach ($fieldGroups as $group) {
+            $items->push([
+                'component_type' => 'field_group',
+                'field_group_id' => $group->field_group_id,
+                'order' => $group->order,
+            ]);
+        }
+
+        $items = $items->sortBy('order');
+
+        foreach ($items as $item) {
+            if ($item['component_type'] === 'form_field') {
+                $components[] = [
+                    'component_type' => 'form_field',
+                    'form_field_id' => $item['form_field_id'],
+                ];
+            } elseif ($item['component_type'] === 'field_group') {
+                $components[] = [
+                    'component_type' => 'field_group',
+                    'field_group_id' => $item['field_group_id'],
+                ];
+            }
+        }
+
+        $data['components'] = $components;
+
+        return $data;
     }
 }

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/EditFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/EditFormVersion.php
@@ -78,24 +78,32 @@ class EditFormVersion extends EditRecord
                     'repeater' => $component['repeater'] ?? false,
                 ]);
 
-                $fieldGroup = $fieldGroupInstance->fieldGroup;
-
-                foreach ($fieldGroup->formFields as $fieldOrder => $formField) {
-                    FormInstanceField::create([
+                $formFields = $component['form_fields'] ?? [];
+                foreach ($formFields as $fieldOrder => $fieldData) {
+                    $formInstanceField = FormInstanceField::create([
                         'form_version_id' => $formVersion->id,
-                        'form_field_id' => $formField->id,
+                        'form_field_id' => $fieldData['form_field_id'],
                         'field_group_instance_id' => $fieldGroupInstance->id,
                         'order' => $fieldOrder,
-                        'label' => $formField->label,
-                        'data_binding' => $formField->data_binding,
-                        'conditional_logic' => $formField->conditional_logic,
-                        'styles' => $formField->styles,
+                        'label' => $fieldData['label'] ?? null,
+                        'data_binding' => $fieldData['data_binding'] ?? null,
+                        'conditional_logic' => $fieldData['conditional_logic'] ?? null,
+                        'styles' => $fieldData['styles'] ?? null,
                     ]);
+
+                    $validations = $fieldData['validations'] ?? [];
+                    foreach ($validations as $validationData) {
+                        FormInstanceFieldValidation::create([
+                            'form_instance_field_id' => $formInstanceField->id,
+                            'type' => $validationData['type'],
+                            'value' => $validationData['value'] ?? null,
+                            'error_message' => $validationData['error_message'] ?? null,
+                        ]);
+                    }
                 }
             }
         }
     }
-
 
 
     protected function mutateFormDataBeforeFill(array $data): array
@@ -133,11 +141,35 @@ class EditFormVersion extends EditRecord
         $fieldGroups = $this->record->fieldGroupInstances()->get();
 
         foreach ($fieldGroups as $group) {
+            $groupFields = $group->formInstanceFields()->orderBy('order')->get();
+
+            $formFieldsData = [];
+            foreach ($groupFields as $field) {
+                $validations = [];
+                foreach ($field->validations as $validation) {
+                    $validations[] = [
+                        'type' => $validation->type,
+                        'value' => $validation->value,
+                        'error_message' => $validation->error_message,
+                    ];
+                }
+
+                $formFieldsData[] = [
+                    'form_field_id' => $field->form_field_id,
+                    'label' => $field->label,
+                    'data_binding' => $field->data_binding,
+                    'conditional_logic' => $field->conditional_logic,
+                    'styles' => $field->styles,
+                    'validations' => $validations,
+                ];
+            }
+
             $components[] = [
                 'component_type' => 'field_group',
                 'field_group_id' => $group->field_group_id,
                 'group_label' => $group->label,
                 'repeater' => $group->repeater,
+                'form_fields' => $formFieldsData,
                 'order' => $group->order,
             ];
         }

--- a/app/Helpers/FormTemplateHelper.php
+++ b/app/Helpers/FormTemplateHelper.php
@@ -17,11 +17,13 @@ class FormTemplateHelper
             return self::formatField($field, $index + 1);
         })->all();
 
+        $form = FormVersion::find($formVersionId);
+
         return json_encode([
-            "version" => "0.0.1",
+            "version" => $form->version_number,
             "id" => (string) Str::uuid(),
-            "lastModified" => now()->toIso8601String(),
-            "title" => FormVersion::find($formVersionId)->form->form_title,
+            "lastModified" => $form->updated_at,
+            "title" => $form->form_title,
             "data" => [
                 "items" => $items,
                 "id" => $formVersionId,

--- a/app/Helpers/FormTemplateHelper.php
+++ b/app/Helpers/FormTemplateHelper.php
@@ -6,6 +6,7 @@ use App\Models\FormInstanceField;
 use Illuminate\Support\Str;
 use App\Models\SelectOptions;
 use App\Models\FormVersion;
+use App\Models\Form;
 
 class FormTemplateHelper
 {
@@ -17,18 +18,18 @@ class FormTemplateHelper
             return self::formatField($field, $index + 1);
         })->all();
 
-        $form = FormVersion::find($formVersionId);
+        $formVersion = FormVersion::find($formVersionId);
+        $form = Form::find($formVersion->form_id);
 
         return json_encode([
-            "version" => $form->version_number,
+            "version" => $formVersion->version_number,
+            "ministry_id" => $form->ministry_id,
             "id" => (string) Str::uuid(),
-            "lastModified" => $form->updated_at,
+            "lastModified" => $formVersion->updated_at,
             "title" => $form->form_title,
             "data" => [
                 "items" => $items,
-                "id" => $formVersionId,
             ],
-            "allCssClasses" => [],
         ], JSON_PRETTY_PRINT);
     }
 

--- a/app/Helpers/FormTemplateHelper.php
+++ b/app/Helpers/FormTemplateHelper.php
@@ -2,30 +2,69 @@
 
 namespace App\Helpers;
 
-use App\Models\FormInstanceField;
 use Illuminate\Support\Str;
 use App\Models\SelectOptions;
 use App\Models\FormVersion;
 use App\Models\Form;
+use App\Models\FieldGroupInstance;
+use App\Models\FormInstanceField;
 
 class FormTemplateHelper
 {
     public static function generateJsonTemplate($formVersionId)
     {
-        $fields = FormInstanceField::where('form_version_id', $formVersionId)->orderBy('order')->get();
-
-        $items = $fields->map(function ($field, $index) {
-            return self::formatField($field, $index + 1);
-        })->all();
-
         $formVersion = FormVersion::find($formVersionId);
         $form = Form::find($formVersion->form_id);
+
+        $components = [];
+
+        $formFields = $formVersion->formInstanceFields()
+            ->whereNull('field_group_instance_id')
+            ->orderBy('order')
+            ->get();
+
+        foreach ($formFields as $field) {
+            $components[] = [
+                'component_type' => 'form_field',
+                'data' => $field,
+                'order' => $field->order,
+            ];
+        }
+
+        $fieldGroups = $formVersion->fieldGroupInstances()->orderBy('order')->get();
+
+        foreach ($fieldGroups as $group) {
+            $components[] = [
+                'component_type' => 'field_group',
+                'data' => $group,
+                'order' => $group->order,
+            ];
+        }
+
+        usort($components, function ($a, $b) {
+            return $a['order'] <=> $b['order'];
+        });
+
+        $items = [];
+        $index = 1;
+
+        foreach ($components as $component) {
+            if ($component['component_type'] === 'form_field') {
+                $field = $component['data'];
+                $items[] = self::formatField($field, $index);
+                $index++;
+            } elseif ($component['component_type'] === 'field_group') {
+                $group = $component['data'];
+                $items[] = self::formatGroup($group, $index);
+                $index++;
+            }
+        }
 
         return json_encode([
             "version" => $formVersion->version_number,
             "ministry_id" => $form->ministry_id,
             "id" => (string) Str::uuid(),
-            "lastModified" => $formVersion->updated_at,
+            "lastModified" => $formVersion->updated_at->toIso8601String(),
             "title" => $form->form_title,
             "data" => [
                 "items" => $items,
@@ -33,67 +72,90 @@ class FormTemplateHelper
         ], JSON_PRETTY_PRINT);
     }
 
-    protected static function formatField($field, $index)
+    protected static function formatField($fieldInstance, $index)
     {
+        $field = $fieldInstance->formField;
+
         $base = [
-            "type" => $field->formField->dataType->name,
-            "id" => (string) $index,
-            "label" => $field->formField->label,
-            "customLabel" => $field->label,
-            "dataBinding" => $field->formField->data_binding,
-            "customDataBinding" => $field->data_binding,
-            "validation" => $field->formField->validation,
-            "customValidation" => $field->validations->map(function ($validation) {
+            "type" => $field->dataType->name,
+            "id" => $field->name . '_' . $index,
+            "label" => $field->label,
+            "customLabel" => $fieldInstance->label,
+            "dataBinding" => $field->data_binding,
+            "customDataBinding" => $fieldInstance->data_binding,
+            "validation" => [],
+            "customValidation" => $fieldInstance->validations->map(function ($validation) {
                 return [
                     'type' => $validation->type,
                     'value' => $validation->value,
                     'errorMessage' => $validation->error_message,
                 ];
             })->toArray(),
-            "conditionalLogic" => $field->formField->conditional_logic,
-            "customConditionalLogic" => $field->conditional_logic,
-            "styles" => $field->formField->styles,
-            "customStyles" => $field->styles,
+            "conditionalLogic" => $field->conditional_logic,
+            "customConditionalLogic" => $fieldInstance->conditional_logic,
+            "styles" => $field->styles,
+            "customStyles" => $fieldInstance->styles,
             "codeContext" => [
-                "name" => $field->formField->name,
+                "name" => $field->name,
             ],
         ];
 
-        switch ($field->formField->dataType->name) {
+        switch ($field->dataType->name) {
             case "text-input":
                 return array_merge($base, [
-                    "placeholder" => "Enter your {$field->label}",
-                    "helperText" => "{$field->label} as it appears on official documents",
+                    "placeholder" => "Enter your {$fieldInstance->label}",
+                    "helperText" => "{$fieldInstance->label} as it appears on official documents",
                     "inputType" => "text",
                 ]);
             case "dropdown":
                 return array_merge($base, [
-                    "placeholder" => "Select your {$field->label}",
+                    "placeholder" => "Select your {$fieldInstance->label}",
                     "isMulti" => false,
                     "isInline" => false,
                     "selectionFeedback" => "top-after-reopen",
                     "direction" => "bottom",
                     "size" => "md",
                     "helperText" => "Choose one from the list",
-                    "listItems" => collect(SelectOptions::where('form_field_id', $field->form_field_id)->get())
+                    "listItems" => SelectOptions::where('form_field_id', $field->id)
+                        ->get()
                         ->map(function ($selectOption) {
                             return ["text" => $selectOption->label];
                         })
                         ->toArray(),
                 ]);
-            case "checkbox":
-                return array_merge($base, []);
-            case "toggle":
-                return array_merge($base, [
-                    "header" => "Enable {$field->label}",
-                    "offText" => "Off",
-                    "onText" => "On",
-                    "disabled" => false,
-                    "checked" => false,
-                    "size" => "md",
-                ]);
             default:
                 return $base;
         }
+    }
+
+    protected static function formatGroup($groupInstance, $index)
+    {
+        $group = $groupInstance->fieldGroup;
+
+        $fieldsInGroup = $groupInstance->formInstanceFields()->orderBy('order')->get();
+
+        $fields = $fieldsInGroup->map(function ($fieldInstance, $fieldIndex) {
+            return self::formatField($fieldInstance, $fieldIndex + 1);
+        })->values()->all();
+
+        $base = [
+            "type" => "group",
+            "label" => $group->label,
+            "customLabel" => $groupInstance->label,
+            "id" => $group->name . '_' . $index,
+            "groupId" => (string) $group->id,
+            "repeater" => $groupInstance->repeater,
+            "codeContext" => [
+                "name" => $group->name,
+            ],
+        ];
+
+        return array_merge($base, [
+            "groupItems" => [
+                [
+                    "fields" => $fields,
+                ],
+            ],
+        ]);
     }
 }

--- a/app/Models/FieldGroupInstance.php
+++ b/app/Models/FieldGroupInstance.php
@@ -16,6 +16,7 @@ class FieldGroupInstance extends Model
         'field_group_id',
         'label',
         'repeater',
+        'order'
     ];
 
     public function formVersion(): BelongsTo

--- a/app/Models/FieldGroupInstance.php
+++ b/app/Models/FieldGroupInstance.php
@@ -4,8 +4,8 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class FieldGroupInstance extends Model
 {
@@ -16,7 +16,7 @@ class FieldGroupInstance extends Model
         'field_group_id',
         'label',
         'repeater',
-        'order'
+        'order',
     ];
 
     public function formVersion(): BelongsTo

--- a/app/Models/FieldGroupInstance.php
+++ b/app/Models/FieldGroupInstance.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class FieldGroupInstance extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'form_version_id',
+        'field_group_id',
+        'label',
+        'repeater',
+    ];
+
+    public function formVersion(): BelongsTo
+    {
+        return $this->belongsTo(FormVersion::class);
+    }
+
+    public function fieldGroup(): BelongsTo
+    {
+        return $this->belongsTo(FieldGroup::class);
+    }
+
+    public function formInstanceFields(): HasMany
+    {
+        return $this->hasMany(FormInstanceField::class);
+    }
+}

--- a/app/Models/FormInstanceField.php
+++ b/app/Models/FormInstanceField.php
@@ -14,7 +14,6 @@ class FormInstanceField extends Model
         'form_version_id',
         'order',
         'form_field_id',
-        'field_group_id',
         'label',
         'data_binding',
         'styles',
@@ -29,11 +28,6 @@ class FormInstanceField extends Model
     public function formField(): BelongsTo
     {
         return $this->belongsTo(FormField::class);
-    }
-
-    public function fieldGroup(): BelongsTo
-    {
-        return $this->belongsTo(FieldGroup::class);
     }
 
     public function validations()

--- a/app/Models/FormInstanceField.php
+++ b/app/Models/FormInstanceField.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class FormInstanceField extends Model
 {
@@ -12,12 +13,13 @@ class FormInstanceField extends Model
 
     protected $fillable = [
         'form_version_id',
-        'order',
         'form_field_id',
+        'order',
         'label',
         'data_binding',
-        'styles',
         'conditional_logic',
+        'styles',
+        'field_group_instance_id',
     ];
 
     public function formVersion(): BelongsTo
@@ -35,8 +37,7 @@ class FormInstanceField extends Model
         return $this->belongsTo(FieldGroupInstance::class);
     }
 
-
-    public function validations()
+    public function validations(): HasMany
     {
         return $this->hasMany(FormInstanceFieldValidation::class);
     }

--- a/app/Models/FormInstanceField.php
+++ b/app/Models/FormInstanceField.php
@@ -30,6 +30,12 @@ class FormInstanceField extends Model
         return $this->belongsTo(FormField::class);
     }
 
+    public function fieldGroupInstance(): BelongsTo
+    {
+        return $this->belongsTo(FieldGroupInstance::class);
+    }
+
+
     public function validations()
     {
         return $this->hasMany(FormInstanceFieldValidation::class);

--- a/app/Models/FormInstanceFieldValidation.php
+++ b/app/Models/FormInstanceFieldValidation.php
@@ -3,12 +3,13 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class FormInstanceFieldValidation extends Model
 {
     protected $fillable = ['form_instance_field_id', 'type', 'value', 'error_message'];
 
-    public function formInstanceField()
+    public function formInstanceField(): BelongsTo
     {
         return $this->belongsTo(FormInstanceField::class);
     }

--- a/app/Models/FormVersion.php
+++ b/app/Models/FormVersion.php
@@ -25,6 +25,7 @@ class FormVersion extends Model
         'comments',
         'deployed_to',
         'deployed_at',
+        'components'
     ];
 
     public static function boot()
@@ -48,5 +49,10 @@ class FormVersion extends Model
     public function formInstanceFields(): HasMany
     {
         return $this->hasMany(FormInstanceField::class);
+    }
+
+    public function fieldGroupInstances(): HasMany
+    {
+        return $this->hasMany(FieldGroupInstance::class);
     }
 }

--- a/database/migrations/2024_10_03_180857_remove_field_group_constraint.php
+++ b/database/migrations/2024_10_03_180857_remove_field_group_constraint.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('form_instance_fields', function (Blueprint $table) {
+            $table->dropColumn('field_group_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('form_instance_fields', function (Blueprint $table) {
+            $table->foreignId('field_group_id')->nullable()->constrained()->onDelete('cascade');
+        });
+    }
+};

--- a/database/migrations/2024_10_03_180917_create_field_group_instance_table.php
+++ b/database/migrations/2024_10_03_180917_create_field_group_instance_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('field_group_instance', function (Blueprint $table) {
+        Schema::create('field_group_instances', function (Blueprint $table) {
             $table->foreignId('form_version_id')->constrained()->onDelete('cascade');
             $table->foreignId('field_group_id')->nullable()->constrained()->onDelete('cascade');
             $table->string('label')->nullable();
@@ -26,6 +26,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('field_group_instance');
+        Schema::dropIfExists('field_group_instances');
     }
 };

--- a/database/migrations/2024_10_03_180917_create_field_group_instance_table.php
+++ b/database/migrations/2024_10_03_180917_create_field_group_instance_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('field_group_instance', function (Blueprint $table) {
+            $table->foreignId('form_version_id')->constrained()->onDelete('cascade');
+            $table->foreignId('field_group_id')->nullable()->constrained()->onDelete('cascade');
+            $table->string('label')->nullable();
+            $table->boolean('repeater')->default(false);
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('field_group_instance');
+    }
+};

--- a/database/migrations/2024_10_03_180933_add_field_group_instance_constraint.php
+++ b/database/migrations/2024_10_03_180933_add_field_group_instance_constraint.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('form_instance_fields', function (Blueprint $table) {
+            $table->foreignId('field_group_instance_id')->nullable()->constrained()->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('form_instance_fields', function (Blueprint $table) {
+            $table->dropColumn('field_group_instance_id');
+        });
+    }
+};

--- a/database/migrations/2024_10_29_074036_add_order_to_field_group_instances_table.php
+++ b/database/migrations/2024_10_29_074036_add_order_to_field_group_instances_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('field_group_instances', function (Blueprint $table) {
+            $table->integer('order')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('field_group_instances', function (Blueprint $table) {
+            $table->dropColumn('order');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,7 +17,6 @@ class DatabaseSeeder extends Seeder
         $this->call([
             MinistrySeeder::class,
             ValueTypeSeeder::class,
-            RenderedFormSeeder::class,
             DataTypeSeeder::class,
             FormFieldSeeder::class,
             RolesSeeder::class,


### PR DESCRIPTION
## What changes did you make? 

Adds form groups to the form versioning system

## Why did you make these changes?

We need to accommodate forms having both form fields and field groups that contain form fields.

## What alternatives did you consider?

I am actually storing all the relationships as fields and form groups and doing some order assigning and whatnot in the database fields. I considered using some string manipulation such as adding the prefix grp- or fld- but that did not feel sustainable long term and it was error prone. This was quite a challenging feature implementation due to Filament not supporting a lot of these features so it takes a bit of effort to make it work.

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
