### PR TITLE
increase default php memory limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ RUN apt-get update && apt-get install -y \
 # Enable Apache mod_rewrite
 RUN a2enmod rewrite
 
+# Overwrite default 128mb memory limit to 1gb
+RUN echo "memory_limit = 1024M" > /usr/local/etc/php/conf.d/memory-limit.ini
+
 # Set working directory
 WORKDIR /var/www
 


### PR DESCRIPTION
## What changes did you make? 

Increased the default PHP memory_limit

## Why did you make these changes?

We were encountering this error:

```
$ cat laravel.log
[2025-04-23 17:08:39] production.ERROR: Allowed memory size of 134217728 bytes exhausted (tried to allocate 12783504 bytes) {"userId":7,"exception":"[object] (Symfony\\Component\\ErrorHandler\\Error\\FatalError(code: 0): Allowed memory size of 134217728 bytes exhausted (tried to allocate 12783504 bytes) at /var/www/vendor/laravel/framework/src/Illuminate/View/Engines/PhpEngine.php:63)
[stacktrace]
#0 {main}
"} 
```

The container has a 1gb memory request but was restricted by PHP to only use 128mb

## What alternatives did you consider?

Manually editing php.ini or setting up the change with laravels env variables or in the helm chart. This was the cleanest and recommended from Laravel.

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
