### PR TITLE
Sort and order select options ADO 2304

### DIFF
--- a/app/Filament/Components/FormFieldBlock.php
+++ b/app/Filament/Components/FormFieldBlock.php
@@ -5,7 +5,9 @@ namespace App\Filament\Components;
 use App\Models\Style;
 use App\Models\FormField;
 use App\Models\FormDataSource;
+use App\Models\SelectOptions;
 use Closure;
+use Filament\Forms\Components\Builder;
 use Filament\Forms\Components\Builder\Block;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\Grid;
@@ -43,6 +45,8 @@ class FormFieldBlock
             'readOnly' => 'Read Only',
         ];
 
+        $selectOptions = fn() => SelectOptions::all()->keyBy('id');
+
         return Block::make('form_field')
             ->label(function (?array $state): string {
                 if ($state === null) {
@@ -68,43 +72,36 @@ class FormFieldBlock
                 Select::make('form_field_id')
                     ->label('Form Field')
                     ->live()
-                    ->options(function () {
-                        // Compose option labels
-                        $options = FormField::pluck('label', 'id');
-                        foreach ($options as $id => $option) {
-                            $field = FormField::find($id) ?: null;
-                            $options[$id] = $option
-                                . ' | ' . $field->dataType->name
-                                . ' | name: ' . ($field->name ?? '');
-                        }
-                        return $options;
-                    })
+                    ->options(fn() => FormField::with('dataType')->get()->mapWithKeys(fn($field) => [
+                        $field->id => "{$field->label} | {$field->dataType?->name} | name: {$field->name}"
+                    ]))
                     ->searchable()
                     ->required()
                     ->reactive()
                     ->columnSpan(2)
                     ->afterStateUpdated(function ($state, callable $set) {
-                        $field = FormField::find($state);
+                        $field = FormField::with(['webStyles', 'pdfStyles', 'validations', 'selectOptionInstances'])->find($state);
                         if ($field) {
-                            // Fetch styles and set them manually
-                            $webStyles = $field->webStyles()->pluck('styles.id')->toArray();
-                            $set('webStyles', $webStyles);
-                            $pdfStyles = $field->pdfStyles()->pluck('styles.id')->toArray();
-                            $set('pdfStyles', $pdfStyles);
-                            // Fetch validations as well
-                            $validations = $field->validations()->get()->map(function ($validation) {
-                                return [
-                                    'type' => $validation->type,
-                                    'value' => $validation->value,
-                                    'error_message' => $validation->error_message,
-                                ];
-                            })->toArray();
-                            $set('validations', $validations);
+                            $set('webStyles', $field->webStyles->pluck('id')->toArray());
+                            $set('pdfStyles', $field->pdfStyles->pluck('id')->toArray());
+                            $set('validations', $field->validations->map(fn($validation) => [
+                                'type' => $validation->type,
+                                'value' => $validation->value,
+                                'error_message' => $validation->error_message,
+                            ])->toArray());
+                            $set('select_option_instances', $field->selectOptionInstances->map(fn($instance) => [
+                                'type' => 'select_option_instance',
+                                'data' => [
+                                    'select_option_id' => $instance->select_option_id,
+                                    'order' => $instance->order,
+                                ],
+                            ])->toArray());
                         } else {
                             // Reset when no field is selected
                             $set('webStyles', []);
                             $set('pdfStyles', []);
                             $set('validations', []);
+                            $set('select_option_instances', []);
                         }
                     }),
                 Section::make('Field Properties')
@@ -262,6 +259,39 @@ class FormFieldBlock
                                     ]),
                             ]),
                     ]),
+                Builder::make('select_option_instances')
+                    ->label('Select Option Instances')
+                    ->columnSpanFull()
+                    ->reorderable()
+                    ->blockNumbers(false)
+                    ->collapsible()
+                    ->collapsed(true)
+                    ->live()
+                    ->reactive()
+                    ->visible(fn($get) => in_array(FormField::find($get('form_field_id'))?->dataType?->name, ['radio', 'dropdown']))
+                    ->blocks([
+                        Block::make('select_option_instance')
+                            ->label(
+                                fn(?array $state): string =>
+                                isset($state['select_option_id']) && $selectOptions()->has($state['select_option_id'])
+                                    ? $selectOptions()[$state['select_option_id']]->label
+                                    . ' | ' . $selectOptions()[$state['select_option_id']]->name
+                                    . ' | value: ' . $selectOptions()[$state['select_option_id']]->value
+                                    : 'New Option'
+                            )
+                            ->schema([
+                                Select::make('select_option_id')
+                                    ->label('Option')
+                                    ->searchable()
+                                    ->preload()
+                                    ->required()
+                                    ->live()
+                                    ->options($selectOptions()->map(function ($option) {
+                                        return "{$option->label} | {$option->name} | value: {$option->value}";
+                                    })->toArray()),
+                            ])
+                    ]),
+
                 Select::make('webStyles')
                     ->label('Web Styles')
                     ->options(Style::pluck('name', 'id'))

--- a/app/Filament/Forms/Resources/FormFieldResource/Pages/CreateFormField.php
+++ b/app/Filament/Forms/Resources/FormFieldResource/Pages/CreateFormField.php
@@ -3,9 +3,9 @@
 namespace App\Filament\Forms\Resources\FormFieldResource\Pages;
 
 use App\Filament\Forms\Resources\FormFieldResource;
-use Filament\Actions;
 use Filament\Resources\Pages\CreateRecord;
 use App\Models\FormFieldValue;
+use App\Models\SelectOptionInstance;
 
 class CreateFormField extends CreateRecord
 {
@@ -14,13 +14,39 @@ class CreateFormField extends CreateRecord
     protected function afterCreate(): void
     {
         $formField = $this->record;
-        $formFieldValue = $this->form->getState()['value'] ?? null;    
-        
-        if($formFieldValue) {
+
+        $this->createFormFieldValue($formField);
+        $this->createSelectOptionInstance($formField);
+    }
+
+    private function createFormFieldValue($formField)
+    {
+        if (method_exists($this, 'getRecord')) {
+            $formField->formFieldValue()->delete();
+        }
+
+        $formFieldValue = $this->form->getState()['value'] ?? null;
+        if ($formFieldValue) {
             FormFieldValue::create([
-                'form_field_id' => $formField->id,                        
-                'value' => $formFieldValue ?? null,                        
+                'form_field_id' => $formField->id,
+                'value' => $formFieldValue ?? null,
             ]);
-        }        
+        }
+    }
+
+    private function createSelectOptionInstance($formField)
+    {
+        if (method_exists($this, 'getRecord')) {
+            $formField->selectOptionInstances()->delete();
+        }
+
+        $selectOptions = $this->form->getState()['select_option_instances'] ?? [];
+        foreach ($selectOptions as $index => $instance) {
+            SelectOptionInstance::create([
+                'form_field_id' => $formField->id,
+                'select_option_id' => $instance['data']['select_option_id'],
+                'order' => $index + 1,
+            ]);
+        }
     }
 }

--- a/app/Filament/Forms/Resources/FormFieldResource/Pages/EditFormField.php
+++ b/app/Filament/Forms/Resources/FormFieldResource/Pages/EditFormField.php
@@ -55,7 +55,10 @@ class EditFormField extends EditRecord
 
         $data['select_option_instances'] = $this->record->selectOptionInstances->map(fn($instance) => [
             'type' => 'select_option_instance',
-            'data' => ['select_option_id' => $instance->select_option_id],
+            'data' => [
+                'select_option_id' => $instance->select_option_id,
+                'order' => $instance->order,
+            ],
         ])->toArray();
 
         return $data;

--- a/app/Filament/Forms/Resources/FormFieldResource/Pages/EditFormField.php
+++ b/app/Filament/Forms/Resources/FormFieldResource/Pages/EditFormField.php
@@ -7,6 +7,7 @@ use Filament\Actions\DeleteAction;
 use Filament\Actions\ViewAction;
 use Filament\Resources\Pages\EditRecord;
 use App\Models\FormFieldValue;
+use App\Models\SelectOptionInstance;
 use Filament\Notifications\Notification;
 
 class EditFormField extends EditRecord
@@ -52,22 +53,49 @@ class EditFormField extends EditRecord
         $formFieldValueObj = $this->record->formFieldValue()->first();
         $data['value'] = $formFieldValueObj?->value;
 
+        $data['select_option_instances'] = $this->record->selectOptionInstances->map(fn($instance) => [
+            'type' => 'select_option_instance',
+            'data' => ['select_option_id' => $instance->select_option_id],
+        ])->toArray();
+
         return $data;
     }
 
     protected function afterSave(): void
     {
         $formField = $this->record;
-        $formFieldValue = $this->form->getState()['value'] ?? null;
 
+        $this->createFormFieldValue($formField);
+        $this->createSelectOptionInstance($formField);
+    }
+
+    private function createFormFieldValue($formField)
+    {
         if (method_exists($this, 'getRecord')) {
             $formField->formFieldValue()->delete();
         }
 
+        $formFieldValue = $this->form->getState()['value'] ?? null;
         if ($formFieldValue) {
             FormFieldValue::create([
                 'form_field_id' => $formField->id,
                 'value' => $formFieldValue ?? null,
+            ]);
+        }
+    }
+
+    private function createSelectOptionInstance($formField)
+    {
+        if (method_exists($this, 'getRecord')) {
+            $formField->selectOptionInstances()->delete();
+        }
+
+        $selectOptions = $this->form->getState()['select_option_instances'] ?? [];
+        foreach ($selectOptions as $index => $instance) {
+            SelectOptionInstance::create([
+                'form_field_id' => $formField->id,
+                'select_option_id' => $instance['data']['select_option_id'],
+                'order' => $index + 1,
             ]);
         }
     }

--- a/app/Filament/Forms/Resources/FormFieldResource/Pages/ViewFormField.php
+++ b/app/Filament/Forms/Resources/FormFieldResource/Pages/ViewFormField.php
@@ -19,10 +19,15 @@ class ViewFormField extends ViewRecord
 
     protected function mutateFormDataBeforeFill(array $data): array
     {
-        $data = array_merge($this->record->toArray(), $data);    
+        $data = array_merge($this->record->toArray(), $data);
 
-        $formFieldValueObj = $this->record->formFieldValue()->first();        
+        $formFieldValueObj = $this->record->formFieldValue()->first();
         $data['value'] = $formFieldValueObj?->value;
+
+        $data['select_option_instances'] = $this->record->selectOptionInstances->map(fn($instance) => [
+            'type' => 'select_option_instance',
+            'data' => ['select_option_id' => $instance->select_option_id],
+        ])->toArray();
 
         return $data;
     }

--- a/app/Filament/Forms/Resources/FormFieldResource/Pages/ViewFormField.php
+++ b/app/Filament/Forms/Resources/FormFieldResource/Pages/ViewFormField.php
@@ -26,7 +26,10 @@ class ViewFormField extends ViewRecord
 
         $data['select_option_instances'] = $this->record->selectOptionInstances->map(fn($instance) => [
             'type' => 'select_option_instance',
-            'data' => ['select_option_id' => $instance->select_option_id],
+            'data' => [
+                'select_option_id' => $instance->select_option_id,
+                'order' => $instance->order,
+            ],
         ])->toArray();
 
         return $data;

--- a/app/Filament/Forms/Resources/FormFieldsRelationManagerResource/RelationManagers/FormFieldsRelationManager.php
+++ b/app/Filament/Forms/Resources/FormFieldsRelationManagerResource/RelationManagers/FormFieldsRelationManager.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Filament\Resources\SelectOptionsResource\RelationManagers;
+
+use Filament\Tables;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Resources\RelationManagers\RelationManager;
+use Illuminate\Database\Eloquent\Builder;
+use App\Models\FormField;
+
+class FormFieldsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'selectOptionInstances'; // A placeholder; we override query() anyway
+    protected static ?string $title = 'Fields using this SelectOption';
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->with('selectOptionInstances');
+    }
+
+    public function table(Tables\Table $table): Tables\Table
+    {
+        return $table
+            ->query(function () {
+                return FormField::whereHas('selectOptionInstances', function (Builder $query) {
+                    $query->where('select_option_id', $this->ownerRecord->id);
+                });
+            })
+            ->columns([
+                TextColumn::make('label')
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('name')
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('dataType.name')
+                    ->label('Data Type')
+                    ->sortable(),
+            ]);
+    }
+}

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/CreateFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/CreateFormVersion.php
@@ -12,6 +12,7 @@ use App\Models\FieldGroupInstance;
 use App\Models\FormInstanceFieldConditionals;
 use App\Models\FormInstanceFieldValidation;
 use App\Models\FormInstanceFieldValue;
+use App\Models\SelectOptionInstance;
 use App\Models\StyleInstance;
 
 class CreateFormVersion extends CreateRecord
@@ -129,6 +130,19 @@ class CreateFormVersion extends CreateRecord
         }
     }
 
+    private function createSelectOptionInstance($component, $formInstanceField)
+    {
+        foreach ($component['select_option_instances'] as $index => $instance) {
+            if (!empty($component['select_option_instances'])) {
+                SelectOptionInstance::create([
+                    'form_instance_field_id' => $formInstanceField->id,
+                    'select_option_id' => $instance['data']['select_option_id'] ?? null,
+                    'order' => $index + 1,
+                ]);
+            }
+        }
+    }
+
     private function createField($formVersion, $order, $component, $fieldGroupInstanceID, $containerID)
     {
         $formInstanceField = FormInstanceField::create([
@@ -156,6 +170,7 @@ class CreateFormVersion extends CreateRecord
         $this->createFieldValidations($component, $formInstanceField);
         $this->createFieldConditionals($component, $formInstanceField);
         $this->createFieldValue($component, $formInstanceField);
+        $this->createSelectOptionInstance($component, $formInstanceField);
     }
 
     private function createGroup($formVersion, $order, $component, $containerID)

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/EditFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/EditFormVersion.php
@@ -12,6 +12,7 @@ use App\Models\FieldGroupInstance;
 use App\Models\FormInstanceFieldValidation;
 use App\Models\FormInstanceFieldConditionals;
 use App\Models\FormInstanceFieldValue;
+use App\Models\SelectOptionInstance;
 use App\Models\StyleInstance;
 
 class EditFormVersion extends EditRecord
@@ -70,6 +71,7 @@ class EditFormVersion extends EditRecord
         $this->record->load([
             'formInstanceFields' => function ($query) {
                 $query->whereNull('field_group_instance_id')->whereNull('container_id');
+                $query->with('selectOptionInstances');
             },
             'fieldGroupInstances' => function ($query) {
                 $query->whereNull('container_id');
@@ -154,6 +156,19 @@ class EditFormVersion extends EditRecord
         }
     }
 
+    private function createSelectOptionInstance($component, $formInstanceField)
+    {
+        foreach ($component['select_option_instances'] as $index => $instance) {
+            if (!empty($component['select_option_instances'])) {
+                SelectOptionInstance::create([
+                    'form_instance_field_id' => $formInstanceField->id,
+                    'select_option_id' => $instance['data']['select_option_id'] ?? null,
+                    'order' => $index + 1,
+                ]);
+            }
+        }
+    }
+
     private function createField($formVersion, $order, $component, $fieldGroupInstanceID, $containerID)
     {
         $formInstanceField = FormInstanceField::create([
@@ -176,6 +191,7 @@ class EditFormVersion extends EditRecord
         $this->createFieldValidations($component, $formInstanceField);
         $this->createFieldConditionals($component, $formInstanceField);
         $this->createFieldValue($component, $formInstanceField);
+        $this->createSelectOptionInstance($component, $formInstanceField);
     }
 
     private function createGroup($formVersion, $order, $component, $containerID)
@@ -243,29 +259,44 @@ class EditFormVersion extends EditRecord
         return $styles;
     }
 
-    private function fillValidations($field)
+    private function fillValidations($validations)
     {
-        $validations = [];
-        foreach ($field->validations as $validation) {
-            $validations[] = [
+        $data = [];
+        foreach ($validations as $validation) {
+            $data[] = [
                 'type' => $validation->type,
                 'value' => $validation->value,
                 'error_message' => $validation->error_message,
             ];
         }
-        return $validations;
+        return $data;
     }
 
-    private function fillConditionals($field)
+    private function fillConditionals($conditionals)
     {
-        $conditionals = [];
-        foreach ($field->conditionals as $conditional) {
-            $conditionals[] = [
+        $data = [];
+        foreach ($conditionals as $conditional) {
+            $data[] = [
                 'type' => $conditional->type,
                 'value' => $conditional->value,
             ];
         }
-        return $conditionals;
+        return $data;
+    }
+
+    private function fillSelectOptionInstances($selectOptionInstances)
+    {
+        $data = [];
+        foreach ($selectOptionInstances as $instance) {
+            $data[] = [
+                'type' => 'select_option_instance',
+                'data' => [
+                    'select_option_id' => $instance->select_option_id,
+                    'order' => $instance->order
+                ],
+            ];
+        }
+        return $data;
     }
 
     private function fillFields($formFields)
@@ -273,8 +304,9 @@ class EditFormVersion extends EditRecord
         $components = [];
         foreach ($formFields as $field) {
             $styles = $this->fillStyles($field->styleInstances);
-            $validations = $this->fillValidations($field);
-            $conditionals = $this->fillConditionals($field);
+            $validations = $this->fillValidations($field->validations);
+            $conditionals = $this->fillConditionals($field->conditionals);
+            $selectOptionInstances = $this->fillSelectOptionInstances($field->selectOptionInstances);
 
             $formField = $field->formField;
             $components[] = [
@@ -302,6 +334,7 @@ class EditFormVersion extends EditRecord
                     'pdfStyles' => $styles['pdfStyles'],
                     'validations' => $validations,
                     'conditionals' => $conditionals,
+                    'select_option_instances' => $selectOptionInstances,
                     'order' => $field->order,
                 ],
             ];

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/ViewFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/ViewFormVersion.php
@@ -3,8 +3,6 @@
 namespace App\Filament\Forms\Resources\FormVersionResource\Pages;
 
 use App\Filament\Forms\Resources\FormVersionResource;
-use App\Models\FieldGroup;
-use App\Models\FormField;
 use Filament\Actions;
 use Filament\Resources\Pages\ViewRecord;
 
@@ -73,28 +71,54 @@ class ViewFormVersion extends ViewRecord
         return $styles;
     }
 
+    private function fillValidations($validations)
+    {
+        $data = [];
+        foreach ($validations as $validation) {
+            $data[] = [
+                'type' => $validation->type,
+                'value' => $validation->value,
+                'error_message' => $validation->error_message,
+            ];
+        }
+        return $data;
+    }
+
+    private function fillConditionals($conditionals)
+    {
+        $data = [];
+        foreach ($conditionals as $conditional) {
+            $data[] = [
+                'type' => $conditional->type,
+                'value' => $conditional->value,
+            ];
+        }
+        return $data;
+    }
+
+    private function fillSelectOptionInstances($selectOptionInstances)
+    {
+        $data = [];
+        foreach ($selectOptionInstances as $instance) {
+            $data[] = [
+                'type' => 'select_option_instance',
+                'data' => [
+                    'select_option_id' => $instance->select_option_id,
+                    'order' => $instance->order
+                ],
+            ];
+        }
+        return $data;
+    }
+
     private function fillFields($formFields)
     {
         $components = [];
         foreach ($formFields as $field) {
             $styles = $this->fillStyles($field->styleInstances);
-
-            $validations = [];
-            foreach ($field->validations as $validation) {
-                $validations[] = [
-                    'type' => $validation->type,
-                    'value' => $validation->value,
-                    'error_message' => $validation->error_message,
-                ];
-            }
-
-            $conditionals = [];
-            foreach ($field->conditionals as $conditional) {
-                $conditionals[] = [
-                    'type' => $conditional->type,
-                    'value' => $conditional->value,
-                ];
-            }
+            $validations = $this->fillValidations($field->validations);
+            $conditionals = $this->fillConditionals($field->conditionals);
+            $selectOptionInstances = $this->fillSelectOptionInstances($field->selectOptionInstances);
 
             $formField = $field->formField;
             $components[] = [
@@ -126,6 +150,7 @@ class ViewFormVersion extends ViewRecord
                     'pdfStyles' => $styles['pdfStyles'],
                     'validations' => $validations,
                     'conditionals' => $conditionals,
+                    'select_option_instances' => $selectOptionInstances,
                     'order' => $field->order,
                 ],
             ];

--- a/app/Filament/Forms/Resources/SelectOptionsResource.php
+++ b/app/Filament/Forms/Resources/SelectOptionsResource.php
@@ -4,6 +4,8 @@ namespace App\Filament\Forms\Resources;
 
 use App\Filament\Forms\Resources\SelectOptionsResource\Pages;
 use App\Filament\Imports\SelectOptionsImporter;
+use App\Filament\Resources\SelectOptionsResource\RelationManagers\FormFieldsRelationManager;
+use App\Filament\Resources\SelectOptionsResource\RelationManagers\FormInstanceFieldsRelationManager;
 use App\Models\SelectOptions;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
@@ -85,7 +87,8 @@ class SelectOptionsResource extends Resource
     public static function getRelations(): array
     {
         return [
-            //
+            FormFieldsRelationManager::class,
+            FormInstanceFieldsRelationManager::class,
         ];
     }
 

--- a/app/Filament/Forms/Resources/SelectOptionsResource.php
+++ b/app/Filament/Forms/Resources/SelectOptionsResource.php
@@ -3,17 +3,17 @@
 namespace App\Filament\Forms\Resources;
 
 use App\Filament\Forms\Resources\SelectOptionsResource\Pages;
-use App\Filament\Forms\Resources\SelectOptionsResource\RelationManagers;
 use App\Filament\Imports\SelectOptionsImporter;
 use App\Models\SelectOptions;
-use Filament\Forms;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Actions\ImportAction;
+use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class SelectOptionsResource extends Resource
 {
@@ -26,24 +26,15 @@ class SelectOptionsResource extends Resource
     {
         return $form
             ->schema([
-                Forms\Components\TextInput::make('name')
+                TextInput::make('name')
                     ->unique(ignoreRecord: true)
                     ->required(),
-                Forms\Components\TextInput::make('label')
+                TextInput::make('label')
                     ->required(),
-                Forms\Components\TextInput::make('value')
+                TextInput::make('value')
                     ->required(),
-                Forms\Components\Textarea::make('description')
+                Textarea::make('description')
                     ->columnSpanFull(),
-                Forms\Components\Select::make('formFields')
-                    ->relationship('formFields', 'label', function ($query) {
-                        $query->whereHas('dataType', function ($query) {
-                            $query->whereIn('name', ['radio', 'dropdown']);
-                        });
-                    })
-                    ->multiple()
-                    ->preload()
-                    ->required(),
             ]);
     }
 
@@ -51,23 +42,20 @@ class SelectOptionsResource extends Resource
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('label')
+                TextColumn::make('label')
                     ->sortable()
                     ->searchable(),
-                Tables\Columns\TextColumn::make('name')
+                TextColumn::make('name')
                     ->sortable()
                     ->searchable(),
-                Tables\Columns\TextColumn::make('value')
+                TextColumn::make('value')
                     ->sortable()
                     ->searchable(),
-                Tables\Columns\TextColumn::make('formFields.label')
-                    ->numeric()
-                    ->sortable(),
-                Tables\Columns\TextColumn::make('created_at')
+                TextColumn::make('created_at')
                     ->dateTime()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
-                Tables\Columns\TextColumn::make('updated_at')
+                TextColumn::make('updated_at')
                     ->dateTime()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),

--- a/app/Filament/Forms/Resources/SelectOptionsResource/RelationManagers/FormInstanceFieldsRelationManager.php
+++ b/app/Filament/Forms/Resources/SelectOptionsResource/RelationManagers/FormInstanceFieldsRelationManager.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Filament\Resources\SelectOptionsResource\RelationManagers;
+
+use Filament\Tables;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Resources\RelationManagers\RelationManager;
+use Illuminate\Database\Eloquent\Builder;
+use App\Models\FormInstanceField;
+
+class FormInstanceFieldsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'selectOptionInstances';
+    protected static ?string $title = 'Forms using this SelectOption';
+
+    public function table(Tables\Table $table): Tables\Table
+    {
+        return $table
+            ->query(function () {
+                return FormInstanceField::whereHas('selectOptionInstances', function (Builder $query) {
+                    $query->where('select_option_id', $this->ownerRecord->id);
+                });
+            })
+            ->columns([
+                TextColumn::make('formVersion.form.form_id')
+                    ->label('Form ID')
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('formVersion.form.form_title')
+                    ->label('Form title')
+                    ->toggleable()
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('formVersion.version_number')
+                    ->label('Version')
+                    ->toggleable()
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('formVersion.status')
+                    ->label('Status')
+                    ->toggleable()
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('formField.label')
+                    ->label('Field Label')
+                    ->toggleable()
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('formField.name')
+                    ->label('Field Name')
+                    ->toggleable()
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('formField.datatype.name')
+                    ->sortable()
+                    ->searchable(),
+            ]);
+    }
+}

--- a/app/Helpers/FormTemplateHelper.php
+++ b/app/Helpers/FormTemplateHelper.php
@@ -3,12 +3,8 @@
 namespace App\Helpers;
 
 use Illuminate\Support\Str;
-use App\Models\SelectOptions;
 use App\Models\FormVersion;
 use App\Models\Form;
-use App\Models\FieldGroupInstance;
-use App\Models\FormInstanceField;
-use App\Models\FormDataSource;
 
 class FormTemplateHelper
 {
@@ -197,12 +193,12 @@ class FormTemplateHelper
                     "selectionFeedback" => "top-after-reopen",
                     "direction" => "bottom",
                     "size" => "md",
-                    "listItems" => $field->selectOptions()
+                    "listItems" => $fieldInstance->selectOptionInstances()
                         ->get()
-                        ->map(function ($selectOption) {
+                        ->map(function ($selectOptionInstance) {
                             return [
-                                "text" => $selectOption->label,
-                                "value" => $selectOption->value
+                                "text" => $selectOptionInstance->selectOption->label,
+                                "value" => $selectOptionInstance->selectOption->value
                             ];
                         })
                         ->toArray(),
@@ -213,12 +209,12 @@ class FormTemplateHelper
                 ]);
             case "radio":
                 return array_merge($base, [
-                    "listItems" => $field->selectOptions()
+                    "listItems" => $field->selectOptionInstances()
                         ->get()
-                        ->map(function ($selectOption) {
+                        ->map(function ($selectOptionInstance) {
                             return [
-                                "text" => $selectOption->label,
-                                "value" => $selectOption->value
+                                "text" => $selectOptionInstance->selectOption->label,
+                                "value" => $selectOptionInstance->selectOption->value
                             ];
                         })
                         ->toArray(),

--- a/app/Models/FormField.php
+++ b/app/Models/FormField.php
@@ -79,9 +79,9 @@ class FormField extends Model
         return $this->dataType && $this->dataType->name === 'text-info';
     }
 
-    public function selectOptions(): BelongsToMany
+    public function selectOptionInstances(): HasMany
     {
-        return $this->belongsToMany(SelectOptions::class);
+        return $this->hasMany(SelectOptionInstance::class, 'form_field_id');
     }
 
     public function formVersions()

--- a/app/Models/FormInstanceField.php
+++ b/app/Models/FormInstanceField.php
@@ -48,6 +48,11 @@ class FormInstanceField extends Model
         return $this->belongsTo(Container::class);
     }
 
+    public function selectOptionInstances(): HasMany
+    {
+        return $this->hasMany(SelectOptionInstance::class, 'form_instance_field_id');
+    }
+
     public function styleInstances(): HasMany
     {
         return $this->hasMany(StyleInstance::class);

--- a/app/Models/SelectOptionInstance.php
+++ b/app/Models/SelectOptionInstance.php
@@ -4,10 +4,9 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class SelectOptions extends Model
+class SelectOptionInstance extends Model
 {
     use HasFactory;
 
@@ -17,10 +16,9 @@ class SelectOptions extends Model
      * @var array
      */
     protected $fillable = [
-        'name',
-        'label',
-        'value',
-        'description',
+        'form_field_id',
+        'select_option_id',
+        'order',
     ];
 
     /**
@@ -30,11 +28,15 @@ class SelectOptions extends Model
      */
     protected $casts = [
         'id' => 'integer',
-        'form_field_id' => 'integer',
     ];
 
-    public function selectOptionInstances(): HasMany
+    public function selectOption(): BelongsTo
     {
-        return $this->hasMany(SelectOptionInstance::class);
+        return $this->belongsTo(SelectOptions::class, 'select_option_id');
+    }
+
+    public function formField(): BelongsTo
+    {
+        return $this->belongsTo(FormField::class, 'form_field_id');
     }
 }

--- a/app/Models/SelectOptionInstance.php
+++ b/app/Models/SelectOptionInstance.php
@@ -17,6 +17,7 @@ class SelectOptionInstance extends Model
      */
     protected $fillable = [
         'form_field_id',
+        'form_instance_field_id',
         'select_option_id',
         'order',
     ];
@@ -38,5 +39,10 @@ class SelectOptionInstance extends Model
     public function formField(): BelongsTo
     {
         return $this->belongsTo(FormField::class, 'form_field_id');
+    }
+
+    public function formInstanceField(): BelongsTo
+    {
+        return $this->belongsTo(FormInstanceField::class, 'form_instance_field_id');
     }
 }

--- a/app/Models/SelectOptions.php
+++ b/app/Models/SelectOptions.php
@@ -35,6 +35,6 @@ class SelectOptions extends Model
 
     public function selectOptionInstances(): HasMany
     {
-        return $this->hasMany(SelectOptionInstance::class);
+        return $this->hasMany(SelectOptionInstance::class, "select_option_id");
     }
 }

--- a/database/migrations/2025_02_21_193254_add_order_to_form_field_select_options_table.php
+++ b/database/migrations/2025_02_21_193254_add_order_to_form_field_select_options_table.php
@@ -1,0 +1,67 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('select_option_instances', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('select_option_id')->constrained()->onDelete('cascade');
+            $table->foreignId('form_field_id')->nullable()->constrained()->onDelete('cascade');
+            $table->foreignId('form_instance_field_id')->nullable()->constrained()->onDelete('cascade');
+            $table->integer('order');
+            $table->timestamps();
+        });
+
+        // Seed the new table with data from the old table
+        $oldData = DB::table('form_field_select_options')->get();
+        foreach ($oldData as $index => $data) {
+            DB::table('select_option_instances')->insert([
+                'form_field_id' => $data->form_field_id,
+                'select_option_id' => $data->select_options_id,
+                'form_instance_field_id' => null,
+                'order' => $index + 1,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        // Drop the old table
+        Schema::dropIfExists('form_field_select_options');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Store data from the new table before dropping it
+        $dataToRestore = DB::table('select_option_instances')->get();
+
+        // Drop the new table
+        Schema::dropIfExists('select_option_instances');
+
+        // Recreate the old table
+        Schema::create('form_field_select_options', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('form_field_id')->constrained()->onDelete('cascade');
+            $table->foreignId('select_options_id')->constrained()->onDelete('cascade');
+        });
+
+        // Insert the data back into the old table
+        foreach ($dataToRestore as $data) {
+            DB::table('form_field_select_options')->insert([
+                'form_field_id' => $data->form_field_id,
+                'select_options_id' => $data->select_option_id, // Use the correct column name
+            ]);
+        }
+    }
+};


### PR DESCRIPTION
## What changes did you make? 

Allows for sorting and ordering SelectOptions for dropdown and radio -type Fields and FieldInstances, as well as viewing which Fields/FormInstances a SelectOption is used on. While this update uses SelectOptionInstances on Fields (1-many relationship) instead of SelectOptions (many-many), it should preserve the associations (although Fields will still have to be updated once to set the desired order)

## Why did you make these changes?

Implementing https://dev.azure.com/BC-SDPR/Forms%20Modernization/_sprints/backlog/FormFoundry/Forms%20Modernization/02-12-2025%20(Sprint%2032)?workitem=2304&System.AreaPath=FormFoundry&System.AssignedTo=%40me

## What alternatives did you consider?

Considered modifying the multi-select for the many-to-many relationship between Fields and SelectOptions, as well as using RelationManagers to set the order for SelectOptions on fields, but this proved too clunky and difficult to apply to FormInstances. 

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [x] **My code has adequate test coverage (if applicable)**
