### PR TITLE
move queue runner to pod rather than in container

### DIFF
--- a/helm/templates/queue-deployment.yaml
+++ b/helm/templates/queue-deployment.yaml
@@ -1,27 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: klamm-app
+  name: klamm-queue-worker
   labels:
-    app.kubernetes.io/name: klamm-app
+    app.kubernetes.io/name: klamm-queue-worker
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.queueWorker.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: klamm-app
+      app.kubernetes.io/name: klamm-queue-worker
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: klamm-app
+        app.kubernetes.io/name: klamm-queue-worker
     spec:
       containers:
-        - name: klamm-app
+        - name: queue-worker
           image: "{{ .Values.image.tag }}"
-          ports:
-            - containerPort: 8080
-          volumeMounts:
-            - name: storage-volume
-              mountPath: /var/www/storage
+          command: ["php", "/var/www/artisan", "queue:work", "--sleep=3", "--tries=3", "--timeout=3600"]
           envFrom:
             - secretRef:
                 name: app-secrets
@@ -56,13 +52,16 @@ spec:
                 secretKeyRef:
                   name: app-secrets
                   key: DB_PASSWORD
+          volumeMounts:
+            - name: storage-volume
+              mountPath: /var/www/storage
           resources:
             limits:
-              cpu: {{ .Values.resources.limits.cpu }}
-              memory: {{ .Values.resources.limits.memory }}
+              cpu: {{ .Values.queueWorker.resources.limits.cpu }}
+              memory: {{ .Values.queueWorker.resources.limits.memory }}
             requests:
-              cpu: {{ .Values.resources.requests.cpu }}
-              memory: {{ .Values.resources.requests.memory }}
+              cpu: {{ .Values.queueWorker.resources.requests.cpu }}
+              memory: {{ .Values.queueWorker.resources.requests.memory }}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: {{ .Values.image.pullPolicy }}


### PR DESCRIPTION
## What changes did you make? 

Moves the queue runner to a separate pod rather than a container within the klamm app

## Why did you make these changes?

If we want to scale up the Laravel app we don't want to scale up a bunch of queue runners. This way we can independently scale up the queue runner or the application as needed. We pretty rarely use the queue runner for imports and exports so it is fine if it doesn't get scaled up when the application does.

## What alternatives did you consider?

Just leaving it as is. But this is the best for the long term health of Klamm.

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
