### PR TITLE
Improved FormVersion element headers

### DIFF
--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/EditFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/EditFormVersion.php
@@ -195,8 +195,6 @@ class EditFormVersion extends EditRecord
                 'component_type' => 'form_field',
                 'form_field_id' => $field->form_field_id,
                 'custom_label' => $field->custom_label ?? null,
-                // 'custom_label' => $field->customize_label === 'customize' ? $field->custom_label : null,
-                // 'custom_label' => $component['customize_label'] === 'customize' ? $component['custom_label'] : null,
                 'customize_label' => $field->customize_label ?? null,
                 'custom_data_binding_path' => $field->custom_data_binding_path ?? $formField->data_binding_path,
                 'customize_data_binding_path' => $field->custom_data_binding_path ?? null,

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/EditFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/EditFormVersion.php
@@ -58,7 +58,7 @@ class EditFormVersion extends EditRecord
                     'form_version_id' => $formVersion->id,
                     'form_field_id' => $component['form_field_id'],
                     'order' => $order,
-                    'custom_label' => $component['customize_label'] == 'customize' ? $component['custom_label'] : null,
+                    'custom_label' => $component['customize_label'] === 'customize' ? $component['custom_label'] : null,
                     'customize_label' => $component['customize_label'] ?? null,
                     'custom_data_binding_path' => $component['customize_data_binding_path'] ? $component['custom_data_binding_path'] : null,
                     'custom_data_binding' => $component['customize_data_binding'] ? $component['custom_data_binding'] : null,
@@ -194,7 +194,9 @@ class EditFormVersion extends EditRecord
             $components[] = [
                 'component_type' => 'form_field',
                 'form_field_id' => $field->form_field_id,
-                'custom_label' => $field->custom_label ?? $formField->label,
+                'custom_label' => $field->custom_label ?? null,
+                // 'custom_label' => $field->customize_label === 'customize' ? $field->custom_label : null,
+                // 'custom_label' => $component['customize_label'] === 'customize' ? $component['custom_label'] : null,
                 'customize_label' => $field->customize_label ?? null,
                 'custom_data_binding_path' => $field->custom_data_binding_path ?? $formField->data_binding_path,
                 'customize_data_binding_path' => $field->custom_data_binding_path ?? null,
@@ -246,7 +248,7 @@ class EditFormVersion extends EditRecord
                 $formFieldsData[] = [
                     'form_field_id' => $field->form_field_id,
                     'label' => $field->label,
-                    'custom_label' => $field->custom_label ?? $formField->label,
+                    'custom_label' => $field->custom_label ?? null,
                     'customize_label' => $field->customize_label ?? null,
                     'custom_data_binding_path' => $field->custom_data_binding_path ?? $formField->data_binding_path,
                     'customize_data_binding_path' => $field->custom_data_binding_path ?? null,


### PR DESCRIPTION
## What changes did you make? 

Fields now display in the format 'Label | type | id: instanceID'
Groups display 'Label | group | id: instanceID'

Field selectors display 'Label | type | name: fieldName'
Group selectors display ''Label | type | name: groupName'

Also fixed a bug where the Label part of the element header does not update when a different field is selected.

## Why did you make these changes?

Implementing https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/2318/

## What alternatives did you consider?

Discussed alternative formats and the utility of including the Name property in the Element header (we decided having it in the Selector was enough)

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [x] **My code has adequate test coverage (if applicable)**
