### PR TITLE
Make value property required on SelectOptions ADO 2372

### DIFF
--- a/app/Filament/Forms/Resources/SelectOptionsResource.php
+++ b/app/Filament/Forms/Resources/SelectOptionsResource.php
@@ -31,7 +31,8 @@ class SelectOptionsResource extends Resource
                     ->required(),
                 Forms\Components\TextInput::make('label')
                     ->required(),
-                Forms\Components\TextInput::make('value'),
+                Forms\Components\TextInput::make('value')
+                    ->required(),
                 Forms\Components\Textarea::make('description')
                     ->columnSpanFull(),
                 Forms\Components\Select::make('formFields')


### PR DESCRIPTION
## What changes did you make? 

Make value required for SelectOptions (on the front-end only)

## Why did you make these changes?

Implementing https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/2372/

## What alternatives did you consider?

None

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [x] **My code has adequate test coverage (if applicable)**
