### PR TITLE
make UUID unique to each form version

### DIFF
--- a/app/Filament/Forms/Resources/FormVersionResource.php
+++ b/app/Filament/Forms/Resources/FormVersionResource.php
@@ -161,8 +161,7 @@ class FormVersionResource extends Resource
                         // Duplicate all FormElements and map new to old
                         $oldToNewElementMap = [];
                         foreach ($record->formElements()->orderBy('order')->get() as $element) {
-                            $newElement = $element->replicate(['id', 'uuid', 'form_version_id', 'parent_id', 'created_at', 'updated_at']);
-                            $newElement->uuid = (string) Str::uuid();
+                            $newElement = $element->replicate(['id', 'form_version_id', 'parent_id', 'created_at', 'updated_at']);
                             $newElement->form_version_id = $newVersion->id;
                             $newElement->parent_id = null;
                             $newElement->save();

--- a/database/migrations/2025_07_10_235814_modify_form_elements_uuid_constraint.php
+++ b/database/migrations/2025_07_10_235814_modify_form_elements_uuid_constraint.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('form_elements', function (Blueprint $table) {
+            // Drop the existing unique constraint on uuid
+            $table->dropUnique(['uuid']);
+
+            // Add a composite unique constraint on uuid and form_version_id
+            $table->unique(['uuid', 'form_version_id'], 'form_elements_uuid_form_version_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('form_elements', function (Blueprint $table) {
+            // Drop the composite unique constraint
+            $table->dropUnique('form_elements_uuid_form_version_unique');
+
+            // Restore the original unique constraint on uuid
+            $table->unique('uuid');
+        });
+    }
+};


### PR DESCRIPTION
## What changes did you make? 

Makes UUIDs unique per form version
Makes UUIDs duplicate when you duplicate a form version

## Why did you make these changes?

The duplication is important since we use those UUIDs in the styles and data bindings. So we need to keep them consistent between different versions of the same form.

## What alternatives did you consider?

N/A

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
