### PR TITLE
use afteCreate in the create class

### DIFF
--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/CreateFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/CreateFormVersion.php
@@ -50,7 +50,7 @@ class CreateFormVersion extends CreateRecord
         //
     }
 
-    protected function afterSave(): void
+    protected function afterCreate(): void
     {
         $formVersion = $this->record;
         $components = $this->form->getState()['components'] ?? [];


### PR DESCRIPTION
## What changes did you make? 

changed afterSave to afterCreate for the create class

## Why did you make these changes?

afterSave was not running so no form fields would save when creating a new form version

## What alternatives did you consider?

none

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
