### PR TITLE
Bug/forms icm generated

### DIFF
--- a/app/Filament/Forms/Resources/FormResource.php
+++ b/app/Filament/Forms/Resources/FormResource.php
@@ -160,7 +160,7 @@ class FormResource extends Resource
 
                 Section::make('Development')
                     ->collapsible()
-                    ->collapsed()
+                    ->collapsed(false)
                     ->schema([
                         InfolistGrid::make(1)
                             ->schema([

--- a/database/migrations/2025_05_26_193950_update_forms_table_null_boolean_fields_to_false.php
+++ b/database/migrations/2025_05_26_193950_update_forms_table_null_boolean_fields_to_false.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Models\Form;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Form::whereNull('icm_generated')->update(['icm_generated' => false]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Form::where('icm_generated', false)->update(['icm_generated' => null]);
+    }
+};


### PR DESCRIPTION
## What changes did you make? 

- expands form development by default
- sets all the null values in icm_generated to false

## Why did you make these changes?

Right now if it is ICM generated it is just saved as null.
Forms team requested that Development tab be expanded by default to save the click.

## What alternatives did you consider?

N/A

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
