### PR TITLE
More descriptive labels when adding and viewing a field/group

### DIFF
--- a/app/Filament/Forms/Resources/FormVersionResource.php
+++ b/app/Filament/Forms/Resources/FormVersionResource.php
@@ -3,7 +3,6 @@
 namespace App\Filament\Forms\Resources;
 
 use App\Filament\Forms\Resources\FormVersionResource\Pages;
-use App\Models\DataType;
 use App\Models\FormVersion;
 use App\Models\FormField;
 use App\Models\FieldGroup;
@@ -99,7 +98,7 @@ class FormVersionResource extends Resource
                         if ($state['component_type'] === 'form_field') {
                             $field = FormField::find($state['form_field_id']) ?: null;
                             $field ? $label = ($state['label'] ?: ($field->label ?? ''))
-                            . ' - '. (DataType::find($field ? $field->data_type_id : null)->short_description ?? '')
+                            . ' - '. $field->dataType->short_description
                             . ' (' . ($field->name ?? '') . ')'
                             : $label =  'New Field';
                             return $label;
@@ -131,8 +130,8 @@ class FormVersionResource extends Resource
                                         foreach ($options as $id => $option) {
                                             $field = FormField::find($id) ?: null;
                                             $options[$id] = $option
-                                            . ' - ' . DataType::find($field ? $field->data_type_id : null)->short_description
-                                            . ' (' . (FormField::find($id)->name ?? '') . ')';
+                                            . ' - ' . $field->dataType->short_description
+                                            . ' (' . ($field->name ?? '') . ')';
                                         }
                                         return $options;
                                     })
@@ -257,7 +256,7 @@ class FormVersionResource extends Resource
                                     ->itemLabel(function ($state) {
                                         $field = FormField::find($state['form_field_id']) ?: null;
                                         $field ? $label = ($state['label'] ?: ($field->label ?? 'New Field'))
-                                        . ' - ' . (DataType::find($field ? $field->data_type_id : null)->short_description ?? '')
+                                        . ' - ' . $field->dataType->short_description
                                         . ' (' . ($field->name ?? 'empty') . ')'
                                         : $label =  'New Field';
                                         return $label;
@@ -272,8 +271,8 @@ class FormVersionResource extends Resource
                                                 foreach ($options as $id => $option) {
                                                     $field = FormField::find($id) ?: null;
                                                     $options[$id] = $option
-                                                    . ' - ' . DataType::find($field ? $field->data_type_id : null)->short_description
-                                                    . ' (' . (FormField::find($id)->name ?? '') . ')';
+                                                    . ' - ' . $field->dataType->short_description
+                                                    . ' (' . ($field->name ?? '') . ')';
                                                 }
                                                 return $options;
                                             })


### PR DESCRIPTION
## What changes did you make? 

Added more descriptive labels to fields that display the name and type of field or group

## Why did you make these changes?

Makes fields/groups easier to identify and removes extraneous information (see https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/2202)

## What alternatives did you consider?

No alternative way to implement this feature

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [x] **My code has adequate test coverage (if applicable)**
