### PR TITLE
Enable repeaters and ministry logo.

### DIFF
--- a/app/Services/FormVersionJsonService.php
+++ b/app/Services/FormVersionJsonService.php
@@ -68,6 +68,7 @@ class FormVersionJsonService
             'form_id' => $formVersion->form->form_id ?? '',
             'deployed_to' => null,
             'footer' => $formVersion->footer,
+            'ministry_id' => $formVersion->form->ministry_id ?? null,
             'dataSources' => $this->getDataSources($formVersion),
             'data' => [
                 'styles' => $this->getStyles($formVersion),
@@ -240,18 +241,31 @@ class FormVersionJsonService
             'id' => $element->uuid,
         ];
 
-        // Handle different element types
-        if ($elementType === 'container') {
+        // Handle repeatable containers as groups FIRST, before other container logic
+        if ($elementType === 'container' && $element->elementable?->is_repeatable) {
+            return $this->transformRepeatableContainerAsGroup($element, $elementData);
+        }
+        // Handle non-repeatable containers
+        elseif ($elementType === 'container' && !$element->elementable?->is_repeatable) {
             return $this->transformContainerElement($element, $elementData);
-        } elseif ($this->isGroupElement($elementType)) {
+        }
+        // Handle explicit group elements
+        elseif ($this->isGroupElement($elementType)) {
             return $this->transformGroupElement($element, $elementData);
-        } else {
+        }
+        // Handle all other standard elements
+        else {
             return $this->transformStandardElement($element, $elementData, $elementType);
         }
     }
 
     protected function transformContainerElement(FormElement $element, array $elementData): array
     {
+        // Check if this container is repeatable - if so, transform it as a group
+        if ($element->elementable?->is_repeatable) {
+            return $this->transformRepeatableContainerAsGroup($element, $elementData);
+        }
+
         $elementData['containerId'] = (string)($element->id ?? '');
         $elementData['clear_button'] = false;
         $elementData['codeContext'] = [
@@ -259,6 +273,9 @@ class FormVersionJsonService
         ];
         $elementData['attributes'] = $this->remapAttributes($this->getElementAttributes($element));
         $elementData['label'] = $elementData['attributes']['legend'] ?? null;
+
+        $elementData['repeater'] = false;
+        $elementData['repeaterLabel'] = null;
 
         $elementData['pdfStyles'] = [
             'display' => $element->visible_pdf ? null : 'none',
@@ -297,15 +314,103 @@ class FormVersionJsonService
         return $elementData;
     }
 
-    protected function transformGroupElement(FormElement $element, array $elementData): array
+    protected function transformRepeatableContainerAsGroup(FormElement $element, array $elementData): array
     {
-        $elementData['label'] = $element->name;
+        // Transform repeatable container to group format for renderer compatibility
+        $elementData['type'] = 'group'; // Override type to group
+        $elementData['label'] = $element->label ?? $element->name;
         $elementData['groupId'] = (string)($element->id ?? '1');
-        $elementData['repeater'] = false;
-        $elementData['clear_button'] = false;
+        $elementData['repeater'] = true; // Always true for repeatable containers
+        $elementData['repeaterLabel'] = $element->label ?? $element->name;
+        $elementData['repeaterItemLabel'] = $element->elementable?->repeater_item_label ?? ($element->label ?? $element->name);
+        $elementData['clear_button'] = $element->elementable?->clear_button ?? false;
         $elementData['codeContext'] = [
             'name' => $this->generateCodeContextName($element->name ?? 'group')
         ];
+
+        // Add styles
+        $elementData['pdfStyles'] = [
+            'display' => $element->visible_pdf ? null : 'none',
+            'readOnly' => (bool)$element->is_read_only,
+        ];
+        $elementData['webStyles'] = [
+            'display' => $element->visible_web ? null : 'none',
+            'readOnly' => (bool)$element->is_read_only,
+        ];
+
+        // Add validation rules
+        $validation = $this->transformValidationRules($element);
+        if (!empty($validation)) {
+            $elementData['validation'] = $validation;
+        }
+
+        // Add conditions
+        $conditions = $this->transformConditions($element);
+        if (!empty($conditions)) {
+            $elementData['conditions'] = $conditions;
+        }
+
+        // Get children and transform them as group fields
+        $children = FormElement::where('parent_id', $element->id)
+            ->orderBy('order')
+            ->with(['elementable', 'dataBindings.formDataSource'])
+            ->get();
+
+        $fields = [];
+        if ($children->count() > 0) {
+            $fields = $children->map(function (FormElement $child) {
+                return $this->transformElementToPreMigrationFormat($child);
+            })->toArray();
+        }
+
+        // Create groupItems structure expected by the renderer
+        $elementData['groupItems'] = [
+            ['fields' => $fields]
+        ];
+
+        // Add container-specific attributes
+        $attributes = $this->getElementAttributes($element);
+        if (!empty($attributes)) {
+            $elementData['attributes'] = $this->remapAttributes($attributes);
+        }
+
+        $this->addElementStyles($elementData, $element);
+        return $elementData;
+    }
+
+    protected function transformGroupElement(FormElement $element, array $elementData): array
+    {
+        $elementData['label'] = $element->label ?? $element->name;
+        $elementData['groupId'] = (string)($element->id ?? '1');
+        $elementData['repeater'] = $element->elementable?->is_repeatable ?? false;
+        $elementData['repeaterLabel'] = $element->label ?? $element->name;
+        $elementData['repeaterItemLabel'] = $element->elementable?->repeater_item_label ?? ($element->label ?? $element->name);
+        $elementData['clear_button'] = $element->elementable?->clear_button ?? false;
+        $elementData['codeContext'] = [
+            'name' => $this->generateCodeContextName($element->name ?? 'group')
+        ];
+
+        // Add styles
+        $elementData['pdfStyles'] = [
+            'display' => $element->visible_pdf ? null : 'none',
+            'readOnly' => (bool)$element->is_read_only,
+        ];
+        $elementData['webStyles'] = [
+            'display' => $element->visible_web ? null : 'none',
+            'readOnly' => (bool)$element->is_read_only,
+        ];
+
+        // Add validation rules
+        $validation = $this->transformValidationRules($element);
+        if (!empty($validation)) {
+            $elementData['validation'] = $validation;
+        }
+
+        // Add conditions
+        $conditions = $this->transformConditions($element);
+        if (!empty($conditions)) {
+            $elementData['conditions'] = $conditions;
+        }
 
         // Get children and group them into fields
         $children = FormElement::where('parent_id', $element->id)
@@ -323,6 +428,12 @@ class FormVersionJsonService
         $elementData['groupItems'] = [
             ['fields' => $fields]
         ];
+
+        // Add group-specific attributes
+        $attributes = $this->getElementAttributes($element);
+        if (!empty($attributes)) {
+            $elementData['attributes'] = $this->remapAttributes($attributes);
+        }
 
         $this->addElementStyles($elementData, $element);
         return $elementData;


### PR DESCRIPTION
## What changes did you make? 

- Enable conversion of containers with repeating logic to groups for render in pre-migration format.
- Re-enable export of ministry_id for form so that logo renders again.
