### PR TITLE
allow custom repeater labels

### DIFF
--- a/app/Models/FormBuilding/ContainerFormElement.php
+++ b/app/Models/FormBuilding/ContainerFormElement.php
@@ -15,6 +15,7 @@ class ContainerFormElement extends Model
         'collapsible',
         'collapsed_by_default',
         'is_repeatable',
+        'repeater_item_label',
         'legend',
     ];
 
@@ -60,7 +61,13 @@ class ContainerFormElement extends Model
                 ->label('Repeatable')
                 ->helperText('Allow users to add multiple instances of this container')
                 ->default(false)
+                ->live()
                 ->disabled($disabled),
+            \Filament\Forms\Components\TextInput::make('elementable_data.repeater_item_label')
+                ->label('Repeater Item Label')
+                ->helperText('Label for individual repeater items (e.g., "Item", "Entry")')
+                ->disabled($disabled)
+                ->visible(fn(callable $get) => $get('elementable_data.is_repeatable')),
         ];
     }
 
@@ -82,6 +89,7 @@ class ContainerFormElement extends Model
             'collapsible' =>         $this->collapsible,
             'collapsed_by_default' =>         $this->collapsed_by_default,
             'is_repeatable' =>         $this->is_repeatable,
+            'repeater_item_label' =>         $this->repeater_item_label,
             'legend' =>         $this->legend,
         ];
     }

--- a/app/Services/FormVersionJsonService.php
+++ b/app/Services/FormVersionJsonService.php
@@ -349,7 +349,7 @@ class FormVersionJsonService
         $elementData['groupId'] = (string)($element->id ?? '1');
         $elementData['repeater'] = true; // Always true for repeatable containers
         $elementData['repeaterLabel'] = $element->elementable?->legend ?? null;
-        $elementData['repeaterItemLabel'] = $element->elementable?->repeater_item_label ?? ($element->elementable?->legend ?? null);
+        $elementData['repeaterItemLabel'] = $element->elementable?->repeater_item_label;
         $elementData['clear_button'] = $element->elementable?->clear_button ?? false;
         $elementData['codeContext'] = [
             'name' => $this->generateCodeContextName($element->name ?? 'group')
@@ -411,7 +411,7 @@ class FormVersionJsonService
         $elementData['groupId'] = (string)($element->id ?? '1');
         $elementData['repeater'] = $element->elementable?->is_repeatable ?? false;
         $elementData['repeaterLabel'] = $element->elementable?->legend ?? null;
-        $elementData['repeaterItemLabel'] = $element->elementable?->repeater_item_label ?? ($element->elementable?->legend ?? null);
+        $elementData['repeaterItemLabel'] = $element->elementable?->repeater_item_label;
         $elementData['clear_button'] = $element->elementable?->clear_button ?? false;
         $elementData['codeContext'] = [
             'name' => $this->generateCodeContextName($element->name ?? 'group')

--- a/database/migrations/2025_07_15_063520_add_repeater_item_label_to_container_form_elements_table.php
+++ b/database/migrations/2025_07_15_063520_add_repeater_item_label_to_container_form_elements_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('container_form_elements', function (Blueprint $table) {
+            $table->string('repeater_item_label')->nullable()->after('is_repeatable');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('container_form_elements', function (Blueprint $table) {
+            $table->dropColumn('repeater_item_label');
+        });
+    }
+};


### PR DESCRIPTION
## What changes did you make? 

Adds custom repeater labels.

## Why did you make these changes?

Since you might have a legend for the container but each element inside it needs a short name like "Child 1", "Child 2", etc

## What alternatives did you consider?

N/A

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
