### PR TITLE
Update field group requirements

### DIFF
--- a/app/Filament/Forms/Resources/FieldGroupResource.php
+++ b/app/Filament/Forms/Resources/FieldGroupResource.php
@@ -27,7 +27,8 @@ class FieldGroupResource extends Resource
             ->schema([
                 TextInput::make('name')
                     ->required(),
-                TextInput::make('label'),
+                TextInput::make('label')
+                    ->required(),
                 Textarea::make('description')
                     ->columnSpanFull(),
                 Textarea::make('internal_description')
@@ -38,8 +39,7 @@ class FieldGroupResource extends Resource
                     ->relationship('formFields', 'name')
                     ->searchable()
                     ->preload(),
-                Toggle::make('repeater')
-                    ->required(),
+                Toggle::make('repeater'),
             ]);
     }
 


### PR DESCRIPTION
## What changes did you make? 

For FieldGroups, made Label required and Repeater not required.

## Why did you make these changes?

Label is required to create and properly display a FieldGroup. Repeater is technically required, but as it is a boolean, it always already has a value. When creating/editing a FieldGroup, making it required is confusing because it implies it is supposed to be set to True - removing the requirement solves this

## What alternatives did you consider?

None

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [x] **My code has adequate test coverage (if applicable)**
