### PR TITLE
Update dependabot to open PRs in dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     commit-message:
       prefix: "deps"
     open-pull-requests-limit: 5
+    target-branch: "dev"
     ignore:
       - dependency-name: "laravel/framework"
         versions: ["^11.0"]


### PR DESCRIPTION
## What changes did you make? 

Moved dependabot to make it's PRs in the dev env

## Why did you make these changes?

Since our CI/CD path goes from Dev->Main these PRs from dependabot directly into main were a bit of a problem since they wouldn't get passed into dev in any way.

## What alternatives did you consider?

N/A

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
