### PR TITLE
Attached fields not being added to groups ADO 2361

### DIFF
--- a/app/Filament/Forms/Resources/FormVersionResource.php
+++ b/app/Filament/Forms/Resources/FormVersionResource.php
@@ -389,18 +389,21 @@ class FormVersionResource extends Resource
                                         if ($fieldGroup) {
                                             $formFields = $fieldGroup->formFields()->get()->map(function ($field, $index) {
                                                 return [
-                                                    'form_field_id' => $field->id,
-                                                    'label' => $field->label,
-                                                    'data_binding_path' => $field->data_binding_path,
-                                                    'data_binding' => $field->data_binding,
-                                                    'help_text' => $field->help_text,
-                                                    'styles' => $field->styles,
-                                                    'mask' => $field->mask,
-                                                    'validations' => [],
-                                                    'conditionals' => [],
-                                                    'instance_id' => 'nestedField' . $index + 1,
-                                                    'customize_label' => 'default',
-                                                    'customize_group_label' => 'default',
+                                                    'type' => 'form_field',
+                                                    'data' => [
+                                                        'form_field_id' => $field->id,
+                                                        'label' => $field->label,
+                                                        'data_binding_path' => $field->data_binding_path,
+                                                        'data_binding' => $field->data_binding,
+                                                        'help_text' => $field->help_text,
+                                                        'styles' => $field->styles,
+                                                        'mask' => $field->mask,
+                                                        'validations' => [],
+                                                        'conditionals' => [],
+                                                        'instance_id' => 'nestedField' . $index + 1,
+                                                        'customize_label' => 'default',
+                                                        'customize_group_label' => 'default',
+                                                    ],
                                                 ];
                                             })->toArray();
                                             $set('form_fields', $formFields);


### PR DESCRIPTION
## What changes did you make? 

Resolved bug by wrapping the field data inside the 'data' array key, as expected by the builder

## Why did you make these changes?

Resolving https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/2361/

## What alternatives did you consider?

None

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [x] **My code has adequate test coverage (if applicable)**
