### PR TITLE
Add activity log setup and update version statuses

### DIFF
--- a/app/Filament/Components/FormVersionBuilder.php
+++ b/app/Filament/Components/FormVersionBuilder.php
@@ -19,6 +19,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
 use Illuminate\Support\Facades\Session;
+use App\Models\FormVersion;
 
 class FormVersionBuilder
 {
@@ -34,12 +35,7 @@ class FormVersionBuilder
                     ->searchable()
                     ->default(request()->query('form_id_title')),
                 Select::make('status')
-                    ->options([
-                        'draft' => 'Draft',
-                        'testing' => 'Testing',
-                        'archived' => 'Archived',
-                        'published' => 'Published',
-                    ])
+                    ->options(FormVersion::getStatusOptions())
                     ->required(),
                 Section::make('Form Properties')
                     ->collapsible()

--- a/app/Filament/Forms/Resources/FormFieldsRelationManagerResource/RelationManagers/FormFieldsRelationManager.php
+++ b/app/Filament/Forms/Resources/FormFieldsRelationManagerResource/RelationManagers/FormFieldsRelationManager.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Filament\Resources\SelectOptionsResource\RelationManagers;
+namespace App\Filament\Forms\Resources\FormFieldsRelationManagerResource\RelationManagers;
 
 use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;

--- a/app/Filament/Forms/Resources/FormVersionResource.php
+++ b/app/Filament/Forms/Resources/FormVersionResource.php
@@ -115,8 +115,10 @@ class FormVersionResource extends Resource
                     ->searchable(),
                 Tables\Columns\TextColumn::make('version_number')
                     ->searchable(),
-                Tables\Columns\TextColumn::make('status')
-                    ->searchable(),
+                Tables\Columns\TextColumn::make('formatted_status')
+                    ->label('Status')
+                    ->searchable()
+                    ->getStateUsing(fn($record) => $record->getFormattedStatusName()),
                 Tables\Columns\TextColumn::make('deployed_to')
                     ->searchable(),
                 Tables\Columns\TextColumn::make('deployed_at')

--- a/app/Filament/Forms/Resources/SelectOptionsResource.php
+++ b/app/Filament/Forms/Resources/SelectOptionsResource.php
@@ -4,8 +4,8 @@ namespace App\Filament\Forms\Resources;
 
 use App\Filament\Forms\Resources\SelectOptionsResource\Pages;
 use App\Filament\Imports\SelectOptionsImporter;
-use App\Filament\Resources\SelectOptionsResource\RelationManagers\FormFieldsRelationManager;
-use App\Filament\Resources\SelectOptionsResource\RelationManagers\FormInstanceFieldsRelationManager;
+use App\Filament\Forms\Resources\FormFieldsRelationManagerResource\RelationManagers\FormFieldsRelationManager;
+use App\Filament\Forms\Resources\SelectOptionsResource\RelationManagers\FormInstanceFieldsRelationManager;
 use App\Models\SelectOptions;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;

--- a/app/Filament/Forms/Resources/SelectOptionsResource/RelationManagers/FormInstanceFieldsRelationManager.php
+++ b/app/Filament/Forms/Resources/SelectOptionsResource/RelationManagers/FormInstanceFieldsRelationManager.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Filament\Resources\SelectOptionsResource\RelationManagers;
+namespace App\Filament\Forms\Resources\SelectOptionsResource\RelationManagers;
 
 use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;

--- a/app/Models/FormVersion.php
+++ b/app/Models/FormVersion.php
@@ -6,10 +6,12 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Spatie\Activitylog\Traits\LogsActivity;
+use Spatie\Activitylog\LogOptions;
 
 class FormVersion extends Model
 {
-    use HasFactory;
+    use HasFactory, LogsActivity;
 
     protected $fillable = [
         'form_id',
@@ -40,6 +42,21 @@ class FormVersion extends Model
 
             $formVersion->version_number = $latestVersion ? $latestVersion->version_number + 1 : 1;
         });
+    }
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['status', 'form_id', 'version_number'])
+            ->logOnlyDirty()
+            ->setDescriptionForEvent(function (string $eventName) {
+                return "Form version metadata was {$eventName}";
+            });
+    }
+
+    public function getLogNameToUse(): string
+    {
+        return 'form_versions';
     }
 
     public function form()

--- a/app/Models/FormVersion.php
+++ b/app/Models/FormVersion.php
@@ -59,6 +59,22 @@ class FormVersion extends Model
         return 'form_versions';
     }
 
+    public static function getStatusOptions(): array
+    {
+        return [
+            'draft' => 'Draft',
+            'under_review' => 'Under Review',
+            'approved' => 'Approved',
+            'published' => 'Published',
+            'archived' => 'Archived',
+        ];
+    }
+
+    public function getFormattedStatusName(): string
+    {
+        return self::getStatusOptions()[$this->status] ?? $this->status;
+    }
+
     public function form()
     {
         return $this->belongsTo(Form::class);

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "laravel/framework": "^11.0",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.9",
-        "orangehill/iseed": "^3.0"
+        "orangehill/iseed": "^3.0",
+        "spatie/laravel-activitylog": "^4.10"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a90546bd5da032e2223034aaa4336ec9",
+    "content-hash": "b391c28e6c70d84870dc63280234e2e2",
     "packages": [
         {
             "name": "althinect/filament-spatie-roles-permissions",
@@ -5019,6 +5019,97 @@
                 }
             ],
             "time": "2024-05-17T09:06:10+00:00"
+        },
+        {
+            "name": "spatie/laravel-activitylog",
+            "version": "4.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-activitylog.git",
+                "reference": "466f30f7245fe3a6e328ad5e6812bd43b4bddea5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-activitylog/zipball/466f30f7245fe3a6e328ad5e6812bd43b4bddea5",
+                "reference": "466f30f7245fe3a6e328ad5e6812bd43b4bddea5",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/config": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
+                "illuminate/database": "^8.69 || ^9.27 || ^10.0 || ^11.0 || ^12.0",
+                "illuminate/support": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
+                "php": "^8.1",
+                "spatie/laravel-package-tools": "^1.6.3"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "orchestra/testbench": "^6.23 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
+                "pestphp/pest": "^1.20 || ^2.0 || ^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Activitylog\\ActivitylogServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Spatie\\Activitylog\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian De Deyne",
+                    "email": "sebastian@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Tom Witkowski",
+                    "email": "dev.gummibeer@gmail.com",
+                    "homepage": "https://gummibeer.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A very simple activity logger to monitor the users of your website or application",
+            "homepage": "https://github.com/spatie/activitylog",
+            "keywords": [
+                "activity",
+                "laravel",
+                "log",
+                "spatie",
+                "user"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-activitylog/issues",
+                "source": "https://github.com/spatie/laravel-activitylog/tree/4.10.1"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-10T15:38:25+00:00"
         },
         {
             "name": "spatie/laravel-package-tools",
@@ -11160,12 +11251,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/database/migrations/2025_05_06_050214_create_activity_log_table.php
+++ b/database/migrations/2025_05_06_050214_create_activity_log_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateActivityLogTable extends Migration
+{
+    public function up()
+    {
+        Schema::connection(config('activitylog.database_connection'))->create(config('activitylog.table_name'), function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('log_name')->nullable();
+            $table->text('description');
+            $table->nullableMorphs('subject', 'subject');
+            $table->nullableMorphs('causer', 'causer');
+            $table->json('properties')->nullable();
+            $table->timestamps();
+            $table->index('log_name');
+        });
+    }
+
+    public function down()
+    {
+        Schema::connection(config('activitylog.database_connection'))->dropIfExists(config('activitylog.table_name'));
+    }
+}

--- a/database/migrations/2025_05_06_050215_add_event_column_to_activity_log_table.php
+++ b/database/migrations/2025_05_06_050215_add_event_column_to_activity_log_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddEventColumnToActivityLogTable extends Migration
+{
+    public function up()
+    {
+        Schema::connection(config('activitylog.database_connection'))->table(config('activitylog.table_name'), function (Blueprint $table) {
+            $table->string('event')->nullable()->after('subject_type');
+        });
+    }
+
+    public function down()
+    {
+        Schema::connection(config('activitylog.database_connection'))->table(config('activitylog.table_name'), function (Blueprint $table) {
+            $table->dropColumn('event');
+        });
+    }
+}

--- a/database/migrations/2025_05_06_050216_add_batch_uuid_column_to_activity_log_table.php
+++ b/database/migrations/2025_05_06_050216_add_batch_uuid_column_to_activity_log_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddBatchUuidColumnToActivityLogTable extends Migration
+{
+    public function up()
+    {
+        Schema::connection(config('activitylog.database_connection'))->table(config('activitylog.table_name'), function (Blueprint $table) {
+            $table->uuid('batch_uuid')->nullable()->after('properties');
+        });
+    }
+
+    public function down()
+    {
+        Schema::connection(config('activitylog.database_connection'))->table(config('activitylog.table_name'), function (Blueprint $table) {
+            $table->dropColumn('batch_uuid');
+        });
+    }
+}

--- a/database/migrations/2025_05_06_054952_update_form_versions_enum.php
+++ b/database/migrations/2025_05_06_054952_update_form_versions_enum.php
@@ -1,0 +1,80 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // add a temp column for the new enum statuses
+        Schema::table('form_versions', function (Blueprint $table) {
+            $table->enum('temp_status', ['draft', 'under_review', 'approved', 'published', 'archived'])->default('draft');
+        });
+
+        // copy the existing values to the new column
+        DB::table('form_versions')->get()->each(function ($record) {
+            $newStatus = match ($record->status) {
+                'draft' => 'draft',
+                'testing' => 'under_review',
+                'published' => 'published',
+                'archived' => 'archived',
+                default => 'draft',
+            };
+
+            DB::table('form_versions')
+                ->where('id', $record->id)
+                ->update(['temp_status' => $newStatus]);
+        });
+
+        // delete the old column
+        Schema::table('form_versions', function (Blueprint $table) {
+            $table->dropColumn('status');
+        });
+
+        // rename the temp column
+        Schema::table('form_versions', function (Blueprint $table) {
+            $table->renameColumn('temp_status', 'status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // add a temp column for the old enum statuses
+        Schema::table('form_versions', function (Blueprint $table) {
+            $table->enum('temp_status', ['draft', 'testing', 'published', 'archived'])->default('draft');
+        });
+
+        // copy the existing values back to the original format
+        DB::table('form_versions')->get()->each(function ($record) {
+            $oldStatus = match ($record->status) {
+                'draft' => 'draft',
+                'under_review' => 'testing',
+                'published' => 'published',
+                'archived' => 'archived',
+                default => 'draft',
+            };
+
+            DB::table('form_versions')
+                ->where('id', $record->id)
+                ->update(['temp_status' => $oldStatus]);
+        });
+
+        // delete the new column
+        Schema::table('form_versions', function (Blueprint $table) {
+            $table->dropColumn('status');
+        });
+
+        // rename the temp column back to the original name
+        Schema::table('form_versions', function (Blueprint $table) {
+            $table->renameColumn('temp_status', 'status');
+        });
+    }
+};


### PR DESCRIPTION
## What changes did you make? 

- Adds the https://github.com/spatie/laravel-activitylog package
- Logs status changes for form versions
- Changes the statuses to use the new system outlined here https://knowledge.social.gov.bc.ca/klamm/forms_release_management

## Why did you make these changes?

Part of the new release management system involves tracking all the changes. Adding this package and tracking status changes is a good start. Right now it is set to "logOnlyDirty" so it only logs the attributes which have been updated, it is also set to log the 'status', 'form_id' and 'version_number'.

To run and test this you will need to run `sail composer install` to grab the new package. Then make sure to run the migrations.

The activity log right now is tracking whether it was created vs updated (important distinction), who did the change, and when. From the Form Version ID we can identify which form it belongs to.

<img width="216" alt="image" src="https://github.com/user-attachments/assets/b67f179d-2e89-4acd-9b87-d11bf88a2114" />

We can build an activity log timeline from this data and basically just have 2 different events. If a status was updated or if a form version was created.

Also the migration to change the enum is a bit complicated. Postgres and eloquent [do not support](https://stackoverflow.com/questions/33496518/how-to-change-enum-type-column-in-laravel-migration) the ->change() prop so I am doing it in a bit of a roundabout way. It creates a new temp column, transfers the values, and then deletes the old column. I tested it locally in a number of edge cases and seems to be working correctly.

## What alternatives did you consider?

I thought about making some custom activity log system but the Spatie package is great for our needs right now.

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [x] **My code has adequate test coverage (if applicable)**
