### PR TITLE
Use Textareas for JavaScript input

### DIFF
--- a/app/Filament/Components/ContainerBlock.php
+++ b/app/Filament/Components/ContainerBlock.php
@@ -13,6 +13,7 @@ use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 
@@ -72,7 +73,7 @@ class ContainerBlock
                                     ->columnSpan(1)
                                     ->live()
                                     ->reactive(),
-                                TextInput::make('visibility')
+                                Textarea::make('visibility')
                                     ->columnSpanFull()
                                     ->label('Visibility'),
                             ]),

--- a/app/Filament/Components/FieldGroupBlock.php
+++ b/app/Filament/Components/FieldGroupBlock.php
@@ -16,6 +16,7 @@ use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 
@@ -199,7 +200,7 @@ class FieldGroupBlock
                                             ->options(FormDataSource::pluck('name', 'name'))
                                             ->visible(fn($get) => $get('customize_data_binding')),
                                     ]),
-                                TextInput::make('visibility')
+                                Textarea::make('visibility')
                                     ->columnSpanFull()
                                     ->label('Visibility'),
                             ]),

--- a/app/Filament/Components/FormFieldBlock.php
+++ b/app/Filament/Components/FormFieldBlock.php
@@ -325,7 +325,7 @@ class FormFieldBlock
                             ->options($validationOptions)
                             ->reactive()
                             ->required(),
-                        TextInput::make('value')
+                        Textarea::make('value')
                             ->label('Value'),
                         TextInput::make('error_message')
                             ->label('Error Message'),
@@ -343,7 +343,7 @@ class FormFieldBlock
                             ->options($conditionalOptions)
                             ->reactive()
                             ->required(),
-                        TextInput::make('value')
+                        Textarea::make('value')
                             ->label('Value'),
                     ]),
             ]);


### PR DESCRIPTION
## What changes did you make? 

Use resizable Textarea instead of TextInput for JavaScript input fields

## Why did you make these changes?

Single line text input is annoying and not ideal for writing code

## What alternatives did you consider?

None

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [x] **My code has adequate test coverage (if applicable)**
