### PR TITLE
Sequential element IDs ADO 2419

### DIFF
--- a/app/Filament/Components/ContainerBlock.php
+++ b/app/Filament/Components/ContainerBlock.php
@@ -86,8 +86,8 @@ class ContainerBlock
                     ->columnSpan(2)
                     ->cloneable()
                     ->blocks([
-                        FormFieldBlock::make(fn($get) => FormTemplateHelper::calculateFieldInGroupID($get('../../'))),
-                        FieldGroupBlock::make(fn($get) => FormTemplateHelper::calculateFieldInGroupID($get('../../'))),
+                        FormFieldBlock::make(fn($get) => FormTemplateHelper::calculateElementID()),
+                        FieldGroupBlock::make(fn($get) => FormTemplateHelper::calculateElementID()),
                     ]),
             ]);
     }

--- a/app/Filament/Components/ContainerBlock.php
+++ b/app/Filament/Components/ContainerBlock.php
@@ -25,7 +25,7 @@ class ContainerBlock
                 if ($state === null) {
                     return 'Container';
                 }
-                return 'Container | id: ' . ($state['custom_instance_id'] ?? $state['instance_id'] ?? '');
+                return 'Container | id: ' . ($state['customize_instance_id'] && !empty($state['custom_instance_id']) ? $state['custom_instance_id'] : $state['instance_id']);
             })
             ->icon('heroicon-o-square-3-stack-3d')
             ->schema([

--- a/app/Filament/Components/FieldGroupBlock.php
+++ b/app/Filament/Components/FieldGroupBlock.php
@@ -54,10 +54,10 @@ class FieldGroupBlock
                     ->required()
                     ->reactive()
                     ->columnSpan(2)
-                    ->afterStateUpdated(function ($state, callable $set, callable $get) {
+                    ->afterStateUpdated(function ($state, callable $set) {
                         $fieldGroup = FieldGroup::find($state);
                         if ($fieldGroup) {
-                            $formFields = $fieldGroup->formFields()->get()->map(function ($field, $index) {
+                            $formFields = $fieldGroup->formFields()->get()->map(function ($field) {
                                 $webStyles = $field->webStyles()->pluck('styles.id')->toArray();
                                 $pdfStyles = $field->pdfStyles()->pluck('styles.id')->toArray();
                                 $validations = $field->validations()->get()->map(function ($validation) {
@@ -80,7 +80,7 @@ class FieldGroupBlock
                                         'mask' => $field->mask,
                                         'validations' => $validations,
                                         'conditionals' => [],
-                                        'instance_id' => 'nestedField' . ($index + 1),
+                                        'instance_id' => FormTemplateHelper::calculateElementID(),
                                         'customize_label' => 'default',
                                         'customize_group_label' => 'default',
                                     ],
@@ -229,7 +229,7 @@ class FieldGroupBlock
                     ->columnSpan(2)
                     ->cloneable()
                     ->blocks([
-                        FormFieldBlock::make(fn($get) => FormTemplateHelper::calculateFieldInGroupID($get('../../'))),
+                        FormFieldBlock::make(fn($get) => FormTemplateHelper::calculateElementID()),
                     ]),
             ]);
     }

--- a/app/Filament/Components/FieldGroupBlock.php
+++ b/app/Filament/Components/FieldGroupBlock.php
@@ -32,10 +32,10 @@ class FieldGroupBlock
                 if ($group) {
                     $label = ($state['group_label'] ?? $group->label ?? '(no label)')
                         . ' | group '
-                        . ' | id: ' . ($state['custom_instance_id'] ?? $state['instance_id'] ?? '');
+                        . ' | id: ' . ($state['customize_instance_id'] && !empty($state['custom_instance_id']) ? $state['custom_instance_id'] : $state['instance_id']);
                     return $label;
                 }
-                return 'New Group';
+                return 'New Group | id: ' . $state['instance_id'];
             })
             ->icon('heroicon-o-square-2-stack')
             ->columns(2)

--- a/app/Filament/Components/FormFieldBlock.php
+++ b/app/Filament/Components/FormFieldBlock.php
@@ -60,11 +60,15 @@ class FormFieldBlock
                     } else {
                         $label .= '(label hidden) | ';
                     }
-                    $label .= ($field->dataType->name ?? '')
-                        . ' | id: ' . ($state['custom_instance_id'] ?? $state['instance_id'] ?? '');
+                    $label .= ($field->dataType->name ?? '') . ' | id: ';
+                    if (!empty($state['customize_instance_id'] ?? null) && !empty($state['custom_instance_id'] ?? null)) {
+                        $label .= $state['custom_instance_id'];
+                    } else {
+                        $label .= $state['instance_id'] ?? 'null';
+                    }
                     return $label;
                 }
-                return 'New Field';
+                return 'New Field | id: ' . $state['instance_id'];
             })
             ->icon('heroicon-o-stop')
             ->columns(2)

--- a/app/Filament/Forms/Resources/FormVersionResource.php
+++ b/app/Filament/Forms/Resources/FormVersionResource.php
@@ -24,6 +24,7 @@ use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\Builder;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
+use Illuminate\Support\Facades\Session;
 
 class FormVersionResource extends Resource
 {
@@ -33,6 +34,47 @@ class FormVersionResource extends Resource
 
     protected static bool $shouldRegisterNavigation = true;
 
+    // Function to get the current counter value from the session
+    public static function getElementCounter(): int
+    {
+        return Session::get('elementCounter', 1); // Default to 1 if not set
+    }
+
+    // Function to increment the counter in the session
+    public static function incrementElementCounter(): void
+    {
+        $currentCounter = self::getElementCounter();
+        Session::put('elementCounter', $currentCounter + 1);
+    }
+
+    // Function to find highest used instance ID
+    protected static function getHighestID(array $blocks): int
+    {
+        $maxID = 0;
+        foreach ($blocks as $block) {
+            // Check top-level elements
+            if (isset($block['data']['instance_id'])) {
+                $idString = $block['data']['instance_id'];
+                $numericPart = str_replace('element', '', $idString); // Remove the 'element' prefix
+                if (is_numeric($numericPart) && $numericPart > 0) {
+                    $id = (int) $numericPart;
+                    $maxID = max($maxID, $id); // Update the maximum ID
+                }
+            }
+            // Recursively check elements inside of Containers
+            if (isset($block['data']['components']) && is_array($block['data']['components'])) {
+                $nestedMaxID = self::getHighestID($block['data']['components']);
+                $maxID = max($maxID, $nestedMaxID);
+            }
+            // Recursively check elements inside of Groups
+            if (isset($block['data']['form_fields']) && is_array($block['data']['form_fields'])) {
+                $nestedMaxID = self::getHighestID($block['data']['form_fields']);
+                $maxID = max($maxID, $nestedMaxID);
+            }
+        }
+
+        return $maxID;
+    }
 
     public static function form(Form $form): Form
     {
@@ -108,10 +150,13 @@ class FormVersionResource extends Resource
                     ->collapsed(true)
                     ->blockNumbers(false)
                     ->cloneable()
+                    ->afterStateHydrated(function (Set $set, Get $get) {
+                        Session::put('elementCounter', self::getHighestID($get('components')) + 1);
+                    })
                     ->blocks([
-                        FormFieldBlock::make(fn($get) => FormTemplateHelper::calculateFieldID($get('../../'))),
-                        FieldGroupBlock::make(fn($get) => FormTemplateHelper::calculateFieldID($get('../../'))),
-                        ContainerBlock::make(fn($get) => FormTemplateHelper::calculateFieldID($get('../../'))),
+                        FormFieldBlock::make(fn() => FormTemplateHelper::calculateElementID()),
+                        FieldGroupBlock::make(fn() => FormTemplateHelper::calculateElementID()),
+                        ContainerBlock::make(fn() => FormTemplateHelper::calculateElementID()),
                     ]),
                 Actions::make([
                     Action::make('Generate Form Template')

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/CreateFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/CreateFormVersion.php
@@ -132,8 +132,8 @@ class CreateFormVersion extends CreateRecord
 
     private function createSelectOptionInstance($component, $formInstanceField)
     {
-        foreach ($component['select_option_instances'] as $index => $instance) {
-            if (!empty($component['select_option_instances'])) {
+        if (!empty($component['select_option_instances'])) {
+            foreach ($component['select_option_instances'] as $index => $instance) {
                 SelectOptionInstance::create([
                     'form_instance_field_id' => $formInstanceField->id,
                     'select_option_id' => $instance['data']['select_option_id'] ?? null,

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/EditFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/EditFormVersion.php
@@ -158,8 +158,8 @@ class EditFormVersion extends EditRecord
 
     private function createSelectOptionInstance($component, $formInstanceField)
     {
-        foreach ($component['select_option_instances'] as $index => $instance) {
-            if (!empty($component['select_option_instances'])) {
+        if (!empty($component['select_option_instances'])) {
+            foreach ($component['select_option_instances'] as $index => $instance) {
                 SelectOptionInstance::create([
                     'form_instance_field_id' => $formInstanceField->id,
                     'select_option_id' => $instance['data']['select_option_id'] ?? null,

--- a/app/Helpers/FormTemplateHelper.php
+++ b/app/Helpers/FormTemplateHelper.php
@@ -2,6 +2,7 @@
 
 namespace App\Helpers;
 
+use App\Filament\Forms\Resources\FormVersionResource;
 use Illuminate\Support\Str;
 use App\Models\FormVersion;
 use App\Models\Form;
@@ -399,15 +400,10 @@ class FormTemplateHelper
         ]);
     }
 
-    public static function calculateFieldID($state)
+    public static function calculateElementID(): string
     {
-        $numOfComponents = count($state);
-        return 'element' . $numOfComponents;
-    }
-
-    public static function calculateFieldInGroupID($state)
-    {
-        $numOfFormFields = count($state);
-        return 'nestedElement' . $numOfFormFields;
+        $counter = FormVersionResource::getElementCounter();
+        FormVersionResource::incrementElementCounter();
+        return 'element' . $counter;
     }
 }


### PR DESCRIPTION
## What changes did you make? 

Updated form elements to use sequential instance IDs, regardless of nesting level. Uses Session to store counter

## Why did you make these changes?

Implementing https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/2419

## What alternatives did you consider?

Considered various ways of storing counter

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [x] **My code has adequate test coverage (if applicable)**
