### PR TITLE
fix eager loading on form fields

### DIFF
--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/EditFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/EditFormVersion.php
@@ -71,7 +71,7 @@ class EditFormVersion extends EditRecord
         $this->record->load([
             'formInstanceFields' => function ($query) {
                 $query->whereNull('field_group_instance_id')->whereNull('container_id');
-                $query->with('selectOptionInstances');
+                $query->with(['selectOptionInstances', 'validations', 'conditionals', 'formField']);
             },
             'fieldGroupInstances' => function ($query) {
                 $query->whereNull('container_id');

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/ViewFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/ViewFormVersion.php
@@ -23,6 +23,7 @@ class ViewFormVersion extends ViewRecord
         $this->record->load([
             'formInstanceFields' => function ($query) {
                 $query->whereNull('field_group_instance_id')->whereNull('container_id');
+                $query->with(['selectOptionInstances', 'validations', 'conditionals', 'formField']);
             },
             'fieldGroupInstances' => function ($query) {
                 $query->whereNull('container_id');

--- a/app/Helpers/FormTemplateHelper.php
+++ b/app/Helpers/FormTemplateHelper.php
@@ -21,6 +21,7 @@ class FormTemplateHelper
             ->whereNull('field_group_instance_id')
             ->whereNull('container_id')
             ->orderBy('order')
+            ->with('formField.dataType', 'styleInstances', 'validations', 'conditionals')
             ->get();
 
         foreach ($formFields as $field) {


### PR DESCRIPTION
## What changes did you make? 

Adds eager loading to the formField properties needed in this component

## Why did you make these changes?

In the previous changes I added the functionality in the AppServiceProvider to locally throw an error when lazy loading occurs. In going through the application I found that lazy loading was happening in the view and FormVersion edit and view pages. I eager loaded the remaining needed resources.

Then in the generateJsonTemplate function the same was happening so I fixed that as well.

One thing that might still be an issue is in the nested relationships with groups and containers. The preventLazyLoading isn't throwing any errors here but I could see it still being an issue. Will investigate this further.

## What alternatives did you consider?

N/A

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [x] **My code has adequate test coverage (if applicable)**
