### PR TITLE
Update the Form Builder "Add element" Icon

### DIFF
--- a/app/Filament/Components/FieldGroupBlock.php
+++ b/app/Filament/Components/FieldGroupBlock.php
@@ -42,7 +42,7 @@ class FieldGroupBlock
                 }
                 return 'New Group | id: ' . $state['instance_id'];
             })
-            ->icon('heroicon-o-square-2-stack')
+            ->icon('heroicon-o-rectangle-group')
             ->columns(2)
             ->schema([
                 Select::make('field_group_id')

--- a/app/Filament/Components/FormFieldBlock.php
+++ b/app/Filament/Components/FormFieldBlock.php
@@ -75,7 +75,7 @@ class FormFieldBlock
                 }
                 return 'New Field | id: ' . $state['instance_id'];
             })
-            ->icon('heroicon-o-stop')
+            ->icon('icon-text-cursor-input')
             ->columns(2)
             ->schema([
                 Select::make('form_field_id')


### PR DESCRIPTION
## What changes did you make? 

Just changes the icons in the form builder to match the left metadata

<img width="1117" alt="image" src="https://github.com/user-attachments/assets/6a8a8492-d848-40f1-a190-cd625dd4cac5" />


## Why did you make these changes?

Just so our icons are all aligned across Klamm

## What alternatives did you consider?

N/A

### Checklist

- [x] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
