### PR TITLE
Form group improvements

### DIFF
--- a/app/Filament/Admin/Resources/UserResource.php
+++ b/app/Filament/Admin/Resources/UserResource.php
@@ -3,7 +3,6 @@
 namespace App\Filament\Admin\Resources;
 
 use App\Filament\Admin\Resources\UserResource\Pages;
-use App\Filament\Admin\Resources\UserResource\RelationManagers;
 use App\Models\User;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -31,8 +30,8 @@ class UserResource extends Resource
                 Forms\Components\TextInput::make('password')
                     ->password()
                     ->maxLength(255)
-                    ->required(fn ($record) => $record === null)
-                    ->hidden(fn ($record) => $record !== null),
+                    ->required(fn($record) => $record === null)
+                    ->hidden(fn($record) => $record !== null),
                 Forms\Components\Select::make('roles')
                     ->multiple()
                     ->preload()
@@ -47,18 +46,10 @@ class UserResource extends Resource
                 Tables\Columns\TextColumn::make('name'),
                 Tables\Columns\TextColumn::make('email'),
             ])
-            ->filters([
-                //
-            ])
-            ->actions([
-                Tables\Actions\EditAction::make(),
-            ])
-            ->bulkActions([
-                //
-            ])
-            ->paginated([
-                10, 25, 50, 100,
-            ]);
+            ->filters([])
+            ->actions([])
+            ->bulkActions([])
+            ->paginated([10, 25, 50, 100]);
     }
 
     public static function getPages(): array
@@ -66,8 +57,8 @@ class UserResource extends Resource
         return [
             'index' => Pages\ListUsers::route('/'),
             'create' => Pages\CreateUser::route('/create'),
+            'view' => Pages\ViewUser::route('/{record}'),
             'edit' => Pages\EditUser::route('/{record}/edit'),
         ];
     }
 }
-

--- a/app/Filament/Admin/Resources/UserResource/Pages/ViewUser.php
+++ b/app/Filament/Admin/Resources/UserResource/Pages/ViewUser.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Filament\Admin\Resources\UserResource\Pages;
+
+use App\Filament\Admin\Resources\UserResource;
+use Filament\Actions;
+use Filament\Forms;
+use Filament\Resources\Pages\ViewRecord;
+use Illuminate\Support\Facades\Hash;
+use Filament\Notifications\Notification;
+
+class ViewUser extends ViewRecord
+{
+    protected static string $resource = UserResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+            Actions\Action::make('resetPassword')
+                ->label('Reset Password')
+                ->modalHeading('Reset User Password')
+                ->form([
+                    Forms\Components\TextInput::make('new_password')
+                        ->label('New Password')
+                        ->password()
+                        ->required(),
+                    Forms\Components\TextInput::make('confirm_password')
+                        ->label('Confirm Password')
+                        ->password()
+                        ->required()
+                        ->same('new_password'),
+                ])
+                ->action(function ($data) {
+                    $this->record->update([
+                        'password' => Hash::make($data['new_password']),
+                    ]);
+                    Notification::make()
+                        ->title("Password reset successfully!")
+                        ->success()
+                        ->send();
+                })
+                ->requiresConfirmation(),
+        ];
+    }
+}

--- a/app/Filament/Forms/Resources/FieldGroupResource.php
+++ b/app/Filament/Forms/Resources/FieldGroupResource.php
@@ -3,37 +3,42 @@
 namespace App\Filament\Forms\Resources;
 
 use App\Filament\Forms\Resources\FieldGroupResource\Pages;
-use App\Filament\Forms\Resources\FieldGroupResource\RelationManagers;
 use App\Models\FieldGroup;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\Toggle;
 
 class FieldGroupResource extends Resource
 {
     protected static ?string $model = FieldGroup::class;
 
     protected static ?string $navigationGroup = 'Form Building';
-
-
     protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
 
     public static function form(Form $form): Form
     {
         return $form
             ->schema([
-                Forms\Components\TextInput::make('name')
+                TextInput::make('name')
                     ->required(),
-                Forms\Components\TextInput::make('label'),
-                Forms\Components\Textarea::make('description')
+                TextInput::make('label'),
+                Textarea::make('description')
                     ->columnSpanFull(),
-                Forms\Components\Textarea::make('internal_description')
+                Textarea::make('internal_description')
                     ->columnSpanFull(),
-                Forms\Components\Toggle::make('repeater')
+                Select::make('form_field_ids')
+                    ->label('Form Fields')
+                    ->multiple()
+                    ->relationship('formFields', 'name')
+                    ->searchable()
+                    ->preload(),
+                Toggle::make('repeater')
                     ->required(),
             ]);
     }
@@ -42,20 +47,11 @@ class FieldGroupResource extends Resource
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('name')
-                    ->searchable(),
-                Tables\Columns\TextColumn::make('label')
-                    ->searchable(),
-                Tables\Columns\IconColumn::make('repeater')
-                    ->boolean(),
-                Tables\Columns\TextColumn::make('created_at')
-                    ->dateTime()
-                    ->sortable()
-                    ->toggleable(isToggledHiddenByDefault: true),
-                Tables\Columns\TextColumn::make('updated_at')
-                    ->dateTime()
-                    ->sortable()
-                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('name')->searchable(),
+                Tables\Columns\TextColumn::make('label')->searchable(),
+                Tables\Columns\IconColumn::make('repeater')->boolean(),
+                Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable()->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')->dateTime()->sortable()->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
                 //
@@ -68,7 +64,10 @@ class FieldGroupResource extends Resource
                 //
             ])
             ->paginated([
-                10, 25, 50, 100,
+                10,
+                25,
+                50,
+                100,
             ]);
     }
 

--- a/app/Filament/Forms/Resources/FormVersionResource.php
+++ b/app/Filament/Forms/Resources/FormVersionResource.php
@@ -91,6 +91,15 @@ class FormVersionResource extends Resource
                     ->label('Form Components')
                     ->reorderable()
                     ->collapsible()
+                    ->collapsed(true)
+                    ->itemLabel(function ($state) {
+                        if ($state['component_type'] === 'form_field') {
+                            return 'Form Field - ' . ($state['label'] ?: (FormField::find($state['form_field_id'])->label ?? 'Unnamed Field'));
+                        } elseif ($state['component_type'] === 'field_group') {
+                            return 'Field Group - ' . ($state['group_label'] ?: (FieldGroup::find($state['field_group_id'])->label ?? 'Unnamed Group'));
+                        }
+                        return 'Component';
+                    })
                     ->schema([
                         Select::make('component_type')
                             ->options([
@@ -121,6 +130,7 @@ class FormVersionResource extends Resource
                                 Repeater::make('validations')
                                     ->label('Validations')
                                     ->collapsible()
+                                    ->collapsed()
                                     ->defaultItems(0)
                                     ->schema([
                                         Select::make('type')
@@ -177,6 +187,10 @@ class FormVersionResource extends Resource
                                     ->label('Form Fields in Group')
                                     ->reorderable()
                                     ->collapsible()
+                                    ->collapsed()
+                                    ->itemLabel(function ($state) {
+                                        return 'Form Field - ' . ($state['label'] ?: (FormField::find($state['form_field_id'])->label ?? 'Unnamed Field'));
+                                    })
                                     ->defaultItems(0)
                                     ->schema([
                                         Select::make('form_field_id')
@@ -199,6 +213,7 @@ class FormVersionResource extends Resource
                                         Repeater::make('validations')
                                             ->label('Validations')
                                             ->collapsible()
+                                            ->collapsed()
                                             ->defaultItems(0)
                                             ->schema([
                                                 Select::make('type')

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/ViewFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/ViewFormVersion.php
@@ -16,4 +16,85 @@ class ViewFormVersion extends ViewRecord
             Actions\EditAction::make(),
         ];
     }
+
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        $data = array_merge($this->record->toArray(), $data);
+
+        $components = [];
+
+        $formFields = $this->record->formInstanceFields()
+            ->whereNull('field_group_instance_id')
+            ->get();
+
+        foreach ($formFields as $field) {
+            $validations = [];
+            foreach ($field->validations as $validation) {
+                $validations[] = [
+                    'type' => $validation->type,
+                    'value' => $validation->value,
+                    'error_message' => $validation->error_message,
+                ];
+            }
+
+            $components[] = [
+                'component_type' => 'form_field',
+                'form_field_id' => $field->form_field_id,
+                'label' => $field->label,
+                'data_binding' => $field->data_binding,
+                'conditional_logic' => $field->conditional_logic,
+                'styles' => $field->styles,
+                'validations' => $validations,
+                'order' => $field->order,
+            ];
+        }
+
+        $fieldGroups = $this->record->fieldGroupInstances()->get();
+
+        foreach ($fieldGroups as $group) {
+            $groupFields = $group->formInstanceFields()->orderBy('order')->get();
+
+            $formFieldsData = [];
+            foreach ($groupFields as $field) {
+                $validations = [];
+                foreach ($field->validations as $validation) {
+                    $validations[] = [
+                        'type' => $validation->type,
+                        'value' => $validation->value,
+                        'error_message' => $validation->error_message,
+                    ];
+                }
+
+                $formFieldsData[] = [
+                    'form_field_id' => $field->form_field_id,
+                    'label' => $field->label,
+                    'data_binding' => $field->data_binding,
+                    'conditional_logic' => $field->conditional_logic,
+                    'styles' => $field->styles,
+                    'validations' => $validations,
+                ];
+            }
+
+            $components[] = [
+                'component_type' => 'field_group',
+                'field_group_id' => $group->field_group_id,
+                'group_label' => $group->label,
+                'repeater' => $group->repeater,
+                'form_fields' => $formFieldsData,
+                'order' => $group->order,
+            ];
+        }
+
+        usort($components, function ($a, $b) {
+            return $a['order'] <=> $b['order'];
+        });
+
+        foreach ($components as &$component) {
+            unset($component['order']);
+        }
+
+        $data['components'] = $components;
+
+        return $data;
+    }
 }


### PR DESCRIPTION
## What changes did you make? 

- You can swap order of form fields within a field group
- The components are displayed in readonly in the View mode of Form Version
- You can manage what form fields are inside a field group by editing a field group
- You can reset a users password from the view user screen in the admin panel

## Why did you make these changes?

These were all brought up as needed features with the Forms Team

## What alternatives did you consider?

Forms being within forms was another needed feature that I am not able to complete due to time constraints

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
