### PR TITLE
Form Version block previews 

### DIFF
--- a/app/Filament/Components/ContainerBlock.php
+++ b/app/Filament/Components/ContainerBlock.php
@@ -32,7 +32,7 @@ class ContainerBlock
                 return 'Container | id: ' . ($state['customize_instance_id'] && !empty($state['custom_instance_id']) ? $state['custom_instance_id'] : $state['instance_id']);
             })
             ->icon('heroicon-o-square-3-stack-3d')
-            ->columns(2)
+            ->preview('filament.forms.resources.form-resource.components.block-previews.blank')
             ->schema([
                 Section::make('Container Properties')
                     ->collapsible()
@@ -50,7 +50,7 @@ class ContainerBlock
                                             ->label("Default")
                                             ->dehydrated(false)
                                             ->content(fn($get) => $get('instance_id')), // Set the sequential default value
-                                        Hidden::make('instance_id') // used to populate value in template 
+                                        Hidden::make('instance_id') // used to populate value in template
                                             ->hidden()
                                             ->dehydrated(false)
                                             ->default($calculateIDCallback), // Set the sequential default value

--- a/app/Filament/Components/FieldGroupBlock.php
+++ b/app/Filament/Components/FieldGroupBlock.php
@@ -44,6 +44,7 @@ class FieldGroupBlock
             })
             ->icon('heroicon-o-square-2-stack')
             ->columns(2)
+            ->preview('filament.forms.resources.form-resource.components.block-previews.blank')
             ->schema([
                 Select::make('field_group_id')
                     ->label('Field Group')
@@ -119,7 +120,7 @@ class FieldGroupBlock
                                             ->label("Default")
                                             ->dehydrated(false)
                                             ->content(fn($get) => $get('instance_id')), // Set the sequential default value
-                                        Hidden::make('instance_id') // used to populate value in template 
+                                        Hidden::make('instance_id') // used to populate value in template
                                             ->hidden()
                                             ->default($calculateIDCallback), // Set the sequential default value
                                         Toggle::make('customize_instance_id')
@@ -152,7 +153,6 @@ class FieldGroupBlock
                                             ->default('default')
                                             ->inline()
                                             ->inlineLabel(false)
-                                            ->label(false)
                                             ->lazy()
                                             ->afterStateUpdated(function ($state, callable $set) {
                                                 if ($state !== 'customize') {

--- a/app/Filament/Components/FormFieldBlock.php
+++ b/app/Filament/Components/FormFieldBlock.php
@@ -77,6 +77,7 @@ class FormFieldBlock
             })
             ->icon('heroicon-o-stop')
             ->columns(2)
+            ->preview('filament.forms.resources.form-resource.components.block-previews.blank')
             ->schema([
                 Select::make('form_field_id')
                     ->label('Form Field')
@@ -129,7 +130,7 @@ class FormFieldBlock
                                             ->label("Default")
                                             ->dehydrated(false)
                                             ->content(fn($get) => $get('instance_id')), // Set the sequential default value
-                                        Hidden::make('instance_id') // used to populate value in template 
+                                        Hidden::make('instance_id') // used to populate value in template
                                             ->hidden()
                                             ->default($calculateIDCallback), // Set the sequential default value
                                         Toggle::make('customize_instance_id')
@@ -314,6 +315,7 @@ class FormFieldBlock
                     ->visible(fn($get) => in_array($fields->get($get('form_field_id'))?->dataType?->name, ['radio', 'dropdown']))
                     ->blocks([
                         Block::make('select_option_instance')
+                            ->preview('filament.forms.resources.form-resource.components.block-previews.blank')
                             ->label(
                                 fn(?array $state): string =>
                                 isset($state['select_option_id']) && $selectOptions->has($state['select_option_id'])

--- a/app/Filament/Components/FormVersionBuilder.php
+++ b/app/Filament/Components/FormVersionBuilder.php
@@ -22,6 +22,7 @@ use Filament\Forms\Get;
 use Filament\Forms\Set;
 use Illuminate\Support\Facades\Session;
 use App\Models\FormVersion;
+use Filament\Notifications\Notification;
 
 class FormVersionBuilder
 {
@@ -93,12 +94,42 @@ class FormVersionBuilder
                     ->addActionLabel('Add to Form Elements')
                     ->addBetweenActionLabel('Insert between elements')
                     ->columnSpan(2)
-                    ->collapsible()
-                    ->collapsed(true)
                     ->blockNumbers(false)
                     ->cloneable()
+                    ->blockPreviews()
+                    ->editAction(
+                        fn(Action $action) => $action
+                            ->visible(fn() => true)
+                            ->icon(function ($livewire) {
+                                return $livewire instanceof \Filament\Resources\Pages\ViewRecord
+                                    ? 'heroicon-o-eye'
+                                    : 'heroicon-o-pencil';
+                            })
+                            ->label(function ($livewire) {
+                                return $livewire instanceof \Filament\Resources\Pages\ViewRecord
+                                    ? 'View'
+                                    : 'Edit';
+                            })
+                            ->disabledForm(fn($livewire) => ($livewire instanceof \Filament\Resources\Pages\ViewRecord)) // Disable the form
+                            ->modalHeading('View Form Field')
+                            ->modalSubmitAction(function ($action, $livewire) {
+                                if ($livewire instanceof \Filament\Resources\Pages\ViewRecord) {
+                                    return false;
+                                } else {
+                                    $action->label('Save');
+                                }
+                            })
+                            ->modalCancelAction(function ($action, $livewire) {
+                                if ($livewire instanceof \Filament\Resources\Pages\ViewRecord) {
+                                    $action->label('Close');
+                                } else {
+                                    $action->label('Cancel');
+                                }
+                            })
+                    )
                     ->afterStateHydrated(function (Set $set, Get $get) {
                         Session::put('elementCounter', self::getHighestID($get('components')) + 1);
+                        FormDataHelper::ensureFullyLoaded();
                     })
                     ->blocks([
                         FormFieldBlock::make(fn() => FormTemplateHelper::calculateElementID()),
@@ -112,10 +143,39 @@ class FormVersionBuilder
                 // Components for view View page
                 Actions::make([
                     Action::make('Generate Form Template')
-                        ->action(function (Get $get, Set $set) {
+                        ->action(function (Get $get, Set $set, $livewire) {
                             $formId = $get('id');
                             $jsonTemplate = \App\Helpers\FormTemplateHelper::generateJsonTemplate($formId);
                             $set('generated_text', $jsonTemplate);
+                            $livewire->js('
+                                setTimeout(() => {
+                                    const textarea = document.getElementById("data.generated_text");
+                                    if (!textarea || !textarea.value) {
+                                        console.error("Could not find textarea or it has no value");
+                                        return;
+                                    }
+                                    const textToCopy = textarea.value;
+                                    if (navigator.clipboard) {
+                                        navigator.clipboard.writeText(textToCopy)
+                                            .catch(err => {
+                                                console.error("Failed to copy: ", err);
+                                            });
+                                    } else {
+                                        // Fallback
+                                        try {
+                                            textarea.select();
+                                            document.execCommand("copy");
+                                        } catch (err) {
+                                            console.error("Fallback copy failed: ", err);
+                                        }
+                                    }
+                                }, 500);
+                            ');
+                            Notification::make()
+                                ->title('Template Generated!')
+                                ->body('Form template generated successfully and copied to clipboard.')
+                                ->success()
+                                ->send();
                         })
                         ->hidden(fn($livewire) => ! ($livewire instanceof \Filament\Resources\Pages\ViewRecord)),
                 ]),

--- a/app/Helpers/FormDataHelper.php
+++ b/app/Helpers/FormDataHelper.php
@@ -7,28 +7,64 @@ use App\Models\FieldGroup;
 use App\Models\FormDataSource;
 use App\Models\SelectOptions;
 use App\Models\Style;
+use Illuminate\Support\Facades\Log;
 
 class FormDataHelper
 {
     protected static array $cache = [];
+    protected static bool $isFullyLoaded = false;
 
     public static function load(): void
     {
+        $routeName = request()->route()?->getName() ?? '';
+        $isEditPage = str_contains($routeName, '.edit');
+        $isCreatePage = str_contains($routeName, '.create');
+        $formId = request()->route('record');
+
+        $needsFullLoad = ($isEditPage || $isCreatePage);
+
+        $fields = collect();
+        $query = FormField::with([
+            'dataType:id,name',
+            'formFieldValue:id,form_field_id,value',
+        ])
+            ->select([
+                'id',
+                'label',
+                'name',
+                'data_type_id',
+                'data_binding',
+                'data_binding_path',
+                'mask',
+                'help_text'
+            ]);
+
+        foreach ($query->cursor() as $field) {
+            $fields[$field->id] = $field;
+        }
+
+        $groups = collect();
+        $groupQuery = FieldGroup::select(['id', 'label', 'name']);
+        foreach ($groupQuery->cursor() as $group) {
+            $groups[$group->id] = $group;
+        }
+
+        // First load data minimally
         self::$cache = [
-            'fields' => FormField::with([
-                'dataType',
-                'webStyles',
-                'pdfStyles',
-                'validations',
-                'selectOptionInstances',
-                'formFieldValue',
-                'formFieldDateFormat',
-            ])->get()->keyBy('id'),
-            'groups' => FieldGroup::with([])->get()->keyBy('id'),
-            'styles' => Style::all()->keyBy('id'),
-            'dataSources' => FormDataSource::all()->keyBy('id'),
-            'selectOptions' => SelectOptions::all()->keyBy('id'),
+            'fields' => $fields,
+            'groups' => $groups,
+            'styles' => Style::select(['id', 'name'])->get()->keyBy('id'),
+            'dataSources' => FormDataSource::select(['id', 'name'])->get()->keyBy('id'),
+            'selectOptions' => SelectOptions::select(['id', 'label'])->get()->keyBy('id'),
         ];
+
+        // For non-view pages that need full data, load additional relationships
+        if ($needsFullLoad && $formId) {
+            self::$isFullyLoaded = true;
+            self::loadAdditionalRelationships($formId);
+        } else {
+            self::$isFullyLoaded = false;
+        }
     }
 
     public static function get(string $key)
@@ -43,5 +79,49 @@ class FormDataHelper
     public static function refresh(): void
     {
         self::load();
+    }
+
+    public static function ensureFullyLoaded(): void
+    {
+        if (!self::$isFullyLoaded) {
+            self::load();
+        }
+    }
+
+    // Load additional relationships for full data
+    protected static function loadAdditionalRelationships(mixed $formId): void
+    {
+        if (!$formId) {
+            return;
+        }
+        try {
+            FormField::with([
+                'webStyles:id,name',
+                'pdfStyles:id,name',
+                'validations:id,form_field_id,type,value,error_message',
+                'selectOptionInstances:id,form_field_id,select_option_id,order',
+            ])->chunk(100, function ($fields) use ($formId) {
+                foreach ($fields as $field) {
+                    if (isset(self::$cache['fields'][$field->id])) {
+                        self::$cache['fields'][$field->id]->webStyles = $field->webStyles;
+                        self::$cache['fields'][$field->id]->pdfStyles = $field->pdfStyles;
+                        self::$cache['fields'][$field->id]->validations = $field->validations;
+                        self::$cache['fields'][$field->id]->selectOptionInstances = $field->selectOptionInstances;
+                    }
+                }
+            });
+
+            FieldGroup::with(['formFields' => function ($query) {
+                $query->select(['form_fields.id', 'form_fields.label', 'form_fields.name']);
+            }])->chunk(50, function ($groups) {
+                foreach ($groups as $group) {
+                    if (isset(self::$cache['groups'][$group->id])) {
+                        self::$cache['groups'][$group->id]->formFields = $group->formFields;
+                    }
+                }
+            });
+        } catch (\Exception $e) {
+            Log::error("Error loading additional relationships: " . $e->getMessage());
+        }
     }
 }


### PR DESCRIPTION
## What changes did you make? 

- Switch to block previews option for blocks components in builder on form version.
- Modify the form load query to load incrementally depending on form version view.
- Add additional functionality to generate json button to also copy to clipboard.

## Why did you make these changes?

- Intended to speed up form version creation by reducing queries on initial page load. Full implementation pending potential caching update to take more advantage of reduced db queries.
