### PR TITLE
Feature/additional attributes rendering

### DIFF
--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/BuildFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/BuildFormVersion.php
@@ -353,6 +353,7 @@ class BuildFormVersion extends Page implements HasForms
                                     $set('description', $template->description);
                                     $set('help_text', $template->help_text);
                                     $set('elementable_type', $template->elementable_type);
+                                    $set('is_required', $template->is_required);
                                     $set('visible_web', $template->visible_web);
                                     $set('visible_pdf', $template->visible_pdf);
                                     $set('is_template', false); // New element should not be a template by default
@@ -392,8 +393,11 @@ class BuildFormVersion extends Page implements HasForms
                                 ->rows(3),
                             \Filament\Forms\Components\TextInput::make('help_text')
                                 ->maxLength(500),
-                            \Filament\Forms\Components\Grid::make(3)
+                            \Filament\Forms\Components\Grid::make(4)
                                 ->schema([
+                                    \Filament\Forms\Components\Toggle::make('is_required')
+                                        ->label('Is Required')
+                                        ->default(false),
                                     \Filament\Forms\Components\Toggle::make('visible_web')
                                         ->label('Visible on Web')
                                         ->default(true),

--- a/app/Livewire/FormElementTreeBuilder.php
+++ b/app/Livewire/FormElementTreeBuilder.php
@@ -118,8 +118,11 @@ class FormElementTreeBuilder extends BaseWidget
                                 ->rows(3),
                             TextInput::make('help_text')
                                 ->maxLength(500),
-                            \Filament\Forms\Components\Grid::make(3)
+                            \Filament\Forms\Components\Grid::make(4)
                                 ->schema([
+                                    Toggle::make('is_required')
+                                        ->label('Is Required')
+                                        ->default(false),
                                     Toggle::make('visible_web')
                                         ->label('Visible on Web')
                                         ->default(true),
@@ -290,8 +293,11 @@ class FormElementTreeBuilder extends BaseWidget
                                 ->rows(3),
                             TextInput::make('help_text')
                                 ->disabled(),
-                            \Filament\Forms\Components\Grid::make(3)
+                            \Filament\Forms\Components\Grid::make(4)
                                 ->schema([
+                                    Toggle::make('is_required')
+                                        ->label('Is Required')
+                                        ->default(false),
                                     Toggle::make('visible_web')
                                         ->label('Visible on Web')
                                         ->disabled(),

--- a/app/Models/FormBuilding/ButtonInputFormElement.php
+++ b/app/Models/FormBuilding/ButtonInputFormElement.php
@@ -62,9 +62,13 @@ class ButtonInputFormElement extends Model
     public static function getButtonTypes(): array
     {
         return [
-            'submit' => 'Submit',
-            'reset' => 'Reset',
-            'button' => 'Button',
+            'primary' => 'Primary',
+            'secondary' => 'Secondary',
+            'tertiary' => 'Tertiary',
+            'danger' => 'Danger',
+            'danger--tertiary' => 'Danger Tertiary',
+            'danger--ghost' => 'Danger Ghost',
+            'ghost' => 'Ghost',
         ];
     }
 }

--- a/app/Models/FormBuilding/FormElement.php
+++ b/app/Models/FormBuilding/FormElement.php
@@ -27,6 +27,7 @@ class FormElement extends Model
         'help_text',
         'calculated_value',
         'is_read_only',
+        'is_required',
         'save_on_submit',
         'visible_web',
         'visible_pdf',
@@ -37,6 +38,7 @@ class FormElement extends Model
         'order' => 'integer',
         'parent_id' => 'integer',
         'is_read_only' => 'boolean',
+        'is_required' => 'boolean',
         'save_on_submit' => 'boolean',
         'visible_web' => 'boolean',
         'visible_pdf' => 'boolean',
@@ -185,6 +187,11 @@ class FormElement extends Model
     public function scopeReadOnly($query)
     {
         return $query->where('is_read_only', true);
+    }
+
+    public function scopeIsRequired($query)
+    {
+        return $query->where('is_required', true);
     }
 
     /**

--- a/database/migrations/2025_07_09_120000_update_button_types_in_button_input_form_elements_table.php
+++ b/database/migrations/2025_07_09_120000_update_button_types_in_button_input_form_elements_table.php
@@ -1,0 +1,78 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    protected $table = 'button_input_form_elements';
+    protected $column = 'button_type';
+    protected $enumValues = [
+        'primary',
+        'secondary',
+        'danger',
+        'ghost',
+        'danger--primary',
+        'danger--ghost',
+        'danger--tertiary',
+        'tertiary',
+    ];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Add enum column with new set and migrate values
+        Schema::table($this->table, function (Blueprint $table) {
+            $table->enum("{$this->column}_new", $this->enumValues)
+                ->default('ghost')
+                ->after($this->column);
+        });
+
+        // Copy over existing values (submit, reset, button) into closest new values
+        DB::table($this->table)->update([
+            "{$this->column}_new" => DB::raw("CASE
+                WHEN {$this->column} = 'submit' THEN 'primary'
+                WHEN {$this->column} = 'reset' THEN 'secondary'
+                WHEN {$this->column} = 'button' THEN 'ghost'
+                ELSE 'ghost' END")
+        ]);
+
+        // Drop old column, rename new to original
+        Schema::table($this->table, function (Blueprint $table) {
+            $table->dropColumn($this->column);
+            $table->renameColumn("{$this->column}_new", $this->column);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Recreate old enum with original values
+        Schema::table($this->table, function (Blueprint $table) {
+            $table->enum("{$this->column}_old", [
+                'submit',
+                'reset',
+                'button',
+            ])->default('button')->after($this->column);
+        });
+
+        // Map new values back to original ones
+        DB::table($this->table)->update([
+            "{$this->column}_old" => DB::raw("CASE
+                WHEN {$this->column} = 'primary' THEN 'submit'
+                WHEN {$this->column} = 'secondary' THEN 'reset'
+                ELSE 'button' END")
+        ]);
+
+        Schema::table($this->table, function (Blueprint $table) {
+            $table->dropColumn($this->column);
+            $table->renameColumn("{$this->column}_old", $this->column);
+        });
+    }
+};

--- a/database/migrations/2025_07_09_130000_add_is_required_to_form_elements_table.php
+++ b/database/migrations/2025_07_09_130000_add_is_required_to_form_elements_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('form_elements', function (Blueprint $table) {
+            $table->boolean('is_required')->default(false)->after('is_read_only');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('form_elements', function (Blueprint $table) {
+            $table->dropColumn('is_required');
+        });
+    }
+};


### PR DESCRIPTION
## What changes did you make? 
- added is_required field
- update button types to match available carbon react types
- update attribute generation in version 1.0 schema, so that it matches kiln expected values
- additional attributes are handled through a kiln-specific update here: https://github.com/kiiskila-bcgov/klamm-kiln/pull/13
- Containers of type 'section' and 'page' no longer render with 'common-container' styling. Field-group containers retain infinitely nesting styles. If a change is required for this, that would be handled on kiln's side. 

## Why did you make these changes?

Required for full rendering of validations/requirements in Kiln.

## What alternatives did you consider?

Additional, in-depth updates to kiln considered, since kiln as implemented was not handling full breadth of element attributes.
