### PR TITLE
Allow moving published form versions to archived

### DIFF
--- a/app/Filament/Fodig/Resources/SystemMessageResource.php
+++ b/app/Filament/Fodig/Resources/SystemMessageResource.php
@@ -21,6 +21,8 @@ class SystemMessageResource extends Resource
 
     protected static ?string $navigationGroup = 'Successor System';
 
+    protected static ?string $label = 'All Messages';
+
     public static function form(Form $form): Form
     {
         return $form

--- a/app/Filament/Forms/Resources/FormVersionResource.php
+++ b/app/Filament/Forms/Resources/FormVersionResource.php
@@ -175,7 +175,7 @@ class FormVersionResource extends Resource
                                                 return [
                                                     'form_field_id' => $field->id,
                                                     'label' => $field->label,
-                                                    'data_binding_path'=> $field->data_binding_path,
+                                                    'data_binding_path' => $field->data_binding_path,
                                                     'data_binding' => $field->data_binding,
                                                     'conditional_logic' => $field->conditional_logic,
                                                     'styles' => $field->styles,
@@ -295,18 +295,6 @@ class FormVersionResource extends Resource
                 Tables\Columns\TextColumn::make('deployed_at')
                     ->date('M j, Y')
                     ->sortable(),
-                Tables\Columns\TextColumn::make('form_requester_name')
-                    ->searchable(),
-                Tables\Columns\TextColumn::make('form_requester_email')
-                    ->searchable(),
-                Tables\Columns\TextColumn::make('form_developer_name')
-                    ->searchable(),
-                Tables\Columns\TextColumn::make('form_developer_email')
-                    ->searchable(),
-                Tables\Columns\TextColumn::make('form_approver_name')
-                    ->searchable(),
-                Tables\Columns\TextColumn::make('form_approver_email')
-                    ->searchable(),
                 Tables\Columns\TextColumn::make('created_at')
                     ->dateTime()
                     ->sortable()
@@ -323,9 +311,21 @@ class FormVersionResource extends Resource
                 Tables\Actions\ViewAction::make(),
                 Tables\Actions\EditAction::make()
                     ->visible(fn($record) => (in_array($record->status, ['draft', 'testing'])) && Gate::allows('form-developer')),
+                Tables\Actions\Action::make('archive')
+                    ->label('Archive')
+                    ->icon('heroicon-o-archive-box-arrow-down')
+                    ->visible(fn($record) => $record->status === 'published')
+                    ->action(function ($record) {
+                        $record->update(['status' => 'archived']);
+                    })
+                    ->requiresConfirmation()
+                    ->color('danger')
+                    ->tooltip('Archive this form version'),
                 Tables\Actions\Action::make('Create New Version')
                     ->label('Create New Version')
                     ->icon('heroicon-o-document-plus')
+                    ->requiresConfirmation()
+                    ->tooltip('Create a new version from this version')
                     ->visible(fn($record) => (Gate::allows('form-developer') && in_array($record->status, ['published', 'archived'])))
                     ->action(function ($record, $livewire) {
                         $newVersion = $record->replicate();


### PR DESCRIPTION
## What changes did you make? 

Added a button so you can move published form versions to the archived status

## Why did you make these changes?

Request from Rob in the forms team

## What alternatives did you consider?

I could have enabled the drop down in the edit page but having this as an action in the list made more sense.

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
