### PR TITLE
Use RichEditor for text-info Value property

### DIFF
--- a/app/Filament/Components/FormFieldBlock.php
+++ b/app/Filament/Components/FormFieldBlock.php
@@ -13,6 +13,7 @@ use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
@@ -166,16 +167,37 @@ class FormFieldBlock
                                     ->columns(1)
                                     ->columnSpanFull()
                                     ->schema([
-                                        Placeholder::make('field_value')
+                                        RichEditor::make('field_value')
                                             ->label("Default")
-                                            ->content(fn($get) => FormField::find($get('form_field_id'))->formFieldValue?->value ?? 'null'),
+                                            ->toolbarButtons([])
+                                            ->disabled()
+                                            ->afterStateHydrated(function ($state, callable $set, callable $get) {
+                                                $value = FormField::find($get('form_field_id'))?->formFieldValue?->value ?? '';
+                                                $set('field_value', $value);
+                                            }),
                                         Toggle::make('customize_field_value')
                                             ->label('Customize Field Value')
                                             ->inline()
                                             ->live(),
-                                        TextInput::make('custom_field_value')
+                                        RichEditor::make('custom_field_value')
                                             ->label(false)
-                                            ->visible(fn($get) => $get('customize_field_value')),
+                                            ->visible(fn($get) => $get('customize_field_value'))
+                                            ->toolbarButtons([
+                                                'bold',
+                                                'italic',
+                                                'underline',
+                                                'strike',
+                                                'link',
+                                                'h1',
+                                                'h2',
+                                                'h3',
+                                                'blockquote',
+                                                'codeBlock',
+                                                'bulletList',
+                                                'orderedList',
+                                                'undo',
+                                                'redo',
+                                            ]),
                                     ]),
                                 Fieldset::make('Data Binding')
                                     ->columns(1)

--- a/app/Filament/Forms/Resources/FormFieldResource.php
+++ b/app/Filament/Forms/Resources/FormFieldResource.php
@@ -13,6 +13,7 @@ use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use App\Models\DataType;
+use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\Textarea;
 use Filament\Support\Enums\Alignment;
 use Filament\Tables\Filters\SelectFilter;
@@ -53,6 +54,30 @@ class FormFieldResource extends Resource
                     ->columnSpan(2)
                     ->required()
                     ->live(),
+                RichEditor::make('value')
+                    ->label('Field Value')
+                    ->visible(function (callable $get) {
+                        $dataType = DataType::find($get('data_type_id'));
+                        return $dataType && $dataType->name === 'text-info';
+                    })
+                    ->toolbarButtons([
+                        'bold',
+                        'italic',
+                        'underline',
+                        'strike',
+                        'link',
+                        'h1',
+                        'h2',
+                        'h3',
+                        'blockquote',
+                        'codeBlock',
+                        'bulletList',
+                        'orderedList',
+                        'undo',
+                        'redo',
+                    ])
+                    ->live()
+                    ->columnSpanFull(),
                 Select::make('selectOptions')
                     ->label('Select Options')
                     ->relationship('selectOptions', 'label')
@@ -113,14 +138,6 @@ class FormFieldResource extends Resource
                     ])
                     ->collapsed(),
                 Textarea::make('help_text')
-                    ->columnSpanFull(),
-                Textarea::make('value')
-                    ->label('Field Value')
-                    ->visible(function (callable $get) {
-                        $dataType = DataType::find($get('data_type_id'));
-                        return $dataType && $dataType->name === 'text-info';
-                    })
-                    ->live()
                     ->columnSpanFull(),
                 Textarea::make('description')
                     ->columnSpanFull(),


### PR DESCRIPTION
## What changes did you make? 

Used RichEditor component for Value property of fields with type text-info, instead of TextInput or Textarea

## Why did you make these changes?

Implementing https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/2384/

## What alternatives did you consider?

Considered using Textarea and Markdown components, but RichEditor is the richest and most compatible with KILN's side of the implementation

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [x] **My code has adequate test coverage (if applicable)**
