### PR TITLE
fix the id/primary duplication for sqlite

### DIFF
--- a/database/migrations/2024_07_16_145421_add_tables_for_forms_workflow.php
+++ b/database/migrations/2024_07_16_145421_add_tables_for_forms_workflow.php
@@ -13,50 +13,50 @@ return new class extends Migration
     {
         // The following tables are being refrenced by the forms table
         Schema::create('business_areas', function (Blueprint $table) {
-            $table->id()->primary();
+            $table->id();
             $table->string('name');
             $table->string('short_name')->nullable();
             $table->text('description')->nullable();
             $table->timestamps();
         });
         Schema::create('fill_types', function (Blueprint $table) {
-            $table->id()->primary();
+            $table->id();
             $table->string('name');
             $table->text('description')->nullable();
             $table->timestamps();
         });
         Schema::create('form_locations', function (Blueprint $table) {
-            $table->id()->primary();
+            $table->id();
             $table->string('name');
             $table->text('description')->nullable();
             $table->timestamps();
         });
         Schema::create('form_software_sources', function (Blueprint $table) {
-            $table->id()->primary();
+            $table->id();
             $table->string('name');
             $table->text('description')->nullable();
             $table->timestamps();
         });
         Schema::create('third_parties', function (Blueprint $table) {
-            $table->id()->primary();
+            $table->id();
             $table->string('name');
             $table->text('description')->nullable();
             $table->timestamps();
         });
         Schema::create('user_types', function (Blueprint $table) {
-            $table->id()->primary();
+            $table->id();
             $table->string('name');
             $table->text('description')->nullable();
             $table->timestamps();
         });
         Schema::create('form_frequencies', function (Blueprint $table) {
-            $table->id()->primary();
+            $table->id();
             $table->string('name');
             $table->text('description')->nullable();
             $table->timestamps();
         });
         Schema::create('form_reaches', function (Blueprint $table) {
-            $table->id()->primary();
+            $table->id();
             $table->string('name');
             $table->text('description')->nullable();
             $table->timestamps();


### PR DESCRIPTION
## What changes did you make? 
Fix an issue with sqlite migrations where primary and id can't both be called on a field.