### PR TITLE
Limit length of labels in element headers to 50 characters

### DIFF
--- a/app/Filament/Components/FieldGroupBlock.php
+++ b/app/Filament/Components/FieldGroupBlock.php
@@ -30,7 +30,8 @@ class FieldGroupBlock
                 }
                 $group = FieldGroup::find($state['field_group_id']);
                 if ($group) {
-                    $label = ($state['custom_group_label'] ?? $group->label ?? '(no label)')
+                    $customLabel = strlen($state['custom_group_label']) > 50 ? substr($state['custom_group_label'], 0, 50) . ' ...' : $state['custom_group_label'];
+                    $label = ($customLabel ?? $group->label ?? '(no label)')
                         . ' | group '
                         . ' | id: ' . ($state['customize_instance_id'] && !empty($state['custom_instance_id']) ? $state['custom_instance_id'] : $state['instance_id']);
                     return $label;

--- a/app/Filament/Components/FormFieldBlock.php
+++ b/app/Filament/Components/FormFieldBlock.php
@@ -56,7 +56,8 @@ class FormFieldBlock
                 if ($field) {
                     $label = '';
                     if ($state['customize_label'] !== 'hide') {
-                        $label .= ($state['custom_label'] ?? $field->label ?? 'null') . ' | ';
+                        $customLabel = strlen($state['custom_label']) > 50 ? substr($state['custom_label'], 0, 50) . ' ...' : $state['custom_label'];
+                        $label .= ($customLabel ?? $field->label ?? 'null') . ' | ';
                     } else {
                         $label .= '(label hidden) | ';
                     }


### PR DESCRIPTION
## What changes did you make? 

Truncate overly long labels and append ' ...' to prevent element from overstretching

## Why did you make these changes?

Resolve https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/2549/

## What alternatives did you consider?

None

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [x] **My code has adequate test coverage (if applicable)**
