### PR TITLE
Bugfix element label

### DIFF
--- a/app/Filament/Components/ContainerBlock.php
+++ b/app/Filament/Components/ContainerBlock.php
@@ -52,7 +52,7 @@ class ContainerBlock
                                         TextInput::make('custom_instance_id')
                                             ->label(false)
                                             ->alphanum()
-                                            ->reactive()
+                                            ->lazy()
                                             ->distinct()
                                             ->visible(fn($get) => $get('customize_instance_id')),
                                     ]),

--- a/app/Filament/Components/FieldGroupBlock.php
+++ b/app/Filament/Components/FieldGroupBlock.php
@@ -119,7 +119,7 @@ class FieldGroupBlock
                                         TextInput::make('custom_instance_id')
                                             ->label(false)
                                             ->alphanum()
-                                            ->reactive()
+                                            ->lazy()
                                             ->distinct()
                                             ->visible(fn($get) => $get('customize_instance_id')),
                                     ]),
@@ -147,6 +147,7 @@ class FieldGroupBlock
                                             }),
                                         TextInput::make('custom_group_label')
                                             ->label(false)
+                                            ->lazy()
                                             ->visible(fn($get) => $get('customize_group_label') == 'customize'),
                                     ]),
                                 Toggle::make('repeater')

--- a/app/Filament/Components/FieldGroupBlock.php
+++ b/app/Filament/Components/FieldGroupBlock.php
@@ -30,7 +30,7 @@ class FieldGroupBlock
                 }
                 $group = FieldGroup::find($state['field_group_id']);
                 if ($group) {
-                    $label = ($state['group_label'] ?? $group->label ?? '(no label)')
+                    $label = ($state['custom_group_label'] ?? $group->label ?? '(no label)')
                         . ' | group '
                         . ' | id: ' . ($state['customize_instance_id'] && !empty($state['custom_instance_id']) ? $state['custom_instance_id'] : $state['instance_id']);
                     return $label;

--- a/app/Filament/Components/FormFieldBlock.php
+++ b/app/Filament/Components/FormFieldBlock.php
@@ -132,7 +132,7 @@ class FormFieldBlock
                                         TextInput::make('custom_instance_id')
                                             ->label(false)
                                             ->alphanum()
-                                            ->reactive()
+                                            ->lazy()
                                             ->distinct()
                                             ->visible(fn($get) => $get('customize_instance_id')),
                                     ]),
@@ -160,7 +160,7 @@ class FormFieldBlock
                                             }),
                                         TextInput::make('custom_label')
                                             ->label(false)
-                                            ->reactive()
+                                            ->lazy()
                                             ->visible(fn($get) => $get('customize_label') == 'customize'),
                                     ]),
                                 Fieldset::make('Field Value')


### PR DESCRIPTION
## What changes did you make? 

Element header only update when custom label/ID blurs. Group headers use custom label values

## Why did you make these changes?

Resolving two bugs:
- https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/2542
- https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/2385

## What alternatives did you consider?

Considered the differences between debounce(), lazy(), live(), and reactive()

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [x] **My code has adequate test coverage (if applicable)**
