### PR TITLE
Update bre controllers to eager load properties for fields/rules.

### DIFF
--- a/app/Http/Controllers/BREFieldController.php
+++ b/app/Http/Controllers/BREFieldController.php
@@ -12,6 +12,22 @@ class BREFieldController extends Controller
     public function index(Request $request)
     {
         $query = BREField::query();
+        $query->with([
+            'breDataType',
+            'breDataType.breValueType',
+            'breDataValidation',
+            'breDataValidation.breValidationType',
+            'breFieldGroups',
+            'breInputs',
+            'breOutputs',
+            'icmcdwFields',
+            'childFields',
+            'siebelBusinessObjects',
+            'siebelBusinessComponents',
+            'siebelApplets',
+            'siebelTables',
+            'siebelFields'
+        ]);
 
         if ($request->has('name')) {
             $query->whereRaw('LOWER(name) LIKE ?', ['%' . strtolower($request->name) . '%']);
@@ -166,7 +182,29 @@ class BREFieldController extends Controller
 
     public function show($id)
     {
-        $breField = BREField::findOrFail($id);
+        $query = BREField::with([
+            'breDataType',
+            'breDataType.breValueType',
+            'breDataValidation',
+            'breDataValidation.breValidationType',
+            'breFieldGroups',
+            'breInputs',
+            'breOutputs',
+            'icmcdwFields',
+            'childFields',
+            'siebelBusinessObjects',
+            'siebelBusinessComponents',
+            'siebelApplets',
+            'siebelTables',
+            'siebelFields'
+        ]);
+
+        if (is_numeric($id)) {
+            $breField = $query->findOrFail($id);
+        } else {
+            $breField = $query->where('name', $id)->firstOrFail();
+        }
+
         return new BREFieldResource($breField);
     }
 

--- a/app/Http/Controllers/BREFieldGroupController.php
+++ b/app/Http/Controllers/BREFieldGroupController.php
@@ -11,9 +11,16 @@ use Illuminate\Support\Facades\Validator;
 class BREFieldGroupController extends Controller
 {
     public function index(Request $request)
-
     {
         $query = BREFieldGroup::query();
+
+        $query->with([
+            'breFields',
+            'breFields.breDataType.breValueType',
+            'breFields.breDataValidation.breValidationType',
+            'breFields.breInputs',
+            'breFields.breOutputs'
+        ]);
 
         if ($request->has('name')) {
             $query->whereRaw('LOWER(name) LIKE ?', ['%' . strtolower($request->name) . '%']);
@@ -39,7 +46,7 @@ class BREFieldGroupController extends Controller
             $query->whereHas('breFields', function ($query) use ($request) {
                 $query->where('name', $request->bre_fields_name);
             });
-        }        
+        }
 
         if ($request->has('order_by')) {
             $orderDirection = $request->input('order_direction', 'asc');
@@ -71,7 +78,20 @@ class BREFieldGroupController extends Controller
 
     public function show($id)
     {
-        $breFieldGroup = BREFieldGroup::findOrFail($id);
+        $query = BREFieldGroup::with([
+            'breFields',
+            'breFields.breDataType.breValueType',
+            'breFields.breDataValidation.breValidationType',
+            'breFields.breInputs',
+            'breFields.breOutputs'
+        ]);
+
+        if (is_numeric($id)) {
+            $breFieldGroup = $query->findOrFail($id);
+        } else {
+            $breFieldGroup = $query->where('name', $id)->firstOrFail();
+        }
+
         return new BREFieldGroupResource($breFieldGroup);
     }
 

--- a/app/Http/Controllers/BRERuleController.php
+++ b/app/Http/Controllers/BRERuleController.php
@@ -12,6 +12,43 @@ class BRERuleController extends Controller
     public function index(Request $request)
     {
         $query = BRERule::query();
+        $query->with([
+            'breInputs.breDataType.breValueType',
+            'breInputs.breDataValidation.breValidationType',
+            'breInputs.breFieldGroups',
+            'breInputs.childFields',
+            'breInputs.icmcdwFields',
+            'breInputs.siebelBusinessObjects',
+            'breInputs.siebelBusinessComponents',
+            'breInputs.siebelApplets',
+            'breInputs.siebelTables',
+            'breInputs.siebelFields',
+
+            'breOutputs.breDataType.breValueType',
+            'breOutputs.breDataValidation.breValidationType',
+            'breOutputs.breFieldGroups',
+            'breOutputs.childFields',
+            'breOutputs.icmcdwFields',
+            'breOutputs.siebelBusinessObjects',
+            'breOutputs.siebelBusinessComponents',
+            'breOutputs.siebelApplets',
+            'breOutputs.siebelTables',
+            'breOutputs.siebelFields',
+
+            'parentRules.breInputs.breDataType.breValueType',
+            'parentRules.breInputs.breDataValidation.breValidationType',
+            'parentRules.breOutputs.breDataType.breValueType',
+            'parentRules.breOutputs.breDataValidation.breValidationType',
+
+            'childRules.breInputs.breDataType.breValueType',
+            'childRules.breInputs.breDataValidation.breValidationType',
+            'childRules.breOutputs.breDataType.breValueType',
+            'childRules.breOutputs.breDataValidation.breValidationType',
+
+            'icmcdwFields',
+            'siebelBusinessObjects',
+            'siebelBusinessComponents',
+        ]);
 
         if ($request->has('name')) {
             $query->whereRaw('LOWER(name) LIKE ?', ['%' . strtolower($request->name) . '%']);
@@ -169,7 +206,50 @@ class BRERuleController extends Controller
 
     public function show($id)
     {
-        $breRule = BRERule::findOrFail($id);
+        $query = BRERule::with([
+            'breInputs.breDataType.breValueType',
+            'breInputs.breDataValidation.breValidationType',
+            'breInputs.breFieldGroups',
+            'breInputs.childFields',
+            'breInputs.icmcdwFields',
+            'breInputs.siebelBusinessObjects',
+            'breInputs.siebelBusinessComponents',
+            'breInputs.siebelApplets',
+            'breInputs.siebelTables',
+            'breInputs.siebelFields',
+
+            'breOutputs.breDataType.breValueType',
+            'breOutputs.breDataValidation.breValidationType',
+            'breOutputs.breFieldGroups',
+            'breOutputs.childFields',
+            'breOutputs.icmcdwFields',
+            'breOutputs.siebelBusinessObjects',
+            'breOutputs.siebelBusinessComponents',
+            'breOutputs.siebelApplets',
+            'breOutputs.siebelTables',
+            'breOutputs.siebelFields',
+
+            'parentRules.breInputs.breDataType.breValueType',
+            'parentRules.breInputs.breDataValidation.breValidationType',
+            'parentRules.breOutputs.breDataType.breValueType',
+            'parentRules.breOutputs.breDataValidation.breValidationType',
+
+            'childRules.breInputs.breDataType.breValueType',
+            'childRules.breInputs.breDataValidation.breValidationType',
+            'childRules.breOutputs.breDataType.breValueType',
+            'childRules.breOutputs.breDataValidation.breValidationType',
+
+            'icmcdwFields',
+            'siebelBusinessObjects',
+            'siebelBusinessComponents',
+        ]);
+
+        if (is_numeric($id)) {
+            $breRule = $query->findOrFail($id);
+        } else {
+            $breRule = $query->where('name', $id)->firstOrFail();
+        }
+
         return new BRERuleResource($breRule);
     }
 

--- a/app/Http/Controllers/ICMCDWFieldController.php
+++ b/app/Http/Controllers/ICMCDWFieldController.php
@@ -13,6 +13,13 @@ class ICMCDWFieldController extends Controller
     {
         $query = ICMCDWField::query();
 
+        $query->with([
+            'breFields',
+            'breFields.breDataType',
+            'breFields.breDataValidation',
+            'breFields.breFieldGroups',
+        ]);
+
         if ($request->has('name')) {
             $query->whereRaw('LOWER(name) LIKE ?', ['%' . strtolower($request->name) . '%']);
         }
@@ -77,7 +84,19 @@ class ICMCDWFieldController extends Controller
 
     public function show($id)
     {
-        $icmCDWField = ICMCDWField::findOrFail($id);
+        $query = ICMCDWField::with([
+            'breFields',
+            'breFields.breDataType',
+            'breFields.breDataValidation',
+            'breFields.breFieldGroups',
+        ]);
+
+        if (is_numeric($id)) {
+            $icmCDWField = $query->findOrFail($id);
+        } else {
+            $icmCDWField = $query->where('name', $id)->firstOrFail();
+        }
+
         return new ICMCDWFieldResource($icmCDWField);
     }
 


### PR DESCRIPTION
## What changes did you make? 
- Update to the bre api controllers to enable eager loading rather than lazy loading. Loading of nested properties is now explicit. 
- Added additional functionality to allow for querying of rules/fields using the rule/field name in addition to the id.

## Why did you make these changes?

- Exact information returned in query is now explicit, and easy to understand, add/remove properties.
- Eager loading minimizes number of database queries

## What alternatives did you consider?
- Looked into re-enabling lazy loading for local development for api queries only, but overall, explicit querying and improvements to database queries preferred.
