### PR TITLE
Form fields table add data binding column ADO 2234

### DIFF
--- a/app/Filament/Forms/Resources/FormFieldResource.php
+++ b/app/Filament/Forms/Resources/FormFieldResource.php
@@ -42,6 +42,7 @@ class FormFieldResource extends Resource
                 Forms\Components\TextInput::make('mask'),
                 Repeater::make('validations')
                     ->label('Validations')
+                    ->itemLabel(fn($state): ?string => $state['type'] ?? 'New Validation')
                     ->relationship('validations')
                     ->defaultItems(0)
                     ->schema([

--- a/app/Filament/Forms/Resources/FormFieldResource.php
+++ b/app/Filament/Forms/Resources/FormFieldResource.php
@@ -15,6 +15,7 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Get;
 use App\Models\DataType;
+use Filament\Tables\Filters\SelectFilter;
 
 class FormFieldResource extends Resource
 {
@@ -115,6 +116,9 @@ class FormFieldResource extends Resource
                     ->searchable(),
                 Tables\Columns\TextColumn::make('dataType.name')
                     ->sortable(),
+                Tables\Columns\TextColumn::make('data_binding')
+                    ->searchable()
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('fieldGroups.name')
                     ->sortable(),
                 Tables\Columns\TextColumn::make('created_at')
@@ -127,7 +131,18 @@ class FormFieldResource extends Resource
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
-                //
+                SelectFilter::make('data_binding')
+                    ->label('Data Binding')
+                    ->multiple()
+                    ->preload()
+                    ->searchable()
+                    ->options(function () {  // Fetch unique values from the 'data_binding' column            
+                        return \App\Models\FormField::query()
+                            ->distinct()
+                            ->pluck('data_binding', 'data_binding')
+                            ->filter()
+                            ->toArray();
+                    }),
             ])
             ->actions([
                 Tables\Actions\ViewAction::make(),

--- a/app/Filament/Forms/Resources/FormFieldResource.php
+++ b/app/Filament/Forms/Resources/FormFieldResource.php
@@ -27,6 +27,16 @@ class FormFieldResource extends Resource
 
     public static function form(Form $form): Form
     {
+        $validationOptions = [
+            'minValue' => 'Minimum Value',
+            'maxValue' => 'Maximum Value',
+            'minLength' => 'Minimum Length',
+            'maxLength' => 'Maximum Length',
+            'required' => 'Required',
+            'email' => 'Email',
+            'phone' => 'Phone Number',
+            'javascript' => 'JavaScript',
+        ];
         return $form
             ->schema([
                 Forms\Components\TextInput::make('name')
@@ -42,22 +52,13 @@ class FormFieldResource extends Resource
                 Forms\Components\TextInput::make('mask'),
                 Repeater::make('validations')
                     ->label('Validations')
-                    ->itemLabel(fn($state): ?string => $state['type'] ?? 'New Validation')
+                    ->itemLabel(fn($state): ?string => $validationOptions[$state['type']] ?? 'New Validation')
                     ->relationship('validations')
                     ->defaultItems(0)
                     ->schema([
                         Select::make('type')
                             ->label('Validation Type')
-                            ->options([
-                                'minValue' => 'Minimum Value',
-                                'maxValue' => 'Maximum Value',
-                                'minLength' => 'Minimum Length',
-                                'maxLength' => 'Maximum Length',
-                                'required' => 'Required',
-                                'email' => 'Email',
-                                'phone' => 'Phone Number',
-                                'javascript' => 'JavaScript',
-                            ])
+                            ->options($validationOptions)
                             ->reactive()
                             ->required(),
                         TextInput::make('value')

--- a/app/Filament/Forms/Resources/FormVersionResource.php
+++ b/app/Filament/Forms/Resources/FormVersionResource.php
@@ -507,6 +507,7 @@ class FormVersionResource extends Resource
                                             ]),
                                         Repeater::make('validations')
                                             ->label('Validations')
+                                            ->itemLabel(fn($state): ?string => $state['type'] ?? 'New Validation')
                                             ->collapsible()
                                             ->collapsed()
                                             ->defaultItems(0)

--- a/app/Filament/Forms/Resources/FormVersionResource.php
+++ b/app/Filament/Forms/Resources/FormVersionResource.php
@@ -270,6 +270,7 @@ class FormVersionResource extends Resource
                                     ]),
                                 Repeater::make('validations')
                                     ->label('Validations')
+                                    ->itemLabel(fn($state): ?string => $state['type'] ?? 'New Validation')
                                     ->collapsible()
                                     ->collapsed()
                                     ->defaultItems(0)

--- a/app/Filament/Forms/Resources/FormVersionResource.php
+++ b/app/Filament/Forms/Resources/FormVersionResource.php
@@ -38,8 +38,20 @@ class FormVersionResource extends Resource
 
     protected static bool $shouldRegisterNavigation = true;
 
+
     public static function form(Form $form): Form
     {
+        $validationOptions = [
+            'minValue' => 'Minimum Value',
+            'maxValue' => 'Maximum Value',
+            'minLength' => 'Minimum Length',
+            'maxLength' => 'Maximum Length',
+            'required' => 'Required',
+            'email' => 'Email',
+            'phone' => 'Phone Number',
+            'javascript' => 'JavaScript',
+        ];
+
         return $form
             ->schema([
                 Select::make('form_id')
@@ -270,23 +282,14 @@ class FormVersionResource extends Resource
                                     ]),
                                 Repeater::make('validations')
                                     ->label('Validations')
-                                    ->itemLabel(fn($state): ?string => $state['type'] ?? 'New Validation')
+                                    ->itemLabel(fn($state): ?string => $validationOptions[$state['type']] ?? 'New Validation')
                                     ->collapsible()
                                     ->collapsed()
                                     ->defaultItems(0)
                                     ->schema([
                                         Select::make('type')
                                             ->label('Validation Type')
-                                            ->options([
-                                                'minValue' => 'Minimum Value',
-                                                'maxValue' => 'Maximum Value',
-                                                'minLength' => 'Minimum Length',
-                                                'maxLength' => 'Maximum Length',
-                                                'required' => 'Required',
-                                                'email' => 'Email',
-                                                'phone' => 'Phone Number',
-                                                'javascript' => 'JavaScript',
-                                            ])
+                                            ->options($validationOptions)
                                             ->reactive()
                                             ->required(),
                                         TextInput::make('value')
@@ -507,23 +510,14 @@ class FormVersionResource extends Resource
                                             ]),
                                         Repeater::make('validations')
                                             ->label('Validations')
-                                            ->itemLabel(fn($state): ?string => $state['type'] ?? 'New Validation')
+                                            ->itemLabel(fn($state): ?string => $validationOptions[$state['type']] ?? 'New Validation')
                                             ->collapsible()
                                             ->collapsed()
                                             ->defaultItems(0)
                                             ->schema([
                                                 Select::make('type')
                                                     ->label('Validation Type')
-                                                    ->options([
-                                                        'minValue' => 'Minimum Value',
-                                                        'maxValue' => 'Maximum Value',
-                                                        'minLength' => 'Minimum Length',
-                                                        'maxLength' => 'Maximum Length',
-                                                        'required' => 'Required',
-                                                        'email' => 'Email',
-                                                        'phone' => 'Phone Number',
-                                                        'javascript' => 'JavaScript',
-                                                    ])
+                                                    ->options($validationOptions)
                                                     ->reactive()
                                                     ->required(),
                                                 TextInput::make('value')


### PR DESCRIPTION
## What changes did you make? 

Added searchable, sortable, filterable data_bindings column to FormFields table

## Why did you make these changes?

Implementing https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/2234/

## What alternatives did you consider?

None

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [x] **My code has adequate test coverage (if applicable)**
