### PR TITLE
Intuitive display override customize version builder ado 2229

### DIFF
--- a/app/Filament/Forms/Resources/FormVersionResource.php
+++ b/app/Filament/Forms/Resources/FormVersionResource.php
@@ -137,39 +137,39 @@ class FormVersionResource extends Resource
                                         return $options;
                                     })
                                     ->searchable()
-                                    ->required(),                                                                  
-                                TextInput::make('label')
-                                    ->label("Custom Label")
-                                    ->placeholder(fn($get) => FormField::find($get('form_field_id'))->label ?? null),
-                                TextInput::make('custom_id')
-                                    ->label("Custom ID")
-                                    ->default(fn($get) =>  \App\Helpers\FormTemplateHelper::calculateFieldID($get('../../'))) // Set the sequential default value
-                                    ->required()
-                                    ->alphanum()                                    
-                                    ->reactive()                                    
-                                    ->distinct(),                                
+                                    ->required(),
+                                Textarea::make('data_binding')
+                                    ->label("Custom Data Binding")
+                                    ->placeholder(fn($get) => FormField::find($get('form_field_id'))->data_binding ?? null),
                                 Select::make('data_binding_path')
                                     ->label("Custom Data Binding Path")
                                     ->options(FormDataSource::pluck('name', 'name'))
                                     ->placeholder(fn($get) => FormField::find($get('form_field_id'))->data_binding_path ?? null),
-                                Textarea::make('data_binding')
-                                    ->label("Custom Data Binding")
-                                    ->placeholder(fn($get) => FormField::find($get('form_field_id'))->data_binding ?? null),
-                                Textarea::make('field_value')
-                                    ->label("Field Value")                                    
-                                    ->visible(fn($get) => FormField::find($get('form_field_id'))?->isValueInputNeededForField() ?? false)
-                                    ->placeholder(fn($get) => FormField::find($get('form_field_id'))->formFieldValue?->value ?? null)
-                                    ->live()
-                                    ->reactive(),
-                                Textarea::make('conditional_logic')
-                                    ->label("Custom Conditional Logic")
-                                    ->placeholder(fn($get) => FormField::find($get('form_field_id'))->conditional_logic ?? null),
+                                TextInput::make('custom_id')
+                                    ->label("Custom ID")
+                                    ->default(fn($get) => \App\Helpers\FormTemplateHelper::calculateFieldID($get('../../'))) // Set the sequential default value
+                                    ->required()
+                                    ->alphanum()                                    
+                                    ->reactive()                                    
+                                    ->distinct(),                                
                                 Textarea::make('styles')
                                     ->label("Custom Styles")
                                     ->placeholder(fn($get) => FormField::find($get('form_field_id'))->styles ?? null),
                                 TextInput::make('mask')
                                     ->label("Custom Mask")
                                     ->placeholder(fn($get) => FormField::find($get('form_field_id'))->mask ?? null),
+                                Textarea::make('help_text')
+                                    ->label("Custom Help text")
+                                    ->placeholder(fn($get) => FormField::find($get('form_field_id'))->help_text ?? null),
+                                TextInput::make('label')
+                                    ->label("Custom Label")
+                                    ->placeholder(fn($get) => FormField::find($get('form_field_id'))->label ?? null),
+                                Textarea::make('field_value')
+                                    ->label("Field Value")                                    
+                                    ->visible(fn($get) => FormField::find($get('form_field_id'))?->isValueInputNeededForField() ?? false)
+                                    ->placeholder(fn($get) => FormField::find($get('form_field_id'))->formFieldValue?->value ?? null)
+                                    ->live()
+                                    ->reactive(),
                                 Repeater::make('validations')
                                     ->label('Validations')
                                     ->collapsible()
@@ -195,9 +195,9 @@ class FormVersionResource extends Resource
                                         TextInput::make('error_message')
                                             ->label('Error Message'),
                                     ]),
-                                Textarea::make('help_text')
-                                    ->label("Custom Help text")
-                                    ->placeholder(fn($get) => FormField::find($get('form_field_id'))->help_text ?? null),
+                                Textarea::make('conditional_logic')
+                                    ->label("Custom Conditional Logic")
+                                    ->placeholder(fn($get) => FormField::find($get('form_field_id'))->conditional_logic ?? null),
                             ])
                             ->visible(fn($get) => $get('component_type') === 'form_field'),
                         Section::make('Field Group Settings')

--- a/app/Filament/Forms/Resources/FormVersionResource.php
+++ b/app/Filament/Forms/Resources/FormVersionResource.php
@@ -22,6 +22,10 @@ use Filament\Forms\Components\Toggle;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Actions;
 use Filament\Forms\Components\Actions\Action;
+use Filament\Forms\Components\Checkbox;
+use Filament\Forms\Components\Hidden;
+use Filament\Forms\Components\Placeholder;
+use Filament\Forms\Components\Radio;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
 
@@ -98,16 +102,16 @@ class FormVersionResource extends Resource
                     ->itemLabel(function ($state) {
                         if ($state['component_type'] === 'form_field') {
                             $field = FormField::find($state['form_field_id']) ?: null;
-                            $field ? $label = ($state['label'] ?: ($field->label ?? ''))
-                            . ' - '. $field->dataType->short_description
-                            . ' (' . ($field->name ?? '') . ')'
-                            : $label =  'New Field';
+                            $field ? $label = ($state['custom_label'] ?: ($field->label ?? ''))
+                                . ' - ' . $field->dataType->short_description
+                                . ' (' . ($field->name ?? '') . ')'
+                                : $label =  'New Field';
                             return $label;
                         } elseif ($state['component_type'] === 'field_group') {
                             $group = FieldGroup::find($state['field_group_id']);
                             $group ? $label = ($state['group_label'] ?: ($group->label ?? ''))
-                            . ' (' . ($group->name ?? '') . ')'
-                            : $label = 'New Group';
+                                . ' (' . ($group->name ?? '') . ')'
+                                : $label = 'New Group';
                             return $label;
                         }
                         return 'Component';
@@ -121,55 +125,149 @@ class FormVersionResource extends Resource
                             ->reactive()
                             ->required(),
                         Section::make('Form Field Settings')
-                            ->live()    
+                            ->live()
                             ->schema([
                                 Select::make('form_field_id')
                                     ->label('Form Field')
-                                    ->options(function() {
+                                    ->options(function () {
                                         // Compose option labels
                                         $options = FormField::pluck('label', 'id');
                                         foreach ($options as $id => $option) {
                                             $field = FormField::find($id) ?: null;
                                             $options[$id] = $option
-                                            . ' - ' . $field->dataType->short_description
-                                            . ' (' . ($field->name ?? '') . ')';
+                                                . ' - ' . $field->dataType->short_description
+                                                . ' (' . ($field->name ?? '') . ')';
                                         }
                                         return $options;
                                     })
                                     ->searchable()
                                     ->required(),
-                                Textarea::make('data_binding')
-                                    ->label("Custom Data Binding")
-                                    ->placeholder(fn($get) => FormField::find($get('form_field_id'))->data_binding ?? null),
-                                Select::make('data_binding_path')
-                                    ->label("Custom Data Binding Path")
-                                    ->options(FormDataSource::pluck('name', 'name'))
-                                    ->placeholder(fn($get) => FormField::find($get('form_field_id'))->data_binding_path ?? null),
-                                TextInput::make('custom_id')
-                                    ->label("Custom ID")
-                                    ->default(fn($get) => \App\Helpers\FormTemplateHelper::calculateFieldID($get('../../'))) // Set the sequential default value
-                                    ->required()
-                                    ->alphanum()                                    
-                                    ->reactive()                                    
-                                    ->distinct(),                                
-                                Textarea::make('styles')
-                                    ->label("Custom Styles")
-                                    ->placeholder(fn($get) => FormField::find($get('form_field_id'))->styles ?? null),
-                                TextInput::make('mask')
-                                    ->label("Custom Mask")
-                                    ->placeholder(fn($get) => FormField::find($get('form_field_id'))->mask ?? null),
-                                Textarea::make('help_text')
-                                    ->label("Custom Help text")
-                                    ->placeholder(fn($get) => FormField::find($get('form_field_id'))->help_text ?? null),
-                                TextInput::make('label')
-                                    ->label("Custom Label")
-                                    ->placeholder(fn($get) => FormField::find($get('form_field_id'))->label ?? null),
-                                Textarea::make('field_value')
-                                    ->label("Field Value")                                    
+                                Fieldset::make('Field Value')
                                     ->visible(fn($get) => FormField::find($get('form_field_id'))?->isValueInputNeededForField() ?? false)
-                                    ->placeholder(fn($get) => FormField::find($get('form_field_id'))->formFieldValue?->value ?? null)
-                                    ->live()
-                                    ->reactive(),
+                                    ->columns(1)
+                                    ->schema([
+                                        Placeholder::make('field_value')
+                                            ->label("Default")
+                                            ->content(fn($get) => FormField::find($get('form_field_id'))->formFieldValue?->value ?? 'null'),
+                                        Checkbox::make('customize_field_value')
+                                            ->label('Customize Field Value')
+                                            ->inline()
+                                            ->live(),
+                                        TextInput::make('custom_field_value')
+                                            ->label(false)
+                                            ->visible(fn($get) => $get('customize_field_value')),
+                                    ]),
+                                Fieldset::make('Data Binding')
+                                    ->columns(1)
+                                    ->schema([
+                                        Placeholder::make('data_binding')
+                                            ->label("Default")
+                                            ->content(fn($get) => FormField::find($get('form_field_id'))->data_binding ?? 'null'),
+                                        Checkbox::make('customize_data_binding')
+                                            ->label('Customize Data Binding')
+                                            ->inline()
+                                            ->live(),
+                                        Textarea::make('custom_data_binding')
+                                            ->label(false)
+                                            ->visible(fn($get) => $get('customize_data_binding')),
+                                    ]),
+                                Fieldset::make('Data Source')
+                                    ->columns(1)
+                                    ->schema([
+                                        Placeholder::make('data_binding_path')
+                                            ->label("Default")
+                                            ->content(fn($get) => FormField::find($get('form_field_id'))->data_binding_path ?? 'null'),
+                                        Checkbox::make('customize_data_binding_path')
+                                            ->label('Customize Data Source')
+                                            ->inline()
+                                            ->live(),
+                                        Select::make('custom_data_binding_path')
+                                            ->label(false)
+                                            ->options(FormDataSource::pluck('name', 'name'))
+                                            ->visible(fn($get) => $get('customize_data_binding_path')),
+                                    ]),
+                                Fieldset::make('Styles')
+                                    ->columns(1)
+                                    ->schema([
+                                        Placeholder::make('styles')
+                                            ->label("Default")
+                                            ->content(fn($get) => FormField::find($get('form_field_id'))->styles ?? 'null'),
+                                        Checkbox::make('customize_styles')
+                                            ->label('Customize Styles')
+                                            ->inline()
+                                            ->live(),
+                                        Textarea::make('custom_styles')
+                                            ->label(false)
+                                            ->visible(fn($get) => $get('customize_styles')),
+                                    ]),
+                                Fieldset::make('Mask')
+                                    ->columns(1)
+                                    ->schema([
+                                        Placeholder::make('mask')
+                                            ->label("Default")
+                                            ->content(fn($get) => FormField::find($get('form_field_id'))->mask ?? 'null'),
+                                        Checkbox::make('customize_mask')
+                                            ->label('Customize Mask')
+                                            ->inline()
+                                            ->live(),
+                                        TextInput::make('custom_mask')
+                                            ->label(false)
+                                            ->visible(fn($get) => $get('customize_mask')),
+                                    ]),
+                                Fieldset::make('Help Text')
+                                    ->columns(1)
+                                    ->schema([
+                                        Placeholder::make('help_text')
+                                            ->label("Default")
+                                            ->content(fn($get) => FormField::find($get('form_field_id'))->help_text ?? 'null'),
+                                        Checkbox::make('customize_help_text')
+                                            ->label('Customize Help text')
+                                            ->inline()
+                                            ->live(),
+                                        Textarea::make('custom_help_text')
+                                            ->label(false)
+                                            ->visible(fn($get) => $get('customize_help_text')),
+                                    ]),
+                                Fieldset::make('Label')
+                                    ->columns(1)
+                                    ->schema([
+                                        Placeholder::make('label')
+                                            ->label("Default")
+                                            ->content(fn($get) => FormField::find($get('form_field_id'))->label ?? 'null'),
+                                        Radio::make('customize_label')
+                                            ->options([
+                                                'default' => 'Use Default',
+                                                'hide' => 'Hide Label',
+                                                'customize' => 'Customize Label'
+                                            ])
+                                            ->default('default')
+                                            ->inline()
+                                            ->inlineLabel(false)
+                                            ->live(),
+                                        TextInput::make('custom_label')
+                                            ->label(false)
+                                            ->visible(fn($get) => $get('customize_label') == 'customize'),
+                                    ]),
+                                Fieldset::make('Instance ID')
+                                    ->columns(1)
+                                    ->schema([
+                                        Placeholder::make('instance_id_placeholder') // used to view value in builder
+                                            ->label("Default")
+                                            ->content(fn($get) => $get('instance_id')), // Set the sequential default value
+                                        Hidden::make('instance_id') // used to populate value in template 
+                                            ->hidden()
+                                            ->default(fn($get) => \App\Helpers\FormTemplateHelper::calculateFieldID($get('../../'))), // Set the sequential default value
+                                        Checkbox::make('customize_instance_id')
+                                            ->label('Customize Instance ID')
+                                            ->inline()
+                                            ->live(),
+                                        TextInput::make('custom_instance_id')
+                                            ->label(false)
+                                            ->alphanum()
+                                            ->reactive()
+                                            ->distinct()
+                                            ->visible(fn($get) => $get('customize_instance_id')),
+                                    ]),
                                 Repeater::make('validations')
                                     ->label('Validations')
                                     ->collapsible()
@@ -201,11 +299,11 @@ class FormVersionResource extends Resource
                             ])
                             ->visible(fn($get) => $get('component_type') === 'form_field'),
                         Section::make('Field Group Settings')
-                            ->live()        
+                            ->live()
                             ->schema([
                                 Select::make('field_group_id')
                                     ->label('Field Group')
-                                    ->options(function() {
+                                    ->options(function () {
                                         // Compose option labels
                                         $options = FieldGroup::pluck('label', 'id');
                                         foreach ($options as $id => $option) {
@@ -218,9 +316,9 @@ class FormVersionResource extends Resource
                                     ->required()
                                     ->reactive()
                                     ->afterStateUpdated(function ($state, callable $set, callable $get) {
-                                        $fieldGroup = FieldGroup::find($state);                                       
+                                        $fieldGroup = FieldGroup::find($state);
                                         if ($fieldGroup) {
-                                            $formFields = $fieldGroup->formFields()->get()->map(function ($field,$index) {
+                                            $formFields = $fieldGroup->formFields()->get()->map(function ($field, $index) {
                                                 return [
                                                     'form_field_id' => $field->id,
                                                     'label' => $field->label,
@@ -231,7 +329,7 @@ class FormVersionResource extends Resource
                                                     'styles' => $field->styles,
                                                     'mask' => $field->mask,
                                                     'validations' => [],
-                                                    'custom_id' =>'nestedField'.$index+1,
+                                                    'instance_id' => 'nestedField' . $index + 1,
                                                 ];
                                             })->toArray();
                                             $set('form_fields', $formFields);
@@ -240,13 +338,13 @@ class FormVersionResource extends Resource
                                 TextInput::make('group_label')
                                     ->label("Group Label")
                                     ->placeholder(fn($get) => FieldGroup::find($get('field_group_id'))->label ?? null),
-                                TextInput::make('custom_id')
-                                    ->label("Custom ID")
+                                TextInput::make('instance_id')
+                                    ->label("ID")
                                     ->default(fn($get) =>  \App\Helpers\FormTemplateHelper::calculateFieldID($get('../../'))) // Set the sequential default value
                                     ->required()
-                                    ->alphanum()                                    
+                                    ->alphanum()
                                     ->reactive()
-                                    ->distinct(),  
+                                    ->distinct(),
                                 Toggle::make('repeater')
                                     ->label('Repeater'),
                                 Repeater::make('form_fields')
@@ -258,59 +356,154 @@ class FormVersionResource extends Resource
                                     ->itemLabel(function ($state) {
                                         $field = FormField::find($state['form_field_id']) ?: null;
                                         $field ? $label = ($state['label'] ?: ($field->label ?? 'New Field'))
-                                        . ' - ' . $field->dataType->short_description
-                                        . ' (' . ($field->name ?? 'empty') . ')'
-                                        : $label =  'New Field';
+                                            . ' - ' . $field->dataType->short_description
+                                            . ' (' . ($field->name ?? 'empty') . ')'
+                                            : $label =  'New Field';
                                         return $label;
                                     })
                                     ->defaultItems(0)
                                     ->schema([
                                         Select::make('form_field_id')
                                             ->label('Form Field')
-                                            ->options(function($state) {
+                                            ->options(function ($state) {
                                                 // Compose option labels
                                                 $options = FormField::pluck('label', 'id');
                                                 foreach ($options as $id => $option) {
                                                     $field = FormField::find($id) ?: null;
                                                     $options[$id] = $option
-                                                    . ' - ' . $field->dataType->short_description
-                                                    . ' (' . ($field->name ?? '') . ')';
+                                                        . ' - ' . $field->dataType->short_description
+                                                        . ' (' . ($field->name ?? '') . ')';
                                                 }
                                                 return $options;
                                             })
                                             ->searchable()
                                             ->required(),
-                                        TextInput::make('label')
-                                            ->label("Custom Label")
-                                            ->placeholder(fn($get) => FormField::find($get('form_field_id'))->label ?? null),
-                                        TextInput::make('custom_id')
-                                            ->label("Custom ID")                                            
-                                            ->default(fn($get) =>  \App\Helpers\FormTemplateHelper::calculateFieldInGroupID($get('../../'))) // Set the sequential default value
-                                            ->required()
-                                            ->alphanum()                                            
-                                            ->reactive()
-                                            ->distinct(),                                        
-                                        Select::make('data_binding_path')
-                                            ->label("Custom Data Binding Path")
-                                            ->options(FormDataSource::pluck('name', 'name'))
-                                            ->placeholder(fn($get) => FormField::find($get('form_field_id'))->data_binding_path ?? null),
-                                        Textarea::make('data_binding')
-                                            ->label("Custom Data Binding")
-                                            ->placeholder(fn($get) => FormField::find($get('form_field_id'))->data_binding ?? null),
-                                        Textarea::make('field_value')
-                                            ->label("Field Value")                                    
+                                        Fieldset::make('Field Value')
                                             ->visible(fn($get) => FormField::find($get('form_field_id'))?->isValueInputNeededForField() ?? false)
-                                            ->placeholder(fn($get) => FormField::find($get('form_field_id'))->formFieldValue()?->value ?? null)
-                                            ->reactive(),
-                                        Textarea::make('conditional_logic')
-                                            ->label("Custom Conditional Logic")
-                                            ->placeholder(fn($get) => FormField::find($get('form_field_id'))->conditional_logic ?? null),
-                                        Textarea::make('styles')
-                                            ->label("Custom Styles")
-                                            ->placeholder(fn($get) => FormField::find($get('form_field_id'))->styles ?? null),
-                                        TextInput::make('mask')
-                                            ->label("Custom Mask")
-                                            ->placeholder(fn($get) => FormField::find($get('form_field_id'))->mask ?? null),
+                                            ->columns(1)
+                                            ->schema([
+                                                Placeholder::make('field_value')
+                                                    ->label("Default")
+                                                    ->content(fn($get) => FormField::find($get('form_field_id'))->formFieldValue?->value ?? 'null'),
+                                                Checkbox::make('customize_field_value')
+                                                    ->label('Customize Field Value')
+                                                    ->inline()
+                                                    ->live(),
+                                                TextInput::make('custom_field_value')
+                                                    ->label(false)
+                                                    ->visible(fn($get) => $get('customize_field_value')),
+                                            ]),
+                                        Fieldset::make('Data Binding')
+                                            ->columns(1)
+                                            ->schema([
+                                                Placeholder::make('data_binding')
+                                                    ->label("Default")
+                                                    ->content(fn($get) => FormField::find($get('form_field_id'))->data_binding ?? 'null'),
+                                                Checkbox::make('customize_data_binding')
+                                                    ->label('Customize Data Binding')
+                                                    ->inline()
+                                                    ->live(),
+                                                Textarea::make('custom_data_binding')
+                                                    ->label(false)
+                                                    ->visible(fn($get) => $get('customize_data_binding')),
+                                            ]),
+                                        Fieldset::make('Data Source')
+                                            ->columns(1)
+                                            ->schema([
+                                                Placeholder::make('data_binding_path')
+                                                    ->label("Default")
+                                                    ->content(fn($get) => FormField::find($get('form_field_id'))->data_binding_path ?? 'null'),
+                                                Checkbox::make('customize_data_binding_path')
+                                                    ->label('Customize Data Source')
+                                                    ->inline()
+                                                    ->live(),
+                                                Select::make('custom_data_binding_path')
+                                                    ->label(false)
+                                                    ->options(FormDataSource::pluck('name', 'name'))
+                                                    ->visible(fn($get) => $get('customize_data_binding_path')),
+                                            ]),
+                                        Fieldset::make('Styles')
+                                            ->columns(1)
+                                            ->schema([
+                                                Placeholder::make('styles')
+                                                    ->label("Default")
+                                                    ->content(fn($get) => FormField::find($get('form_field_id'))->styles ?? 'null'),
+                                                Checkbox::make('customize_styles')
+                                                    ->label('Customize Styles')
+                                                    ->inline()
+                                                    ->live(),
+                                                Textarea::make('custom_styles')
+                                                    ->label(false)
+                                                    ->visible(fn($get) => $get('customize_styles')),
+                                            ]),
+                                        Fieldset::make('Mask')
+                                            ->columns(1)
+                                            ->schema([
+                                                Placeholder::make('mask')
+                                                    ->label("Default")
+                                                    ->content(fn($get) => FormField::find($get('form_field_id'))->mask ?? 'null'),
+                                                Checkbox::make('customize_mask')
+                                                    ->label('Customize Mask')
+                                                    ->inline()
+                                                    ->live(),
+                                                TextInput::make('custom_mask')
+                                                    ->label(false)
+                                                    ->visible(fn($get) => $get('customize_mask')),
+                                            ]),
+                                        Fieldset::make('Help Text')
+                                            ->columns(1)
+                                            ->schema([
+                                                Placeholder::make('help_text')
+                                                    ->label("Default")
+                                                    ->content(fn($get) => FormField::find($get('form_field_id'))->help_text ?? 'null'),
+                                                Checkbox::make('customize_help_text')
+                                                    ->label('Customize Help text')
+                                                    ->inline()
+                                                    ->live(),
+                                                Textarea::make('custom_help_text')
+                                                    ->label(false)
+                                                    ->visible(fn($get) => $get('customize_help_text')),
+                                            ]),
+                                        Fieldset::make('Label')
+                                            ->columns(1)
+                                            ->schema([
+                                                Placeholder::make('label')
+                                                    ->label("Default")
+                                                    ->content(fn($get) => FormField::find($get('form_field_id'))->label ?? 'null'),
+                                                Radio::make('customize_label')
+                                                    ->options([
+                                                        'default' => 'Use Default',
+                                                        'hide' => 'Hide Label',
+                                                        'customize' => 'Customize Label'
+                                                    ])
+                                                    ->default('default')
+                                                    ->inline()
+                                                    ->inlineLabel(false)
+                                                    ->live(),
+                                                TextInput::make('custom_label')
+                                                    ->label(false)
+                                                    ->visible(fn($get) => $get('customize_label') == 'customize'),
+                                            ]),
+                                        Fieldset::make('Instance ID')
+                                            ->columns(1)
+                                            ->schema([
+                                                Placeholder::make('instance_id_placeholder') // used to view value in builder
+                                                    ->label("Default")
+                                                    ->content(fn($get) => $get('instance_id')), // Set the sequential default value
+                                                Hidden::make('instance_id') // used to populate value in template 
+                                                    ->hidden()
+                                                    ->default(fn($get) => \App\Helpers\FormTemplateHelper::calculateFieldInGroupID($get('../../'))), // Set the sequential default value
+                                                Checkbox::make('customize_instance_id')
+                                                    ->label('Customize Instance ID')
+                                                    ->inline()
+                                                    ->live(),
+                                                TextInput::make('custom_instance_id')
+                                                    ->label(false)
+                                                    ->alphanum()
+                                                    ->reactive()
+                                                    ->distinct()
+                                                    ->visible(fn($get) => $get('customize_instance_id')),
+                                            ]),
                                         Repeater::make('validations')
                                             ->label('Validations')
                                             ->collapsible()
@@ -336,9 +529,9 @@ class FormVersionResource extends Resource
                                                 TextInput::make('error_message')
                                                     ->label('Error Message'),
                                             ]),
-                                        Textarea::make('help_text')
-                                            ->label("Custom Help text")
-                                            ->placeholder(fn($get) => FormField::find($get('form_field_id'))->help_text ?? null),
+                                        Textarea::make('conditional_logic')
+                                            ->label("Custom Conditional Logic")
+                                            ->placeholder(fn($get) => FormField::find($get('form_field_id'))->conditional_logic ?? null),
                                     ])
                                     ->columns(1),
                             ])
@@ -477,7 +670,7 @@ class FormVersionResource extends Resource
         ];
     }
 
-    
+
     public static function getPages(): array
     {
         return [

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/CreateFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/CreateFormVersion.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use App\Models\FormInstanceField;
 use App\Models\FieldGroupInstance;
+use App\Models\FormField;
 use App\Models\FormInstanceFieldValidation;
 use App\Models\FormInstanceFieldValue;
 
@@ -68,13 +69,21 @@ class CreateFormVersion extends CreateRecord
                     'form_field_id' => $component['form_field_id'],
                     'order' => $order,
                     'label' => $component['label'] ?? null,
+                    'custom_label' => $component['custom_label'] ?? null,
+                    'customize_label' => $component['customize_label'] ?? null,
                     'data_binding_path' => $component['data_binding_path'] ?? null,
+                    'custom_data_binding_path' => $component['custom_data_binding_path'] ?? null,
                     'data_binding' => $component['data_binding'] ?? null,
-                    'conditional_logic' => $component['conditional_logic'] ?? null,
+                    'custom_data_binding' => $component['custom_data_binding'] ?? null,
                     'help_text' => $component['help_text'] ?? null,
+                    'custom_help_text' => $component['custom_help_text'] ?? null,
                     'styles' => $component['styles'] ?? null,
+                    'custom_styles' => $component['custom_styles'] ?? null,
                     'mask' => $component['mask'] ?? null,
-                    'custom_id' => $component['custom_id'] ?? null,
+                    'custom_mask' => $component['custom_mask'] ?? null,
+                    'instance_id' => $component['instance_id'] ?? null,
+                    'custom_instance_id' => $component['custom_instance_id'] ?? null,
+                    'conditional_logic' => $component['conditional_logic'] ?? null,
                 ]);
 
                 $validations = $component['validations'] ?? [];
@@ -86,14 +95,14 @@ class CreateFormVersion extends CreateRecord
                         'error_message' => $validationData['error_message'] ?? null,
                     ]);
                 }
-                $formFieldValue = $component['field_value'] ?? [];
-                if($formFieldValue) {
+                $customFieldValueCheckbox = $component['customize_field_value'] ?? false;
+                $customFieldValue = $component['custom_field_value'] ?? null;
+                if ($customFieldValueCheckbox) {
                     FormInstanceFieldValue::create([
-                        'form_instance_field_id' => $formInstanceField->id,                        
-                        'value' => $formFieldValue ?? null,                        
+                        'form_instance_field_id' => $formInstanceField->id,
+                        'custom_value' => $customFieldValue ?? null,
                     ]);
                 }
-                
             } elseif ($component['component_type'] === 'field_group') {
                 $fieldGroupInstance = FieldGroupInstance::create([
                     'form_version_id' => $formVersion->id,
@@ -101,7 +110,7 @@ class CreateFormVersion extends CreateRecord
                     'order' => $order,
                     'label' => $component['group_label'] ?? null,
                     'repeater' => $component['repeater'] ?? false,
-                    'custom_id' => $component['custom_id'] ?? null,
+                    'instance_id' => $component['instance_id'] ?? null,
                 ]);
 
                 $formFields = $component['form_fields'] ?? [];
@@ -112,13 +121,21 @@ class CreateFormVersion extends CreateRecord
                         'field_group_instance_id' => $fieldGroupInstance->id,
                         'order' => $fieldOrder,
                         'label' => $fieldData['label'] ?? null,
+                        'custom_label' => $fieldData['custom_label'] ?? null,
+                        'customize_label' => $fieldData['customize_label'] ?? null,
                         'data_binding_path' => $fieldData['data_binding_path'] ?? null,
+                        'custom_data_binding_path' => $fieldData['custom_data_binding_path'] ?? null,
                         'data_binding' => $fieldData['data_binding'] ?? null,
-                        'conditional_logic' => $fieldData['conditional_logic'] ?? null,
+                        'custom_data_binding' => $fieldData['custom_data_binding'] ?? null,
                         'help_text' => $fieldData['help_text'] ?? null,
+                        'custom_help_text' => $fieldData['custom_help_text'] ?? null,
                         'styles' => $fieldData['styles'] ?? null,
+                        'custom_styles' => $fieldData['custom_styles'] ?? null,
                         'mask' => $fieldData['mask'] ?? null,
-                        'custom_id' => $fieldData['custom_id'] ?? null,
+                        'custom_mask' => $fieldData['custom_mask'] ?? null,
+                        'instance_id' => $fieldData['instance_id'] ?? null,
+                        'custom_instance_id' => $fieldData['custom_instance_id'] ?? null,
+                        'conditional_logic' => $fieldData['conditional_logic'] ?? null,
                     ]);
 
                     $validations = $fieldData['validations'] ?? [];
@@ -130,11 +147,13 @@ class CreateFormVersion extends CreateRecord
                             'error_message' => $validationData['error_message'] ?? null,
                         ]);
                     }
-                    $formFieldValue = $fieldData['field_value'] ?? [];
-                    if($formFieldValue) {
+
+                    $customFieldValueCheckbox = $fieldData['customize_field_value'] ?? false;
+                    $customFieldValue = $fieldData['custom_field_value'] ?? null;
+                    if ($customFieldValueCheckbox) {
                         FormInstanceFieldValue::create([
-                            'form_instance_field_id' => $formInstanceField->id,                        
-                            'value' => $formFieldValue ?? null,                        
+                            'form_instance_field_id' => $formInstanceField->id,
+                            'custom_value' => $customFieldValue ?? null,
                         ]);
                     }
                 }

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/EditFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/EditFormVersion.php
@@ -8,6 +8,7 @@ use Filament\Resources\Pages\EditRecord;
 use Illuminate\Support\Facades\Auth;
 use App\Models\FormInstanceField;
 use App\Models\FieldGroupInstance;
+use App\Models\FormField;
 use App\Models\FormInstanceFieldValidation;
 use App\Models\FormInstanceFieldValue;
 
@@ -55,14 +56,16 @@ class EditFormVersion extends EditRecord
                     'form_version_id' => $formVersion->id,
                     'form_field_id' => $component['form_field_id'],
                     'order' => $order,
-                    'label' => $component['label'] ?? null,
-                    'data_binding_path' => $component['data_binding_path'] ?? null,
-                    'data_binding' => $component['data_binding'] ?? null,
+                    'custom_label' => $component['customize_label'] == 'customize' ? $component['custom_label'] : null,
+                    'customize_label' => $component['customize_label'] ?? null,
+                    'custom_data_binding_path' => $component['customize_data_binding_path'] ? $component['custom_data_binding_path'] : null,
+                    'custom_data_binding' => $component['customize_data_binding'] ? $component['custom_data_binding'] : null,
                     'conditional_logic' => $component['conditional_logic'] ?? null,
-                    'help_text' => $component['help_text'] ?? null,
-                    'styles' => $component['styles'] ?? null,
-                    'mask' => $component['mask'] ?? null,
-                    'custom_id' => $component['custom_id'] ?? null,
+                    'custom_help_text' => $component['customize_help_text'] ? $component['custom_help_text'] : null,
+                    'custom_styles' => $component['customize_styles'] ? $component['custom_styles'] : null,
+                    'custom_mask' => $component['customize_mask'] ? $component['custom_mask'] : null,
+                    'instance_id' => $component['instance_id'] ?? null,
+                    'custom_instance_id' => $component['customize_instance_id'] ? $component['custom_instance_id'] : null,
                 ]);
 
                 $validations = $component['validations'] ?? [];
@@ -74,11 +77,12 @@ class EditFormVersion extends EditRecord
                         'error_message' => $validationData['error_message'] ?? null,
                     ]);
                 }
-                $formFieldValue = $component['field_value'] ?? [];
-                if($formFieldValue) {
+                $customFieldValueCheckbox = $component['customize_field_value'] ?? false;
+                $customFieldValue = $component['custom_field_value'] ?? null;
+                if ($customFieldValueCheckbox) {
                     FormInstanceFieldValue::create([
-                        'form_instance_field_id' => $formInstanceField->id,                        
-                        'value' => $formFieldValue ?? null,                        
+                        'form_instance_field_id' => $formInstanceField->id,
+                        'custom_value' => $customFieldValue ?? null,
                     ]);
                 }
             } elseif ($component['component_type'] === 'field_group') {
@@ -88,7 +92,7 @@ class EditFormVersion extends EditRecord
                     'order' => $order,
                     'label' => $component['group_label'] ?? null,
                     'repeater' => $component['repeater'] ?? false,
-                    'custom_id' => $component['custom_id'] ?? null,
+                    'instance_id' => $component['instance_id'] ?? null,
                 ]);
 
                 $formFields = $component['form_fields'] ?? [];
@@ -98,14 +102,16 @@ class EditFormVersion extends EditRecord
                         'form_field_id' => $fieldData['form_field_id'],
                         'field_group_instance_id' => $fieldGroupInstance->id,
                         'order' => $fieldOrder,
-                        'label' => $fieldData['label'] ?? null,
-                        'data_binding_path' => $fieldData['data_binding_path'] ?? null,
-                        'data_binding' => $fieldData['data_binding'] ?? null,
+                        'custom_label' => $fieldData['customize_label'] == 'customize' ? $fieldData['custom_label'] : null,
+                        'customize_label' => $fieldData['customize_label'] ?? null,
+                        'custom_data_binding_path' => $fieldData['customize_data_binding_path'] ? $fieldData['custom_data_binding_path'] : null,
+                        'custom_data_binding' => $fieldData['customize_data_binding'] ? $fieldData['custom_data_binding'] : null,
                         'conditional_logic' => $fieldData['conditional_logic'] ?? null,
-                        'help_text' => $fieldData['help_text'] ?? null,
-                        'styles' => $fieldData['styles'] ?? null,
-                        'mask' => $fieldData['mask'] ?? null,
-                        'custom_id' => $fieldData['custom_id'] ?? null,                        
+                        'custom_help_text' => $fieldData['customize_help_text'] ? $fieldData['custom_help_text'] : null,
+                        'custom_styles' => $fieldData['customize_styles'] ? $fieldData['custom_styles'] : null,
+                        'custom_mask' => $fieldData['customize_mask'] ? $fieldData['custom_mask'] : null,
+                        'instance_id' => $fieldData['instance_id'] ?? null,
+                        'custom_instance_id' => $fieldData['customize_instance_id'] ? $fieldData['custom_instance_id'] : null,
                     ]);
 
                     $validations = $fieldData['validations'] ?? [];
@@ -117,11 +123,12 @@ class EditFormVersion extends EditRecord
                             'error_message' => $validationData['error_message'] ?? null,
                         ]);
                     }
-                    $formFieldValue = $fieldData['field_value'] ?? [];
-                    if($formFieldValue) {
+                    $customFieldValueCheckbox = $fieldData['customize_field_value'] ?? false;
+                    $customFieldValue = $fieldData['custom_field_value'] ?? null;
+                    if ($customFieldValueCheckbox) {
                         FormInstanceFieldValue::create([
-                            'form_instance_field_id' => $formInstanceField->id,                        
-                            'value' => $formFieldValue ?? null,                        
+                            'form_instance_field_id' => $formInstanceField->id,
+                            'custom_value' => $customFieldValue ?? null,
                         ]);
                     }
                 }
@@ -150,20 +157,31 @@ class EditFormVersion extends EditRecord
                 ];
             }
 
+            $formField = FormField::find($field['form_field_id']) ?? 'null';
             $components[] = [
                 'component_type' => 'form_field',
                 'form_field_id' => $field->form_field_id,
-                'label' => $field->label,
-                'data_binding_path' => $field->data_binding_path,
-                'data_binding' => $field->data_binding,
-                'conditional_logic' => $field->conditional_logic,
-                'help_text' => $field->help_text,
-                'styles' => $field->styles,
-                'mask' => $field->mask,
-                'validations' => $validations,
-                'order' => $field->order,
-                'custom_id' => $field->custom_id,
+                'custom_label' => $field->custom_label ?? $formField->label,
+                'customize_label' => $field->customize_label ?? null,
+                'custom_data_binding_path' => $field->custom_data_binding_path ?? $formField->data_binding_path,
+                'customize_data_binding_path' => $field->custom_data_binding_path ?? null,
+                'custom_data_binding' => $field->custom_data_binding ?? $formField->data_binding,
+                'customize_data_binding' => $field->custom_data_binding ?? null,
+                'custom_help_text' => $field->custom_help_text ?? $formField->help_text,
+                'customize_help_text' => $field->custom_help_text ?? null,
+                'custom_styles' => $field->custom_styles ?? $formField->styles,
+                'customize_styles' => $field->custom_styles ?? null,
+                'custom_mask' => $field->custom_mask ?? $formField->mask,
+                'customize_mask' => $field->custom_mask ?? null,
+                'instance_id' => $field->instance_id,
+                'custom_instance_id' => $field->custom_instance_id,
+                'customize_instance_id' => $field->custom_instance_id ?? null,
                 'field_value' => $field->formInstanceFieldValue?->value,
+                'custom_field_value' => $field->formInstanceFieldValue?->value ?? $field->formInstanceFieldValue?->custom_value,
+                'customize_field_value' => $field->formInstanceFieldValue?->custom_value ?? null,
+                'validations' => $validations,
+                'conditional_logic' => $field->conditional_logic,
+                'order' => $field->order,
             ];
         }
 
@@ -183,18 +201,30 @@ class EditFormVersion extends EditRecord
                     ];
                 }
 
+                $formField = FormField::find($field['form_field_id']) ?? 'null';
                 $formFieldsData[] = [
                     'form_field_id' => $field->form_field_id,
                     'label' => $field->label,
-                    'data_binding_path' => $field->data_binding_path,
-                    'data_binding' => $field->data_binding,
-                    'conditional_logic' => $field->conditional_logic,
-                    'help_text' => $field->help_text,
-                    'styles' => $field->styles,
-                    'mask' => $field->mask,
-                    'validations' => $validations,
-                    'custom_id' => $field->custom_id,
+                    'custom_label' => $field->custom_label ?? $formField->label,
+                    'customize_label' => $field->custom_label ?? null,
+                    'custom_data_binding_path' => $field->custom_data_binding_path ?? $formField->data_binding_path,
+                    'customize_data_binding_path' => $field->custom_data_binding_path ?? null,
+                    'custom_data_binding' => $field->custom_data_binding ?? $formField->data_binding,
+                    'customize_data_binding' => $field->custom_data_binding ?? null,
+                    'custom_help_text' => $field->custom_help_text ?? $formField->help_text,
+                    'customize_help_text' => $field->custom_help_text ?? null,
+                    'custom_styles' => $field->custom_styles ?? $formField->styles,
+                    'customize_styles' => $field->custom_styles ?? null,
+                    'custom_mask' => $field->custom_mask ?? $formField->mask,
+                    'customize_mask' => $field->custom_mask ?? null,
+                    'instance_id' => $field->instance_id,
+                    'custom_instance_id' => $field->custom_instance_id,
+                    'customize_instance_id' => $field->custom_instance_id ?? null,
                     'field_value' => $field->formInstanceFieldValue?->value,
+                    'custom_field_value' => $field->formInstanceFieldValue?->custom_value ?? null,
+                    'customize_field_value' => $field->formInstanceFieldValue?->custom_value ?? null,
+                    'validations' => $validations,
+                    'conditional_logic' => $field->conditional_logic,
                 ];
             }
 
@@ -205,7 +235,7 @@ class EditFormVersion extends EditRecord
                 'repeater' => $group->repeater,
                 'form_fields' => $formFieldsData,
                 'order' => $group->order,
-                'custom_id' => $group->custom_id,
+                'instance_id' => $group->instance_id,
             ];
         }
 

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/ViewFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/ViewFormVersion.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Forms\Resources\FormVersionResource\Pages;
 
 use App\Filament\Forms\Resources\FormVersionResource;
+use App\Models\FormField;
 use Filament\Actions;
 use Filament\Resources\Pages\ViewRecord;
 
@@ -35,23 +36,39 @@ class ViewFormVersion extends ViewRecord
                     'value' => $validation->value,
                     'error_message' => $validation->error_message,
                 ];
-            }         
-           
-            
+            }
+
+            $formField = FormField::find($field['form_field_id']) ?? null;
             $components[] = [
                 'component_type' => 'form_field',
                 'form_field_id' => $field->form_field_id,
-                'label' => $field->label,
+                'label' => $formField?->label,
+                'custom_label' => $field->custom_label,
+                'customize_label' => $field->customize_label,
                 'data_binding_path' => $field->data_binding_path,
+                'custom_data_binding_path' => $field->custom_data_binding_path,
+                'customize_data_binding_path' => $field->custom_data_binding_path,
                 'data_binding' => $field->data_binding,
-                'conditional_logic' => $field->conditional_logic,
+                'custom_data_binding' => $field->custom_data_binding,
+                'customize_data_binding' => $field->custom_data_binding,
                 'help_text' => $field->help_text,
+                'custom_help_text' => $field->custom_help_text,
+                'customize_help_text' => $field->custom_help_text,
                 'styles' => $field->styles,
+                'custom_styles' => $field->custom_styles,
+                'customize_styles' => $field->custom_styles,
                 'mask' => $field->mask,
+                'custom_mask' => $field->custom_mask,
+                'customize_mask' => $field->custom_mask,
+                'instance_id' => $field->instance_id,
+                'custom_instance_id' => $field->custom_instance_id,
+                'customize_instance_id' => $field->custom_instance_id,
+                'field_value' => $field->formInstanceFieldValue?->value,
+                'custom_field_value' => $field->formInstanceFieldValue?->custom_value,
+                'customize_field_value' => $field->formInstanceFieldValue?->custom_value,
                 'validations' => $validations,
+                'conditional_logic' => $field->conditional_logic,
                 'order' => $field->order,
-                'custom_id' => $field->custom_id,
-                'field_value' => $field->formInstanceFieldValue?->value, 
             ];
         }
 
@@ -71,18 +88,35 @@ class ViewFormVersion extends ViewRecord
                     ];
                 }
 
+                $formField = FormField::find($field['form_field_id']) ?? null;
                 $formFieldsData[] = [
                     'form_field_id' => $field->form_field_id,
-                    'label' => $field->label,
+                    'label' => $formField?->label,
+                    'custom_label' => $field->custom_label,
+                    'customize_label' => $field->customize_label,
                     'data_binding_path' => $field->data_binding_path,
+                    'custom_data_binding_path' => $field->custom_data_binding_path,
+                    'customize_data_binding_path' => $field->custom_data_binding_path,
                     'data_binding' => $field->data_binding,
-                    'conditional_logic' => $field->conditional_logic,
+                    'custom_data_binding' => $field->custom_data_binding,
+                    'customize_data_binding' => $field->custom_data_binding,
                     'help_text' => $field->help_text,
+                    'custom_help_text' => $field->custom_help_text,
+                    'customize_help_text' => $field->custom_help_text,
                     'styles' => $field->styles,
+                    'custom_styles' => $field->custom_styles,
+                    'customize_styles' => $field->custom_styles,
                     'mask' => $field->mask,
+                    'custom_mask' => $field->custom_mask,
+                    'customize_mask' => $field->custom_mask,
+                    'instance_id' => $field->instance_id,
+                    'custom_instance_id' => $field->custom_instance_id,
+                    'customize_instance_id' => $field->custom_instance_id,
+                    'field_value' => $field->formInstanceFieldValue?->value,
+                    'custom_field_value' => $field->formInstanceFieldValue?->custom_value,
+                    'customize_field_value' => $field->formInstanceFieldValue?->custom_value,
                     'validations' => $validations,
-                    'custom_id' => $field->custom_id,
-                    'field_value' => $field->formInstanceFieldValue?->value, 
+                    'conditional_logic' => $field->conditional_logic,
                 ];
             }
 
@@ -93,7 +127,7 @@ class ViewFormVersion extends ViewRecord
                 'repeater' => $group->repeater,
                 'form_fields' => $formFieldsData,
                 'order' => $group->order,
-                'custom_id' => $group->custom_id, 
+                'instance_id' => $group->instance_id,
             ];
         }
 

--- a/app/Helpers/FormTemplateHelper.php
+++ b/app/Helpers/FormTemplateHelper.php
@@ -90,8 +90,8 @@ class FormTemplateHelper
     protected static function formatField($fieldInstance, $index)
     {
         $field = $fieldInstance->formField;
-        
-        $validation=$fieldInstance->validations->map(function ($validation) {
+
+        $validation = $fieldInstance->validations->map(function ($validation) {
             return [
                 'type' => $validation->type,
                 'value' => $validation->value,
@@ -100,28 +100,36 @@ class FormTemplateHelper
         })->toArray();
 
         $databindings = [
-            "source" => $fieldInstance->data_binding_path??$field->data_binding_path,
-            "path" => $fieldInstance->data_binding??$field->data_binding,
+            "source" => $fieldInstance->custom_data_binding_path ?? $field->data_binding_path,
+            "path" => $fieldInstance->custom_data_binding ?? $field->data_binding,
         ];
 
+        // Construct $label for $base
+        $label = null;
+        if ($fieldInstance->customize_label == 'default') {
+            $label = $field->label;
+        } elseif ($fieldInstance->customize_label == 'customize') {
+            $label = $fieldInstance->custom_label;
+        } elseif ($fieldInstance->customize_label == 'hide') {
+            $label = null;
+        }
         $base = [
             "type" => $field->dataType->name,
-            "id" => $fieldInstance->custom_id,
-            "label" => $fieldInstance->label??$field->label,
-            "labelText" => $fieldInstance->label??$field->label,
-            "helpText" => $fieldInstance->help_text??$field->help_text,
-            "styles" => $fieldInstance->styles??$field->styles,
-            "mask" => $fieldInstance->mask??$field->mask,
+            "id" => $fieldInstance->custom_instance_id ?? $fieldInstance->instance_id,
+            "label" => $label,
+            "helpText" => $fieldInstance->custom_help_text ?? $field->help_text,
+            "styles" => $fieldInstance->custom_styles ?? $field->styles,
+            "mask" => $fieldInstance->custom_mask ?? $field->mask,
             "codeContext" => [
                 "name" => $field->name,
             ],
         ];
 
-        if(sizeof($validation) > 0){
+        if (sizeof($validation) > 0) {
             $base = array_merge($base, ["validation" => $validation]);
         }
 
-        if(!is_null($databindings["source"]) && !is_null($databindings["path"]) ){
+        if (!is_null($databindings["source"]) && !is_null($databindings["path"])) {
             $base = array_merge($base, ["databindings" => $databindings]);
         }
 
@@ -150,7 +158,7 @@ class FormTemplateHelper
                 ]);
             case "text-info":
                 return array_merge($base, [
-                    "value" => $fieldInstance->formInstanceFieldValue?->value ?? $field->formFieldValue?->value,
+                    "value" => $fieldInstance->formInstanceFieldValue?->custom_value ?? $field->formFieldValue?->value,
                     "helperText" => "{$fieldInstance->label} as it appears on official documents",
                 ]);
             case "radio":
@@ -180,8 +188,8 @@ class FormTemplateHelper
 
         $base = [
             "type" => "group",
-            "label" => $groupInstance->label??$group->label,
-            "id" => $groupInstance->custom_id,
+            "label" => $groupInstance->label ?? $group->label,
+            "id" => $groupInstance->instance_id,
             "groupId" => (string) $group->id,
             "repeater" => $groupInstance->repeater,
             "codeContext" => [

--- a/app/Models/FieldGroupInstance.php
+++ b/app/Models/FieldGroupInstance.php
@@ -17,7 +17,7 @@ class FieldGroupInstance extends Model
         'label',
         'repeater',
         'order',
-        'custom_id',
+        'instance_id',
 
     ];
 

--- a/app/Models/FormInstanceField.php
+++ b/app/Models/FormInstanceField.php
@@ -16,15 +16,17 @@ class FormInstanceField extends Model
         'form_version_id',
         'form_field_id',
         'order',
-        'label',
-        'data_binding_path',
-        'data_binding',
+        'custom_label',
+        'customize_label',
+        'custom_data_binding_path',
+        'custom_data_binding',
         'conditional_logic',
-        'help_text',
-        'styles',
-        'mask',
+        'custom_help_text',
+        'custom_styles',
+        'custom_mask',
         'field_group_instance_id',
-        'custom_id'
+        'instance_id',
+        'custom_instance_id'
     ];
 
     public function formVersion(): BelongsTo
@@ -46,9 +48,9 @@ class FormInstanceField extends Model
     {
         return $this->hasMany(FormInstanceFieldValidation::class);
     }
-    
+
     public function formInstanceFieldValue(): HasOne
     {
         return $this->hasOne(FormInstanceFieldValue::class);
     }
-} 
+}

--- a/app/Models/FormInstanceFieldValue.php
+++ b/app/Models/FormInstanceFieldValue.php
@@ -4,13 +4,14 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class FormInstanceFieldValue extends Model
 {
-    protected $fillable = ['form_instance_field_id', 'value'];
+    protected $fillable = ['form_instance_field_id', 'custom_value'];
 
     public function formInstanceField(): BelongsTo
     {
         return $this->belongsTo(FormInstanceField::class);
-    }    
+    }
 }

--- a/database/migrations/2024_12_23_224628_add_custom_properties_to_form_fields.php
+++ b/database/migrations/2024_12_23_224628_add_custom_properties_to_form_fields.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('form_instance_fields', function (Blueprint $table) {
+            $table->renameColumn('custom_id', 'instance_id');
+            $table->renameColumn('data_binding', 'custom_data_binding');
+            $table->renameColumn('data_binding_path', 'custom_data_binding_path');
+            $table->renameColumn('styles', 'custom_styles');
+            $table->renameColumn('mask', 'custom_mask');
+            $table->renameColumn('help_text', 'custom_help_text');
+            $table->renameColumn('label', 'custom_label');
+
+            $table->string('customize_label')->nullable();
+            $table->string('custom_instance_id')->nullable();
+        });
+
+        Schema::table('form_instance_field_values', function (Blueprint $table) {
+            $table->renameColumn('value', 'custom_value')->nullable();
+        });
+
+        Schema::table('field_group_instances', function (Blueprint $table) {
+            $table->renameColumn('custom_id', 'instance_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('form_instance_fields', function (Blueprint $table) {
+            $table->renameColumn('instance_id', 'custom_id');
+            $table->renameColumn('custom_data_binding', 'data_binding');
+            $table->renameColumn('custom_data_binding_path', 'data_binding_path');
+            $table->renameColumn('custom_styles', 'styles');
+            $table->renameColumn('custom_mask', 'mask');
+            $table->renameColumn('custom_help_text', 'help_text');
+            $table->renameColumn('custom_label', 'label');
+
+            $table->dropColumn('customize_label')->nullable();
+            $table->dropColumn('custom_instance_id')->nullable();
+        });
+
+        Schema::table('form_instance_field_values', function (Blueprint $table) {
+            $table->renameColumn('custom_value', 'value');
+        });
+
+        Schema::table('field_group_instances', function (Blueprint $table) {
+            $table->renameColumn('instance_id', 'custom_id');
+        });
+    }
+};


### PR DESCRIPTION
## What changes did you make? 

Added UI and functionality for custom properties on Fields in the Version Builder. Where custom properties exist, they overwrite the default properties in the JSON form template. 

## Why did you make these changes?

Implementing ADO 2229 https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/2229

## What alternatives did you consider?

None

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [x] **My code has adequate test coverage (if applicable)**
