### PR TITLE
limit revision history

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -89,5 +89,5 @@ spec:
       schedulerName: default-scheduler
   strategy:
     type: Recreate
-  revisionHistoryLimit: 10
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   progressDeadlineSeconds: 600

--- a/helm/templates/queue-deployment.yaml
+++ b/helm/templates/queue-deployment.yaml
@@ -88,5 +88,5 @@ spec:
       schedulerName: default-scheduler
   strategy:
     type: Recreate
-  revisionHistoryLimit: 10
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   progressDeadlineSeconds: 600

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,5 +1,7 @@
 replicaCount: 1
 
+revisionHistoryLimit: 3
+
 image:
   repository: ghcr.io/bcgov/klamm
   pullPolicy: Always


### PR DESCRIPTION
## What changes did you make? 

Limits the revision history to 3 (replica set count)

## Why did you make these changes?

There was large amounts of replica sets accumulating. It was set to 10 max but it was getting to way more than 10

## What alternatives did you consider?

You can manually delete them with commands like:

```
# Delete old replica sets for klamm-app (keep only current one)
oc get replicasets --no-headers | grep 'klamm-app.*0.*0.*0' | awk '{print $1}' | xargs oc delete replicaset
```

```
# Delete old replica sets for klamm-queue-worker  
oc get replicasets --no-headers | grep 'klamm-queue-worker.*0.*0.*0' | awk '{print $1}' | xargs oc delete replicaset
```

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
