### PR TITLE
Remove klamm email

### DIFF
--- a/app/Notifications/ApprovalRequestNotification.php
+++ b/app/Notifications/ApprovalRequestNotification.php
@@ -72,7 +72,6 @@ class ApprovalRequestNotification extends Notification
                     ->when(!$isInternal, function ($mail) {
                         return $mail->line('*Note: This is a secure link that is unique to you. Please do not share this link with others.*');
                     })
-                    ->line('If you have any issue accessing the updated form, please email us directly at Klamm@gov.bc.ca.')
                     ->line('')
                     ->line('Thanks for your collaboration.')
                     ->line('')


### PR DESCRIPTION
## What changes did you make? 

Removed the line for the Klamm@gov.bc.ca email

## Why did you make these changes?

We currently do not have access to an email to use for this. When we do we can update the email templates.

## What alternatives did you consider?

I was thinking we could use an alternative but there isn't a generic Forms Team email and I think adding Rob's email (even if pulled from a CONTACT_EMAIL env) wouldn't be a good solution for now. 

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
