### PR TITLE
command to add tags to forms by cli

### DIFF
--- a/app/Console/Commands/AddTagToForms.php
+++ b/app/Console/Commands/AddTagToForms.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Form;
+use App\Models\FormTag;
+use Illuminate\Console\Command;
+
+class AddTagToForms extends Command
+{
+    protected $signature = 'forms:add-tag';
+    protected $description = 'Add a tag to multiple forms by form_id';
+
+    public function handle()
+    {
+        $tagName = $this->ask('Enter the tag name you want to add to forms');
+
+        if (!$tagName) {
+            $this->error('Tag name cannot be empty.');
+            return 1;
+        }
+
+        $tag = FormTag::where('name', $tagName)->first();
+
+        if (!$tag) {
+            $description = $this->ask('Tag does not exist. Enter a description for the new tag (optional)', '');
+
+            $tag = FormTag::create([
+                'name' => $tagName,
+                'description' => $description ?: null,
+            ]);
+
+            $this->info("Created new tag: {$tagName}");
+        } else {
+            $this->info("Using existing tag: {$tagName}");
+        }
+
+        $formIdsInput = $this->ask('Enter the form_ids you want to add this tag to (comma-separated)');
+
+        if (!$formIdsInput) {
+            $this->error('No form IDs provided.');
+            return 1;
+        }
+
+        $formIds = array_map('trim', explode(',', $formIdsInput));
+        $formIds = array_filter($formIds);
+
+        if (empty($formIds)) {
+            $this->error('No valid form IDs provided.');
+            return 1;
+        }
+
+        $this->info('Processing forms...');
+
+        $successCount = 0;
+        $skippedCount = 0;
+        $alreadyTaggedCount = 0;
+
+        foreach ($formIds as $formId) {
+            $form = Form::where('form_id', $formId)->first();
+
+            if (!$form) {
+                $this->warn("Form with form_id '{$formId}' does not exist. Skipping.");
+                $skippedCount++;
+                continue;
+            }
+
+            if ($form->formTags()->where('form_tag_id', $tag->id)->exists()) {
+                $this->info("Form '{$formId}' already has tag '{$tagName}'. Skipping.");
+                $alreadyTaggedCount++;
+                continue;
+            }
+
+            $form->formTags()->attach($tag->id);
+            $this->info("Added tag '{$tagName}' to form '{$formId}'");
+            $successCount++;
+        }
+
+        $this->info('');
+        $this->info('=== Summary ===');
+        $this->info("Successfully tagged: {$successCount} forms");
+        if ($alreadyTaggedCount > 0) {
+            $this->info("Already tagged: {$alreadyTaggedCount} forms");
+        }
+        if ($skippedCount > 0) {
+            $this->warn("Skipped (not found): {$skippedCount} forms");
+        }
+
+        return 0;
+    }
+}

--- a/app/Filament/Forms/Resources/FormTagResource.php
+++ b/app/Filament/Forms/Resources/FormTagResource.php
@@ -29,7 +29,8 @@ class FormTagResource extends Resource
         return $form
             ->schema([
                 Forms\Components\TextInput::make('name')
-                    ->required(),
+                    ->required()
+                    ->columnSpanFull(),
                 Forms\Components\Textarea::make('description')
                     ->columnSpanFull(),
             ]);
@@ -64,7 +65,7 @@ class FormTagResource extends Resource
     public static function getRelations(): array
     {
         return [
-            //
+            RelationManagers\FormsRelationManager::class,
         ];
     }
 

--- a/app/Filament/Forms/Resources/FormTagResource/RelationManagers/FormsRelationManager.php
+++ b/app/Filament/Forms/Resources/FormTagResource/RelationManagers/FormsRelationManager.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Filament\Forms\Resources\FormTagResource\RelationManagers;
+
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class FormsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'forms';
+
+    protected static ?string $recordTitleAttribute = 'form_title';
+
+    protected static ?string $title = 'Forms with this Tag';
+
+    public function form(Form $form): Form
+    {
+        return $form->schema([]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('form_title')
+            ->modifyQueryUsing(function (Builder $query) {
+                return $query->select('forms.*');
+            })
+            ->columns([
+                Tables\Columns\TextColumn::make('form_id')
+                    ->label('Form ID')
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('form_title')
+                    ->label('Title')
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('ministry.short_name')
+                    ->label('Ministry')
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\IconColumn::make('decommissioned')
+                    ->boolean()
+                    ->sortable(),
+            ])
+            ->filters([
+                //
+            ])
+            ->headerActions([
+                Tables\Actions\AttachAction::make()
+                    ->recordSelectSearchColumns(['form_id', 'form_title'])
+                    ->recordTitle(fn($record) => "{$record->form_id} - {$record->form_title}")
+                    ->preloadRecordSelect(),
+            ])
+            ->actions([
+                Tables\Actions\DetachAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DetachBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('forms.form_id');
+    }
+}

--- a/app/Models/FormTag.php
+++ b/app/Models/FormTag.php
@@ -17,6 +17,6 @@ class FormTag extends Model
 
     public function forms(): BelongsToMany
     {
-        return $this->belongsToMany(Form::class, 'form_form_tag');
+        return $this->belongsToMany(Form::class, 'form_form_tags');
     }
 }


### PR DESCRIPTION
## What changes did you make? 

This is a cli tool for adding tags to forms (in bulk)

## Why did you make these changes?

Forms team has requested the bulk tagging of the 300 forms that need to be migrated with a "migration2025" tag. Instead of creating some script or seeder, this is more flexible and I can just run this and pass all the form_id's in the CLI. Could be very useful in the future if we need to do something similar.

Also added a relation manager so we can see the forms that the tag belongs to.

## What alternatives did you consider?

Creating a one time script, but this is more flexible if we need to do it again

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
