### PR TITLE
Fix salutation duplication in email notifications.

### DIFF
--- a/app/Notifications/ApprovalDecisionNotification.php
+++ b/app/Notifications/ApprovalDecisionNotification.php
@@ -103,7 +103,7 @@ class ApprovalDecisionNotification extends Notification
                     ->line(new HtmlString($decisionDetails))
                     ->action('Review decision details', $viewUrl)
                     ->line('Regards,')
-                    ->line('**Forms Modernization Team**')
+                    ->salutation('**Forms Modernization Team**')
                     ->render(),
             ]);
     }

--- a/app/Notifications/ApprovalDecisionReviewerNotification.php
+++ b/app/Notifications/ApprovalDecisionReviewerNotification.php
@@ -100,7 +100,7 @@ class ApprovalDecisionReviewerNotification extends Notification
                     ->line("**Version:** " . ($approval->formVersion->version_number ?? 'N/A'))
                     ->line(new \Illuminate\Support\HtmlString($decisionDetails))
                     ->line('Regards,')
-                    ->line('**Forms Modernization Team**')
+                    ->salutation('**Forms Modernization Team**')
                     ->render()
             ]);
     }

--- a/app/Notifications/ApprovalRequestNotification.php
+++ b/app/Notifications/ApprovalRequestNotification.php
@@ -77,8 +77,7 @@ class ApprovalRequestNotification extends Notification
                     ->line('Thanks for your collaboration.')
                     ->line('')
                     ->line('Regards,')
-                    ->line('')
-                    ->line('**Forms Modernization Team**')
+                    ->salutation('**Forms Modernization Team**')
                     ->render()
             ]);
     }

--- a/app/Notifications/ApprovalRequestReminderNotification.php
+++ b/app/Notifications/ApprovalRequestReminderNotification.php
@@ -67,6 +67,8 @@ class ApprovalRequestReminderNotification extends Notification
                     ->when(!$isInternal, function ($mail) {
                         return $mail->line('*Note: This is a secure link that is unique to you. Please do not share this link with others.*');
                     })
+                    ->line('Regards,')
+                    ->salutation('**Forms Modernization Team**')
                     ->render()
             ]);
     }

--- a/app/Notifications/CancellationNotification.php
+++ b/app/Notifications/CancellationNotification.php
@@ -61,6 +61,8 @@ class CancellationNotification extends Notification
                             return $mail->line('**Original Request Note:** ' . $this->approvalRequest->requester_note);
                         })
                         ->line('The form has been returned to draft status and can be modified if needed.')
+                        ->line('Regards,')
+                        ->salutation('**Forms Modernization Team**')
                         ->render()
                 ]);
         } else {
@@ -87,6 +89,8 @@ class CancellationNotification extends Notification
                             return $mail->line('**Original Request Note:** ' . $this->approvalRequest->requester_note);
                         })
                         ->line('No further action is required from you.')
+                        ->line('Regards,')
+                        ->salutation('**Forms Modernization Team**')
                         ->render()
                 ]);
         }


### PR DESCRIPTION
## What changes did you make? 

Minor bugfix to remove duplicate salutations using default app name.

### Checklist

- [x] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
