### PR TITLE
Added 'deployed_to' to json definition

### DIFF
--- a/app/Helpers/FormTemplateHelper.php
+++ b/app/Helpers/FormTemplateHelper.php
@@ -69,6 +69,7 @@ class FormTemplateHelper
             "lastModified" => $formVersion->updated_at->toIso8601String(),
             "title" => $formVersion->form->form_title,
             "form_id" => $form->form_id,
+            "deployed_to" => $formVersion->deployed_to,
             "dataSources" => $formVersion->formDataSources->map(function ($dataSource) {
                 return [
                     'name' => $dataSource->name,


### PR DESCRIPTION
## What changes did you make? 

Added the 'deployed to' field from the form version to the metadata of the generated JSON.

## Why did you make these changes?

Will be used to specify which version is deployed to in the Template Repository. This field will dictate which version of the form will  be used to generate the ICM version. 

## What alternatives did you consider?

None
### Checklist

- [X] **I have assigned at least one reviewer**
- [X] **My code meets the style guide**
- [X] **My code has adequate test coverage (if applicable)**
