### PR TITLE
Consolidate view only roles to "user"

### DIFF
--- a/app/Filament/Admin/Resources/UserResource.php
+++ b/app/Filament/Admin/Resources/UserResource.php
@@ -37,6 +37,10 @@ class UserResource extends Resource
                     ->multiple()
                     ->preload()
                     ->relationship('roles', 'name')
+                    ->default(function () {
+                        $userRole = \Spatie\Permission\Models\Role::where('name', 'user')->first();
+                        return $userRole ? [$userRole->id] : [];
+                    })
             ]);
     }
 

--- a/app/Filament/Admin/Resources/UserResource/Pages/CreateUser.php
+++ b/app/Filament/Admin/Resources/UserResource/Pages/CreateUser.php
@@ -4,10 +4,23 @@ namespace App\Filament\Admin\Resources\UserResource\Pages;
 
 use App\Filament\Admin\Resources\UserResource;
 use Filament\Resources\Pages\CreateRecord;
+use Filament\Actions;
 
 class CreateUser extends CreateRecord
 {
     protected static string $resource = UserResource::class;
+
+    protected function getCreateFormAction(): Actions\Action
+    {
+        return parent::getCreateFormAction()
+            ->submit(null)
+            ->requiresConfirmation()
+            ->modalDescription('An email invitation will be sent to this user.')
+            ->action(function () {
+                $this->closeActionModal();
+                $this->create();
+            });
+    }
 
     protected function afterCreate(): void
     {

--- a/app/Filament/Forms/Resources/BusinessAreaResource.php
+++ b/app/Filament/Forms/Resources/BusinessAreaResource.php
@@ -72,7 +72,7 @@ class BusinessAreaResource extends Resource
                                     'password' => bcrypt($password),
                                     'created_via_business_area' => true,
                                 ]);
-                                $user->assignRole('forms-view-only');
+                                $user->assignRole('user');
 
                                 $user->notify(new \App\Notifications\FormAccountCreatedNotification());
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -40,6 +40,21 @@ class User extends Authenticatable implements FilamentUser
         'api_token',
     ];
 
+    /**
+     * Boot the model.
+     */
+    protected static function boot()
+    {
+        parent::boot();
+
+        // if a user doesn't have a role, give them the user role
+        static::created(function ($user) {
+            if (!$user->hasAnyRole()) {
+                $user->assignRole('user');
+            }
+        });
+    }
+
     public function canAccessPanel(Panel $panel): bool
     {
         //TODO: Make good authentication

--- a/app/Notifications/AccountCreatedNotification.php
+++ b/app/Notifications/AccountCreatedNotification.php
@@ -40,7 +40,7 @@ class AccountCreatedNotification extends Notification
             ->line('Your account has been successfully created.')
             ->line('Here are your login details:')
             ->line('Email: ' . $notifiable->email)
-            ->action('Login to Your Account', URL::to('/login'))
+            ->action('Login to Your Account', URL::to('/forms/login'))
             ->line('Use the "Forgot Password" feature if you need to set your password.')
             ->line('Thank you!');
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -40,24 +40,16 @@ class AppServiceProvider extends ServiceProvider
             return $user->hasRole('bre');
         });
 
-        Gate::define('bre-view-only', function (User $user) {
-            return $user->hasRole('bre-view-only');
+        Gate::define('user', function (User $user) {
+            return $user->hasRole('user');
         });
 
         Gate::define('fodig', function (User $user) {
             return $user->hasRole('fodig');
         });
 
-        Gate::define('fodig-view-only', function (User $user) {
-            return $user->hasRole('fodig-view-only');
-        });
-
         Gate::define('forms', function (User $user) {
             return $user->hasRole('forms');
-        });
-
-        Gate::define('forms-view-only', function (User $user) {
-            return $user->hasRole('forms-view-only');
         });
 
         Gate::define('form-developer', function (User $user) {

--- a/app/Providers/Filament/BrePanelProvider.php
+++ b/app/Providers/Filament/BrePanelProvider.php
@@ -72,7 +72,7 @@ class BrePanelProvider extends PanelProvider
             ])
             ->authMiddleware([
                 Authenticate::class,
-                CheckRole::class . ':bre,bre-view-only,admin',
+                CheckRole::class . ':bre,user,admin',
             ]);
     }
 }

--- a/app/Providers/Filament/FodigPanelProvider.php
+++ b/app/Providers/Filament/FodigPanelProvider.php
@@ -78,7 +78,7 @@ class FodigPanelProvider extends PanelProvider
             ])
             ->authMiddleware([
                 Authenticate::class,
-                CheckRole::class . ':fodig,fodig-view-only,admin',
+                CheckRole::class . ':fodig,user,admin',
             ]);
     }
 }

--- a/app/Providers/Filament/FormsPanelProvider.php
+++ b/app/Providers/Filament/FormsPanelProvider.php
@@ -98,7 +98,7 @@ class FormsPanelProvider extends PanelProvider
             ])
             ->authMiddleware([
                 Authenticate::class,
-                CheckRole::class . ':forms,forms-view-only,admin',
+                CheckRole::class . ':forms,user,admin',
             ]);
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -49,13 +49,6 @@ class UserFactory extends Factory
         });
     }
 
-    public function fodigViewOnly(): static
-    {
-        return $this->afterCreating(function (User $user) {
-            $user->assignRole('fodig-view-only');
-        });
-    }
-
     public function forms(): static
     {
         return $this->afterCreating(function (User $user) {
@@ -63,10 +56,10 @@ class UserFactory extends Factory
         });
     }
 
-    public function formsViewOnly(): static
+    public function userRole(): static
     {
         return $this->afterCreating(function (User $user) {
-            $user->assignRole('forms-view-only');
+            $user->assignRole('user');
         });
     }
 
@@ -74,13 +67,6 @@ class UserFactory extends Factory
     {
         return $this->afterCreating(function (User $user) {
             $user->assignRole('bre');
-        });
-    }
-
-    public function breViewOnly(): static
-    {
-        return $this->afterCreating(function (User $user) {
-            $user->assignRole('bre-view-only');
         });
     }
 

--- a/database/migrations/2025_06_06_231156_consolidate_view_only_roles_to_user_role.php
+++ b/database/migrations/2025_06_06_231156_consolidate_view_only_roles_to_user_role.php
@@ -1,0 +1,80 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Permission\Models\Role;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::transaction(function () {
+            // Create the user role if it doesn't exist yet
+            $userRole = Role::firstOrCreate(['name' => 'user', 'guard_name' => 'web']);
+
+            // Find users with the view-only roles and assign them the user role
+            $viewOnlyRoles = ['fodig-view-only', 'forms-view-only', 'bre-view-only'];
+            foreach ($viewOnlyRoles as $roleName) {
+                try {
+                    $role = Role::where('name', $roleName)->where('guard_name', 'web')->first();
+
+                    if ($role) {
+                        // Get users with this role
+                        $users = User::role($roleName)->get();
+
+                        foreach ($users as $user) {
+                            // Remove the old view-only role
+                            $user->removeRole($roleName);
+                            // Assign the new user role
+                            if (!$user->hasRole('user')) {
+                                $user->assignRole('user');
+                            }
+                        }
+
+                        // Delete the old role
+                        $role->delete();
+                    }
+                } catch (\Exception $e) {
+                    // Log the error but continue with other roles
+                    Log::warning("Error processing role {$roleName}: " . $e->getMessage());
+                }
+            }
+
+            // Find users with no roles and assign them the user role
+            try {
+                $usersWithoutRoles = User::doesntHave('roles')->get();
+
+                foreach ($usersWithoutRoles as $user) {
+                    $user->assignRole('user');
+                }
+            } catch (\Exception $e) {
+                Log::warning("Error assigning user role to users without roles: " . $e->getMessage());
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::transaction(function () {
+            $viewOnlyRoles = ['fodig-view-only', 'forms-view-only', 'bre-view-only'];
+
+            foreach ($viewOnlyRoles as $roleName) {
+                Role::firstOrCreate(['name' => $roleName, 'guard_name' => 'web']);
+            }
+
+            // Note: We don't reassign users back to their original view-only roles
+            // since we don't know which specific view-only role they had originally.
+            // This rollback creates the roles but leaves users with the 'user' role.
+        });
+    }
+};

--- a/database/seeders/PermissionsSeeder.php
+++ b/database/seeders/PermissionsSeeder.php
@@ -170,9 +170,10 @@ class PermissionsSeeder extends Seeder
             'delete BoundarySystem',
         ])->where('guard_name', 'web')->get());
 
-        // Assign fodig-read-only with read only access to fodig resources
-        $fodigReadOnlyRole = Role::firstOrCreate(['name' => 'fodig-view-only']);
-        $fodigReadOnlyRole->syncPermissions(Permission::whereIn('name', [
+        // Assign user role with read-only access to all resources
+        $userRole = Role::firstOrCreate(['name' => 'user']);
+        $userRole->syncPermissions(Permission::whereIn('name', [
+            // FODIG view permissions
             'view-any SiebelApplet',
             'view SiebelApplet',
             'view-any SiebelApplication',
@@ -231,6 +232,56 @@ class PermissionsSeeder extends Seeder
             'view BoundarySystemContact',
             'view-any BoundarySystem',
             'view BoundarySystem',
+            // FORMS view permissions
+            'view-any FormVersion',
+            'view FormVersion',
+            'view-any Form',
+            'view Form',
+            'view-any ValueType',
+            'view ValueType',
+            'view-any UserType',
+            'view UserType',
+            'view-any SelectOptions',
+            'view SelectOptions',
+            'view-any FormTag',
+            'view FormTag',
+            'view-any FormSoftwareSource',
+            'view FormSoftwareSource',
+            'view-any FormRepository',
+            'view FormRepository',
+            'view-any FormReach',
+            'view FormReach',
+            'view-any FormLocation',
+            'view FormLocation',
+            'view-any FormFrequency',
+            'view FormFrequency',
+            'view-any FormField',
+            'view FormField',
+            'view-any FillType',
+            'view FillType',
+            'view-any FieldGroup',
+            'view FieldGroup',
+            'view-any DataType',
+            'view DataType',
+            'view-any BusinessArea',
+            'view BusinessArea',
+            // BRE view permissions
+            'view-any BREField',
+            'view BREField',
+            'view-any BREFieldGroup',
+            'view BREFieldGroup',
+            'view-any BRERule',
+            'view BRERule',
+            'view-any BREValueType',
+            'view BREValueType',
+            'view-any BREICMCDWField',
+            'view BREICMCDWField',
+            'view-any BREValidationType',
+            'view BREValidationType',
+            'view-any BREDataValidation',
+            'view BREDataValidation',
+            'view-any BREDataType',
+            'view BREDataType',
         ])->where('guard_name', 'web')->get());
 
         // Assign forms with full access to forms resources
@@ -315,43 +366,6 @@ class PermissionsSeeder extends Seeder
             'delete BusinessArea',
         ])->where('guard_name', 'web')->get());
 
-        // Assign forms-read-only with ready only access to forms resources
-        $formsReadOnlyRole = Role::firstOrCreate(['name' => 'forms-view-only']);
-        $formsReadOnlyRole->syncPermissions(Permission::whereIn('name', [
-            'view-any FormVersion',
-            'view FormVersion',
-            'view-any Form',
-            'view Form',
-            'view-any ValueType',
-            'view ValueType',
-            'view-any UserType',
-            'view UserType',
-            'view-any SelectOptions',
-            'view SelectOptions',
-            'view-any FormTag',
-            'view FormTag',
-            'view-any FormSoftwareSource',
-            'view FormSoftwareSource',
-            'view-any FormRepository',
-            'view FormRepository',
-            'view-any FormReach',
-            'view FormReach',
-            'view-any FormLocation',
-            'view FormLocation',
-            'view-any FormFrequency',
-            'view FormFrequency',
-            'view-any FormField',
-            'view FormField',
-            'view-any FillType',
-            'view FillType',
-            'view-any FieldGroup',
-            'view FieldGroup',
-            'view-any DataType',
-            'view DataType',
-            'view-any BusinessArea',
-            'view BusinessArea',
-        ])->where('guard_name', 'web')->get());
-
         // Assign bre with access to bre resources
         $breRole = Role::firstOrCreate(['name' => 'bre']);
         $breRole->syncPermissions(Permission::whereIn('name', [
@@ -396,27 +410,6 @@ class PermissionsSeeder extends Seeder
             'update BREDataType',
             'delete BREDataType',
 
-        ])->where('guard_name', 'web')->get());
-
-        // Assign bre-read-only with ready only access to bre resources
-        $breReadOnlyRole = Role::firstOrCreate(['name' => 'bre-view-only']);
-        $breReadOnlyRole->syncPermissions(Permission::whereIn('name', [
-            'view-any BREField',
-            'view BREField',
-            'view-any BREFieldGroup',
-            'view BREFieldGroup',
-            'view-any BRERule',
-            'view BRERule',
-            'view-any BREValueType',
-            'view BREValueType',
-            'view-any BREICMCDWField',
-            'view BREICMCDWField',
-            'view-any BREValidationType',
-            'view BREValidationType',
-            'view-any BREDataValidation',
-            'view BREDataValidation',
-            'view-any BREDataType',
-            'view BREDataType',
         ])->where('guard_name', 'web')->get());
 
         // Role for Form Developers to edit forms

--- a/database/seeders/RolesSeeder.php
+++ b/database/seeders/RolesSeeder.php
@@ -14,9 +14,7 @@ class RolesSeeder extends Seeder
         Role::create(['name' => 'bre']);
         Role::create(['name' => 'fodig']);
         Role::create(['name' => 'forms']);
-        Role::create(['name' => 'bre-view-only']);
-        Role::create(['name' => 'fodig-view-only']);
-        Role::create(['name' => 'forms-view-only']);
+        Role::create(['name' => 'user']);
         Role::create(['name' => 'form-developer']);
     }
 }

--- a/tests/Feature/Auth/RoleAuthorizationTest.php
+++ b/tests/Feature/Auth/RoleAuthorizationTest.php
@@ -65,11 +65,11 @@ describe('Gate Authorization', function () {
             ->and(Gate::allows('admin'))->toBeFalse();
     });
 
-    test('fodig-view-only role can access fodig-view-only gate', function () {
-        $user = createUserWithRole('fodig-view-only');
+    test('user role can access user gate', function () {
+        $user = createUserWithRole('user');
         $this->actingAs($user);
 
-        expect(Gate::allows('fodig-view-only'))->toBeTrue()
+        expect(Gate::allows('user'))->toBeTrue()
             ->and(Gate::allows('fodig'))->toBeFalse()
             ->and(Gate::allows('admin'))->toBeFalse();
     });
@@ -82,28 +82,12 @@ describe('Gate Authorization', function () {
             ->and(Gate::allows('admin'))->toBeFalse();
     });
 
-    test('forms-view-only role can access forms-view-only gate', function () {
-        $user = createUserWithRole('forms-view-only');
-        $this->actingAs($user);
-
-        expect(Gate::allows('forms-view-only'))->toBeTrue()
-            ->and(Gate::allows('forms'))->toBeFalse();
-    });
-
     test('bre role can access bre gate', function () {
         $user = createUserWithRole('bre');
         $this->actingAs($user);
 
         expect(Gate::allows('bre'))->toBeTrue()
             ->and(Gate::allows('admin'))->toBeFalse();
-    });
-
-    test('bre-view-only role can access bre-view-only gate', function () {
-        $user = createUserWithRole('bre-view-only');
-        $this->actingAs($user);
-
-        expect(Gate::allows('bre-view-only'))->toBeTrue()
-            ->and(Gate::allows('bre'))->toBeFalse();
     });
 
     test('form-developer role can access form-developer gate', function () {
@@ -200,10 +184,10 @@ describe('Factory Role States', function () {
         expect($user->hasRole('fodig'))->toBeTrue();
     });
 
-    test('fodigViewOnly factory creates user with fodig-view-only role', function () {
-        $user = User::factory()->fodigViewOnly()->create();
+    test('userRole factory creates user with user role', function () {
+        $user = User::factory()->userRole()->create();
 
-        expect($user->hasRole('fodig-view-only'))->toBeTrue();
+        expect($user->hasRole('user'))->toBeTrue();
     });
 
     test('forms factory creates user with forms role', function () {
@@ -212,22 +196,10 @@ describe('Factory Role States', function () {
         expect($user->hasRole('forms'))->toBeTrue();
     });
 
-    test('formsViewOnly factory creates user with forms-view-only role', function () {
-        $user = User::factory()->formsViewOnly()->create();
-
-        expect($user->hasRole('forms-view-only'))->toBeTrue();
-    });
-
     test('bre factory creates user with bre role', function () {
         $user = User::factory()->bre()->create();
 
         expect($user->hasRole('bre'))->toBeTrue();
-    });
-
-    test('breViewOnly factory creates user with bre-view-only role', function () {
-        $user = User::factory()->breViewOnly()->create();
-
-        expect($user->hasRole('bre-view-only'))->toBeTrue();
     });
 
     test('formDeveloper factory creates user with form-developer role', function () {
@@ -256,12 +228,11 @@ describe('Role Permissions Integration', function () {
         expect($user2->hasRole('fodig'))->toBeTrue();
     });
 
-    test('view-only roles have limited permissions compared to full roles', function () {
-        $fodigUser = createUserWithRole('fodig');
-        $fodigViewOnlyUser = createUserWithRole('fodig-view-only');
+    test('user role has view-only permissions', function () {
+        $fodigViewOnlyUser = createUserWithRole('user');
 
-        expect($fodigUser->hasRole('fodig'))->toBeTrue()
-            ->and($fodigViewOnlyUser->hasRole('fodig-view-only'))->toBeTrue()
+        expect($fodigViewOnlyUser->hasRole('user'))->toBeTrue()
+            ->and($fodigViewOnlyUser->hasRole('user'))->toBeTrue()
             ->and($fodigViewOnlyUser->hasRole('fodig'))->toBeFalse();
     });
 });

--- a/tests/README.md
+++ b/tests/README.md
@@ -54,9 +54,10 @@ User::factory()->unverified()->create();
 ## Supported Roles
 
 - `admin` - Full access
-- `fodig` / `fodig-view-only` - FODIG resources
-- `forms` / `forms-view-only` - Forms resources  
-- `bre` / `bre-view-only` - BRE resources
+- `fodig` - FODIG resources (full access)
+- `forms` - Forms resources (full access)
+- `bre` - BRE resources (full access)
+- `user` - Read-only access to all resources
 - `form-developer` - Form development
 
 ## How-To Guide

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -71,11 +71,9 @@ abstract class TestCase extends BaseTestCase
         return [
             'admin' => $this->createUserWithRole('admin'),
             'fodig' => $this->createUserWithRole('fodig'),
-            'fodig_view_only' => $this->createUserWithRole('fodig-view-only'),
+            'user' => $this->createUserWithRole('user'),
             'forms' => $this->createUserWithRole('forms'),
-            'forms_view_only' => $this->createUserWithRole('forms-view-only'),
             'bre' => $this->createUserWithRole('bre'),
-            'bre_view_only' => $this->createUserWithRole('bre-view-only'),
             'form_developer' => $this->createUserWithRole('form-developer'),
             'multiple_roles' => $this->createUserWithRole(['fodig', 'forms']),
             'no_role' => User::factory()->create()
@@ -90,11 +88,9 @@ abstract class TestCase extends BaseTestCase
         $roles = [
             'admin',
             'fodig',
-            'fodig-view-only',
+            'user',
             'forms',
-            'forms-view-only',
             'bre',
-            'bre-view-only',
             'form-developer'
         ];
 


### PR DESCRIPTION
## What changes did you make? 

Consolidates
- forms-view-only
- bre-view-only
- fodig-view-only

into the 'user' role.

There are updates to the gates and panels to handle this. The migration does 2 things:
- goes through all users who have the view only role and gives them the user role
- goes through all users without a role, and gives them the user role

You will need to run:
```
sail artisan migrate
sail artisan db:seed --class=PermissionsSeeder
```

## Why did you make these changes?

To simplify our RBAC system instead of having 3 different view only users we are defining one "user" role which will be a catch all user that has view only access to all resources.

## What alternatives did you consider?

Removing the view only role all together, but we want to keep the flexibility in the future for our "users" in the event we need to expand the RBAC setup.

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
