### PR TITLE
Fix placeholder and helperText in JSON

### DIFF
--- a/app/Helpers/FormTemplateHelper.php
+++ b/app/Helpers/FormTemplateHelper.php
@@ -125,7 +125,7 @@ class FormTemplateHelper
             "type" => $field->dataType->name,
             "id" => $fieldInstance->custom_instance_id ?? $fieldInstance->instance_id,
             "label" => $label,
-            "helpText" => $fieldInstance->custom_help_text ?? $field->help_text,
+            "helpText" => $fieldInstance->custom_help_text ?? $field->help_text, // This key may not have a use in KILN, as "helperText" is what populates under form elements. Once this is confirmed, the redundancy can be removed
             "styles" => $fieldInstance->custom_styles ?? $field->styles,
             "mask" => $fieldInstance->custom_mask ?? $field->mask,
             "codeContext" => [
@@ -148,19 +148,19 @@ class FormTemplateHelper
         switch ($field->dataType->name) {
             case "text-input":
                 return array_merge($base, [
-                    "placeholder" => "Enter your {$fieldInstance->label}",
-                    "helperText" => "{$fieldInstance->label} as it appears on official documents",
+                    "helperText" => $fieldInstance->custom_help_text ?? $field->help_text,
                     "inputType" => "text",
                 ]);
             case "dropdown":
+                $label = $fieldInstance->custom_label ?? $fieldInstance->formField->label;
                 return array_merge($base, [
-                    "placeholder" => "Select your {$fieldInstance->label}",
+                    "placeholder" => "Select your {$label}",
                     "isMulti" => false,
                     "isInline" => false,
                     "selectionFeedback" => "top-after-reopen",
                     "direction" => "bottom",
                     "size" => "md",
-                    "helperText" => "Choose one from the list",
+                    "helperText" => $fieldInstance->custom_help_text ?? $field->help_text,
                     "listItems" => $field->selectOptions()
                         ->get()
                         ->map(function ($selectOption) {
@@ -171,11 +171,11 @@ class FormTemplateHelper
             case "text-info":
                 return array_merge($base, [
                     "value" => $fieldInstance->formInstanceFieldValue?->custom_value ?? $field->formFieldValue?->value,
-                    "helperText" => "{$fieldInstance->label} as it appears on official documents",
+                    "helperText" => $fieldInstance->custom_help_text ?? $field->help_text,
                 ]);
             case "radio":
                 return array_merge($base, [
-                    "helperText" => "Choose one option",
+                    "helperText" => $fieldInstance->custom_help_text ?? $field->help_text,
                     "listItems" => $field->selectOptions()
                         ->get()
                         ->map(function ($selectOption) {

--- a/app/Helpers/FormTemplateHelper.php
+++ b/app/Helpers/FormTemplateHelper.php
@@ -125,7 +125,7 @@ class FormTemplateHelper
             "type" => $field->dataType->name,
             "id" => $fieldInstance->custom_instance_id ?? $fieldInstance->instance_id,
             "label" => $label,
-            "helpText" => $fieldInstance->custom_help_text ?? $field->help_text, // This key may not have a use in KILN, as "helperText" is what populates under form elements. Once this is confirmed, the redundancy can be removed
+            "helperText" => $fieldInstance->custom_help_text ?? $field->help_text,
             "styles" => $fieldInstance->custom_styles ?? $field->styles,
             "mask" => $fieldInstance->custom_mask ?? $field->mask,
             "codeContext" => [
@@ -148,7 +148,6 @@ class FormTemplateHelper
         switch ($field->dataType->name) {
             case "text-input":
                 return array_merge($base, [
-                    "helperText" => $fieldInstance->custom_help_text ?? $field->help_text,
                     "inputType" => "text",
                 ]);
             case "dropdown":
@@ -160,7 +159,6 @@ class FormTemplateHelper
                     "selectionFeedback" => "top-after-reopen",
                     "direction" => "bottom",
                     "size" => "md",
-                    "helperText" => $fieldInstance->custom_help_text ?? $field->help_text,
                     "listItems" => $field->selectOptions()
                         ->get()
                         ->map(function ($selectOption) {
@@ -171,11 +169,9 @@ class FormTemplateHelper
             case "text-info":
                 return array_merge($base, [
                     "value" => $fieldInstance->formInstanceFieldValue?->custom_value ?? $field->formFieldValue?->value,
-                    "helperText" => $fieldInstance->custom_help_text ?? $field->help_text,
                 ]);
             case "radio":
                 return array_merge($base, [
-                    "helperText" => $fieldInstance->custom_help_text ?? $field->help_text,
                     "listItems" => $field->selectOptions()
                         ->get()
                         ->map(function ($selectOption) {


### PR DESCRIPTION
## What changes did you make? 

Set "helperText" to help text property of FieldInstance/Field for all field types, and removed "placeholder" on text-input and redundant "helpText" key

## Why did you make these changes?

Resolving https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/2312/

## What alternatives did you consider?

None

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [x] **My code has adequate test coverage (if applicable)**
