### PR TITLE
update dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,28 @@ updates:
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "deps"
     open-pull-requests-limit: 5
     target-branch: "dev"
+    versioning-strategy: "increase"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       - dependency-name: "laravel/framework"
         versions: ["^11.0"]
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+    allow:
+      - dependency-type: "security-updates"
+      - dependency-type: "version-update:semver-major"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,4 @@ updates:
       - dependency-name: "laravel/framework"
         versions: ["^11.0"]
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
-    allow:
-      - dependency-type: "security-updates"
-      - dependency-type: "version-update:semver-major"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]


### PR DESCRIPTION
## What changes did you make? 

Makes dependabot only open PRs for security updates and major releases

## Why did you make these changes?

Dependabot was opening too many PRs for minor versions and unnecessary updates

## What alternatives did you consider?

No

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
