### PR TITLE
Enforce unique names ADO 2223

### DIFF
--- a/app/Filament/Forms/Resources/FieldGroupResource.php
+++ b/app/Filament/Forms/Resources/FieldGroupResource.php
@@ -48,8 +48,8 @@ class FieldGroupResource extends Resource
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('name')->searchable(),
-                Tables\Columns\TextColumn::make('label')->searchable(),
+                Tables\Columns\TextColumn::make('name')->sortable()->searchable(),
+                Tables\Columns\TextColumn::make('label')->sortable()->searchable(),
                 Tables\Columns\IconColumn::make('repeater')->boolean(),
                 Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable()->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('updated_at')->dateTime()->sortable()->toggleable(isToggledHiddenByDefault: true),

--- a/app/Filament/Forms/Resources/FieldGroupResource.php
+++ b/app/Filament/Forms/Resources/FieldGroupResource.php
@@ -26,6 +26,7 @@ class FieldGroupResource extends Resource
         return $form
             ->schema([
                 TextInput::make('name')
+                    ->unique()
                     ->required(),
                 TextInput::make('label')
                     ->required(),

--- a/app/Filament/Forms/Resources/FormFieldResource.php
+++ b/app/Filament/Forms/Resources/FormFieldResource.php
@@ -30,6 +30,7 @@ class FormFieldResource extends Resource
         return $form
             ->schema([
                 Forms\Components\TextInput::make('name')
+                    ->unique()
                     ->required(),
                 Forms\Components\TextInput::make('label')
                     ->required(),

--- a/app/Filament/Forms/Resources/FormFieldResource.php
+++ b/app/Filament/Forms/Resources/FormFieldResource.php
@@ -109,8 +109,10 @@ class FormFieldResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('name')
+                    ->sortable()
                     ->searchable(),
                 Tables\Columns\TextColumn::make('label')
+                    ->sortable()
                     ->searchable(),
                 Tables\Columns\TextColumn::make('dataType.name')
                     ->sortable(),

--- a/app/Filament/Forms/Resources/SelectOptionsResource.php
+++ b/app/Filament/Forms/Resources/SelectOptionsResource.php
@@ -25,6 +25,7 @@ class SelectOptionsResource extends Resource
         return $form
             ->schema([
                 Forms\Components\TextInput::make('name')
+                    ->unique()
                     ->required(),
                 Forms\Components\TextInput::make('label'),
                 Forms\Components\TextInput::make('value'),

--- a/app/Filament/Forms/Resources/SelectOptionsResource.php
+++ b/app/Filament/Forms/Resources/SelectOptionsResource.php
@@ -46,10 +46,13 @@ class SelectOptionsResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('label')
+                    ->sortable()
                     ->searchable(),
                 Tables\Columns\TextColumn::make('name')
+                    ->sortable()
                     ->searchable(),
                 Tables\Columns\TextColumn::make('value')
+                    ->sortable()
                     ->searchable(),
                 Tables\Columns\TextColumn::make('formField.label')
                     ->numeric()


### PR DESCRIPTION
## What changes did you make? 

Enforced uniqueness of names for Fields, Groups, and Select Options (at the front-end level). Also made name, label, and (in the case of Select Options) values searchable in the view table, which will help identify any existing duplicated names

## Why did you make these changes?

Implementing https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/2223

## What alternatives did you consider?

Considered adding validation to the database, but frontend is sufficient and avoids any potential errors with any existing duplicates, which can be safely caught fixed manually

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [x] **My code has adequate test coverage (if applicable)**
