### PR TITLE
fix status search for form versions

### DIFF
--- a/app/Filament/Forms/Resources/FormVersionResource.php
+++ b/app/Filament/Forms/Resources/FormVersionResource.php
@@ -115,8 +115,7 @@ class FormVersionResource extends Resource
                     ->searchable(),
                 Tables\Columns\TextColumn::make('version_number')
                     ->searchable(),
-                Tables\Columns\TextColumn::make('formatted_status')
-                    ->label('Status')
+                Tables\Columns\TextColumn::make('status')
                     ->searchable()
                     ->getStateUsing(fn($record) => $record->getFormattedStatusName()),
                 Tables\Columns\TextColumn::make('deployed_to')


### PR DESCRIPTION
## What changes did you make? 

Change the column name reference for the status in the form versions.

## Why did you make these changes?

Since searchable searches the actual column name, use that rather than the computed name I was using.

## What alternatives did you consider?

Custom search query.

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [x] **My code has adequate test coverage (if applicable)**
