### PR TITLE
Add seeders for generic fields

### DIFF
--- a/database/seeders/FormFieldSeeder.php
+++ b/database/seeders/FormFieldSeeder.php
@@ -20,7 +20,7 @@ class FormFieldSeeder extends Seeder
         $radioType = DataType::where('name', 'radio')->first()->id;
         $numberInputType = DataType::where('name', 'number-input')->first()->id;
         $textInfoType = DataType::where('name', 'text-info')->first()->id;
-        $linkType = DataType::where('name', 'link')->first()->id;        
+        $linkType = DataType::where('name', 'link')->first()->id;
         $fileType = DataType::where('name', 'file')->first()->id;
         $tableType = DataType::where('name', 'table')->first()->id;
 
@@ -40,6 +40,19 @@ class FormFieldSeeder extends Seeder
             ['name' => 'link', 'label' => 'Link', 'data_type_id' => $linkType],
             ['name' => 'attachment', 'label' => 'Attachment', 'data_type_id' => $fileType],
             ['name' => 'table', 'label' => 'Table', 'data_type_id' => $tableType],
+            // Seed generic fields (these fields are required by the JSON Importer to function)
+            ['name' => 'generic_button', 'label' => 'Generic Button', 'data_type_id' => $buttonType],
+            ['name' => 'generic_checkbox', 'label' => 'Generic Checkbox', 'data_type_id' => $checkboxType],
+            ['name' => 'generic_date', 'label' => 'Generic Date', 'data_type_id' => $dateType],
+            ['name' => 'generic_file', 'label' => 'Generic File', 'data_type_id' => $fileType],
+            ['name' => 'generic_link', 'label' => 'Generic Link', 'data_type_id' => $linkType],
+            ['name' => 'generic_number_input', 'label' => 'Generic Number Input', 'data_type_id' => $numberInputType],
+            ['name' => 'generic_radio', 'label' => 'Generic Radio', 'data_type_id' => $radioType],
+            ['name' => 'generic_table', 'label' => 'Generic Table', 'data_type_id' => $tableType],
+            ['name' => 'generic_text_area', 'label' => 'Generic Text Input Area', 'data_type_id' => $textAreaType],
+            ['name' => 'generic_text_info', 'label' => 'Generic Text Display', 'data_type_id' => $textInfoType],
+            ['name' => 'generic_text_input', 'label' => 'Generic Text Input', 'data_type_id' => $textInputType],
+            ['name' => 'generic_toggle', 'label' => 'Generic Toggle', 'data_type_id' => $toggleType],
         ];
 
         foreach ($formFields as $formField) {


### PR DESCRIPTION
## What changes did you make? 

Added seeders for generic fields

## Why did you make these changes?

Generic fields are required to exist for the JSON importer to function correctly

## What alternatives did you consider?

None

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [x] **My code has adequate test coverage (if applicable)**
