### PR TITLE
Add reverb worker to helm deployment

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: klamm-app
-description: A Helm chart for deploing klamm
+description: A Helm chart for deploying klamm
 version: 0.1.0
 appVersion: "1.0"

--- a/helm/templates/queue-deployment.yaml
+++ b/helm/templates/queue-deployment.yaml
@@ -62,6 +62,11 @@ spec:
                 secretKeyRef:
                   name: app-secrets
                   key: MAIL_PORT
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: klamm-cache-redis
+                  key: redis-password
           volumeMounts:
             - name: storage-volume
               mountPath: /var/www/storage

--- a/helm/templates/reverb-deployment.yaml
+++ b/helm/templates/reverb-deployment.yaml
@@ -1,27 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: klamm-app
+  name: klamm-reverb-worker
   labels:
-    app.kubernetes.io/name: klamm-app
+    app.kubernetes.io/name: klamm-reverb-worker
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.reverbWorker.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: klamm-app
+      app.kubernetes.io/name: klamm-reverb-worker
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: klamm-app
+        app.kubernetes.io/name: klamm-reverb-worker
     spec:
       containers:
-        - name: klamm-app
+        - name: reverb-worker
           image: "{{ .Values.image.tag }}"
-          ports:
-            - containerPort: 8080
-          volumeMounts:
-            - name: storage-volume
-              mountPath: /var/www/storage
+          command: ["php", "/var/www/artisan", "reverb:start", "--host=0.0.0.0"]
           envFrom:
             - secretRef:
                 name: app-secrets
@@ -66,21 +62,32 @@ spec:
                 secretKeyRef:
                   name: app-secrets
                   key: MAIL_PORT
+            - name: APP_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: REVERB_APP_KEY
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: klamm-cache-redis
                   key: redis-password
+          volumeMounts:
+            - name: storage-volume
+              mountPath: /var/www/storage
           resources:
             limits:
-              cpu: {{ .Values.resources.limits.cpu }}
-              memory: {{ .Values.resources.limits.memory }}
+              cpu: {{ .Values.reverbWorker.resources.limits.cpu }}
+              memory: {{ .Values.reverbWorker.resources.limits.memory }}
             requests:
-              cpu: {{ .Values.resources.requests.cpu }}
-              memory: {{ .Values.resources.requests.memory }}
+              cpu: {{ .Values.reverbWorker.resources.requests.cpu }}
+              memory: {{ .Values.reverbWorker.resources.requests.memory }}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 6001
+              name: reverb
       volumes:
         - name: storage-volume
           persistentVolumeClaim:

--- a/helm/templates/reverb-service.yaml
+++ b/helm/templates/reverb-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: reverb-service
+  labels:
+    app.kubernetes.io/name: reverb-service
+spec:
+  selector:
+    app.kubernetes.io/name: klamm-reverb-worker
+  ports:
+    - name: reverb
+      protocol: TCP
+      port: 6001
+      targetPort: 6001

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -16,13 +16,24 @@ resources:
     memory: "1Gi"
 
 queueWorker:
+  replicaCount: 1
   resources:
     limits:
-      cpu: "200m"
-      memory: "256Mi"
-    requests:
-      cpu: "100m"
+      cpu: "50m"
       memory: "128Mi"
+    requests:
+      cpu: "25m"
+      memory: "64Mi"
+
+reverbWorker:
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: "50m"
+      memory: "128Mi"
+    requests:
+      cpu: "25m"
+      memory: "64Mi"
 
 pvc:
   storage: "100Mi"


### PR DESCRIPTION
## What changes did you make? 

Add deployment for consistent implementation of reverb websockets and live preview functionality.

## Why did you make these changes?

Required to enable automatic updates of deployment, and keep reverb worker up to date with changes to klamm image.

## What alternatives did you consider?

Individual deployment, but would not be flexible and up-to-date with current implementation of queue worker.

### Checklist

- [x] **I have assigned at least one reviewer**
