### PR TITLE
Feature/unify form element schemas

### DIFF
--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/BuildFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/BuildFormVersion.php
@@ -8,11 +8,11 @@ use App\Models\FormBuilding\StyleSheet;
 use App\Models\FormBuilding\FormScript;
 use App\Models\FormBuilding\FormElement;
 use App\Models\FormBuilding\FormElementTag;
-use App\Models\FormMetadata\FormDataSource;
 use App\Jobs\GenerateFormVersionJsonJob;
 use App\Events\FormVersionUpdateEvent;
 use App\Filament\Forms\Resources\FormResource;
 use App\Helpers\DataBindingsHelper;
+use App\Helpers\ElementPropertiesHelper;
 use Filament\Resources\Pages\Page;
 use Filament\Forms\Form;
 use Filament\Actions;
@@ -23,7 +23,6 @@ use Filament\Forms\Contracts\HasForms;
 use Filament\Forms;
 use Filament\Resources\Pages\Concerns\InteractsWithRecord;
 use Illuminate\Support\Facades\Auth;
-
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\HtmlString;
 use Filament\Forms\Components\Placeholder;
@@ -483,15 +482,9 @@ class BuildFormVersion extends Page implements HasForms
                     \Filament\Forms\Components\Tabs\Tab::make('Element Properties')
                         ->icon('heroicon-o-adjustments-horizontal')
                         ->schema(function (callable $get) {
-                            $elementType = $get('elementable_type');
-                            if (!$elementType) {
-                                return [
-                                    \Filament\Forms\Components\Placeholder::make('select_element_type')
-                                        ->label('')
-                                        ->content('Please select an element type in the General tab first.')
-                                ];
-                            }
-                            return $this->getElementSpecificSchema($elementType);
+                            return ElementPropertiesHelper::getCreateSchema(
+                                $get('elementable_type')
+                            );
                         }),
                     \Filament\Forms\Components\Tabs\Tab::make('Data Bindings')
                         ->icon('heroicon-o-link')
@@ -506,20 +499,7 @@ class BuildFormVersion extends Page implements HasForms
         ];
     }
 
-    protected function getElementSpecificSchema(string $elementType): array
-    {
-        // Check if the element type class exists and has the getFilamentSchema method
-        if (class_exists($elementType) && method_exists($elementType, 'getFilamentSchema')) {
-            return $elementType::getFilamentSchema(false);
-        }
 
-        // Fallback for element types that don't have schema defined yet
-        return [
-            \Filament\Forms\Components\Placeholder::make('no_specific_properties')
-                ->label('')
-                ->content('This element type has no specific properties defined yet.')
-        ];
-    }
 
     protected function mutateFormDataBeforeFill(array $data): array
     {

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/BuildFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/BuildFormVersion.php
@@ -134,8 +134,9 @@ class BuildFormVersion extends Page implements HasForms
                         }
 
                         // Filter out null values from elementable data to let model defaults apply
+                        // Keep false values as they are valid boolean values
                         $elementableData = array_filter($elementableData, function ($value) {
-                            return $value !== null;
+                            return $value !== null && $value !== '';
                         });
 
                         // Set source_element_id if created from template

--- a/app/Helpers/DataBindingsHelper.php
+++ b/app/Helpers/DataBindingsHelper.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace App\Helpers;
+
+use App\Models\FormBuilding\FormVersion;
+use App\Models\FormMetadata\FormDataSource;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Placeholder;
+
+class DataBindingsHelper
+{
+    /**
+     * Get the Data Bindings tab schema for form elements
+     *
+     * @param FormVersion|null $formVersion The form version instance
+     * @param int|null $formVersionId The form version ID if no instance is available
+     * @param callable|null $shouldShowTooltipsCallback Callback to determine if tooltips should be shown
+     * @param bool $disabled Whether the schema should be disabled (for view mode)
+     * @param bool $useRelationship Whether to use the relationship() method on the repeater
+     * @return array The schema array
+     */
+    public static function getDataBindingsSchema(
+        ?FormVersion $formVersion = null,
+        ?int $formVersionId = null,
+        ?callable $shouldShowTooltipsCallback = null,
+        bool $disabled = false,
+        bool $useRelationship = false
+    ): array {
+        // Get form version instance if not provided
+        if (!$formVersion && $formVersionId) {
+            $formVersion = FormVersion::find($formVersionId);
+        }
+
+        // Handle case where no form version is available
+        if (!$formVersion) {
+            return [
+                Placeholder::make('no_form_version')
+                    ->label('')
+                    ->content('Form version not available.')
+            ];
+        }
+
+        // Handle case where no data sources are assigned
+        if ($formVersion->formDataSources->isEmpty()) {
+            $content = $disabled
+                ? 'No Data Sources are assigned to this Form Version.'
+                : 'Please add Data Sources in the Form Version before adding Data Bindings.';
+
+            $placeholder = Placeholder::make('no_data_sources')
+                ->label('')
+                ->content($content);
+
+            if (!$disabled) {
+                $placeholder->extraAttributes(['class' => 'text-warning']);
+            }
+
+            return [$placeholder];
+        }
+
+        // Build the repeater schema
+        $repeater = Repeater::make('dataBindings')
+            ->label('Data Bindings')
+            ->schema([
+                Select::make('form_data_source_id')
+                    ->label('Data Source')
+                    ->when($shouldShowTooltipsCallback && $shouldShowTooltipsCallback(), function ($component) {
+                        return $component->hintIcon('heroicon-m-question-mark-circle', tooltip: 'The ICM Entity this data binding uses');
+                    })
+                    ->options(function () use ($formVersion) {
+                        return $formVersion->formDataSources->pluck('name', 'id')->toArray();
+                    })
+                    ->searchable()
+                    ->preload()
+                    ->required(!$disabled)
+                    ->disabled($disabled)
+                    ->live(onBlur: true),
+                TextInput::make('path')
+                    ->label('Data Path')
+                    ->when($shouldShowTooltipsCallback && $shouldShowTooltipsCallback(), function ($component) {
+                        return $component->hintIcon('heroicon-m-question-mark-circle', tooltip: 'The full string referencing the ICM data');
+                    })
+                    ->required(!$disabled)
+                    ->disabled($disabled)
+                    ->placeholder("$.['Contact'].['Birth Date']")
+                    ->helperText('The path to the data field in the selected data source'),
+            ])
+            ->orderColumn('order')
+            ->itemLabel(
+                fn(array $state): ?string =>
+                isset($state['form_data_source_id']) && isset($state['path'])
+                    ? (FormDataSource::find($state['form_data_source_id'])?->name ?? 'Data Source') . ': ' . $state['path']
+                    : 'New Data Binding'
+            )
+            ->addActionLabel('Add Data Binding')
+            ->reorderableWithButtons()
+            ->collapsible()
+            ->collapsed()
+            ->columnSpanFull();
+
+        // Apply relationship if needed (for edit/view forms)
+        if ($useRelationship) {
+            $repeater->relationship();
+        } else {
+            // For create forms, set default items to 0
+            $repeater->defaultItems(0);
+        }
+
+        // Disable the entire repeater if in disabled mode
+        if ($disabled) {
+            $repeater->disabled();
+        }
+
+        return [$repeater];
+    }
+
+    /**
+     * Get the Data Bindings tab schema for create forms (BuildFormVersion)
+     *
+     * @param FormVersion $formVersion The form version instance
+     * @param callable|null $shouldShowTooltipsCallback Callback to determine if tooltips should be shown
+     * @return array The schema array
+     */
+    public static function getCreateSchema(
+        FormVersion $formVersion,
+        ?callable $shouldShowTooltipsCallback = null
+    ): array {
+        return self::getDataBindingsSchema(
+            formVersion: $formVersion,
+            shouldShowTooltipsCallback: $shouldShowTooltipsCallback,
+            disabled: false,
+            useRelationship: false
+        );
+    }
+
+    /**
+     * Get the Data Bindings tab schema for edit forms (FormElementTreeBuilder edit)
+     *
+     * @param int|null $formVersionId The form version ID
+     * @param callable|null $shouldShowTooltipsCallback Callback to determine if tooltips should be shown
+     * @return array The schema array
+     */
+    public static function getEditSchema(
+        ?int $formVersionId,
+        ?callable $shouldShowTooltipsCallback = null
+    ): array {
+        return self::getDataBindingsSchema(
+            formVersionId: $formVersionId,
+            shouldShowTooltipsCallback: $shouldShowTooltipsCallback,
+            disabled: false,
+            useRelationship: true
+        );
+    }
+
+    /**
+     * Get the Data Bindings tab schema for view forms (FormElementTreeBuilder view)
+     *
+     * @param int|null $formVersionId The form version ID
+     * @param callable|null $shouldShowTooltipsCallback Callback to determine if tooltips should be shown
+     * @return array The schema array
+     */
+    public static function getViewSchema(
+        ?int $formVersionId,
+        ?callable $shouldShowTooltipsCallback = null
+    ): array {
+        return self::getDataBindingsSchema(
+            formVersionId: $formVersionId,
+            shouldShowTooltipsCallback: $shouldShowTooltipsCallback,
+            disabled: true,
+            useRelationship: true
+        );
+    }
+}

--- a/app/Helpers/ElementPropertiesHelper.php
+++ b/app/Helpers/ElementPropertiesHelper.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Helpers;
+
+use Filament\Forms\Components\Placeholder;
+
+class ElementPropertiesHelper
+{
+    /**
+     * Get the Element Properties tab schema for form elements
+     *
+     * @param string|null $elementType The element type class name
+     * @param bool $disabled Whether the schema should be disabled (for view mode)
+     * @return array The schema array
+     */
+    public static function getElementPropertiesSchema(
+        ?string $elementType = null,
+        bool $disabled = false
+    ): array {
+        // Handle case where no element type is available
+        if (!$elementType) {
+            $content = $disabled
+                ? 'No specific properties available.'
+                : 'Please select an element type in the General tab first.';
+
+            $placeholderKey = $disabled ? 'select_element_type' : 'no_element_type';
+
+            return [
+                Placeholder::make($placeholderKey)
+                    ->label('')
+                    ->content($content)
+            ];
+        }
+
+        // Check if the element type class exists and has the getFilamentSchema method
+        if (class_exists($elementType) && method_exists($elementType, 'getFilamentSchema')) {
+            return $elementType::getFilamentSchema($disabled);
+        }
+
+        // Fallback for element types that don't have schema defined yet
+        return [
+            Placeholder::make('no_specific_properties')
+                ->label('')
+                ->content('This element type has no specific properties defined yet.')
+        ];
+    }
+
+    /**
+     * Get the Element Properties tab schema for create forms (BuildFormVersion)
+     *
+     * @param string|null $elementType The element type class name
+     * @return array The schema array
+     */
+    public static function getCreateSchema(?string $elementType = null): array
+    {
+        return self::getElementPropertiesSchema(
+            elementType: $elementType,
+            disabled: false
+        );
+    }
+
+    /**
+     * Get the Element Properties tab schema for edit forms (FormElementTreeBuilder edit)
+     *
+     * @param string|null $elementType The element type class name
+     * @return array The schema array
+     */
+    public static function getEditSchema(?string $elementType = null): array
+    {
+        return self::getElementPropertiesSchema(
+            elementType: $elementType,
+            disabled: false
+        );
+    }
+
+    /**
+     * Get the Element Properties tab schema for view forms (FormElementTreeBuilder view)
+     *
+     * @param string|null $elementType The element type class name
+     * @return array The schema array
+     */
+    public static function getViewSchema(?string $elementType = null): array
+    {
+        return self::getElementPropertiesSchema(
+            elementType: $elementType,
+            disabled: true
+        );
+    }
+}

--- a/app/Helpers/FormElementHelper.php
+++ b/app/Helpers/FormElementHelper.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Helpers;
+
+use App\Models\FormBuilding\SelectInputFormElement;
+use App\Models\FormBuilding\RadioInputFormElement;
+use App\Models\FormBuilding\SelectOptionFormElement;
+
+class FormElementHelper
+{
+    /**
+     * Create select options for select/radio elements
+     *
+     * @param mixed $elementableModel The SelectInputFormElement or RadioInputFormElement instance
+     * @param array $optionsData Array of option data with 'label' and 'value' keys
+     * @return void
+     */
+    public static function createSelectOptions($elementableModel, array $optionsData): void
+    {
+        if (!$elementableModel || empty($optionsData)) {
+            return;
+        }
+
+        // Check if the model supports options (SelectInputFormElement or RadioInputFormElement)
+        if (!method_exists($elementableModel, 'options')) {
+            return;
+        }
+
+        foreach ($optionsData as $index => $optionData) {
+            if (empty($optionData['label'])) {
+                continue; // Skip options without labels
+            }
+
+            $optionData['order'] = $index + 1;
+
+            // Create the option using the existing helper method
+            if ($elementableModel instanceof SelectInputFormElement) {
+                SelectOptionFormElement::createForSelect($elementableModel, $optionData);
+            } elseif ($elementableModel instanceof RadioInputFormElement) {
+                SelectOptionFormElement::createForRadio($elementableModel, $optionData);
+            }
+        }
+    }
+
+    /**
+     * Update select options for select/radio elements
+     * This will delete existing options and create new ones
+     *
+     * @param mixed $elementableModel The SelectInputFormElement or RadioInputFormElement instance
+     * @param array $optionsData Array of option data with 'label' and 'value' keys
+     * @return void
+     */
+    public static function updateSelectOptions($elementableModel, array $optionsData): void
+    {
+        if (!$elementableModel || !method_exists($elementableModel, 'options')) {
+            return;
+        }
+
+        // Delete existing options
+        $elementableModel->options()->delete();
+
+        // Create new options
+        self::createSelectOptions($elementableModel, $optionsData);
+    }
+}

--- a/app/Helpers/GeneralTabHelper.php
+++ b/app/Helpers/GeneralTabHelper.php
@@ -345,6 +345,21 @@ class GeneralTabHelper
                 $templateToggle,
             ]);
 
+        $schema[] = Grid::make(2)
+            ->schema([
+                Toggle::make('is_read_only')
+                    ->label('Is Read Only')
+                    ->default(true)
+                    ->disabled($disabled),
+                Toggle::make('save_on_submit')
+                    ->label('Save on Submit')
+                    ->default(true)
+                    ->disabled($disabled)
+                    ->when($shouldShowTooltipsCallback, function ($component) {
+                        return $component->hintIcon('heroicon-m-question-mark-circle', tooltip: 'If this element\'s data should be saved when the form is submitted');
+                    }),
+            ]);
+
         // Tags field
         $tagsField = Select::make('tags')
             ->label('Tags')

--- a/app/Helpers/GeneralTabHelper.php
+++ b/app/Helpers/GeneralTabHelper.php
@@ -270,6 +270,24 @@ class GeneralTabHelper
                 ->afterStateUpdated(function ($state, callable $set) {
                     // Clear existing elementable data when type changes
                     $set('elementable_data', []);
+
+                    // Populate with defaults from the new element type
+                    if ($state && class_exists($state) && method_exists($state, 'getFilamentSchema')) {
+                        $schema = $state::getFilamentSchema(false);
+                        $defaults = [];
+
+                        foreach ($schema as $field) {
+                            $fieldName = str_replace('elementable_data.', '', $field->getName());
+                            $defaultValue = $field->getDefaultState();
+                            if ($defaultValue !== null) {
+                                $defaults[$fieldName] = $defaultValue;
+                            }
+                        }
+
+                        if (!empty($defaults)) {
+                            $set('elementable_data', $defaults);
+                        }
+                    }
                 })
                 : TextInput::make('elementable_type')
                 ->label('Element Type')

--- a/app/Helpers/GeneralTabHelper.php
+++ b/app/Helpers/GeneralTabHelper.php
@@ -1,0 +1,447 @@
+<?php
+
+namespace App\Helpers;
+
+use App\Models\FormBuilding\FormElement;
+use App\Models\FormBuilding\FormElementTag;
+use Filament\Forms\Components\Grid;
+use Filament\Forms\Components\Hidden;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Forms\Components\Actions\Action;
+use Filament\Forms;
+
+class GeneralTabHelper
+{
+    /**
+     * Get the General tab schema for form elements
+     *
+     * @param string $mode The form mode: 'create', 'edit', or 'view'
+     * @param callable|null $shouldShowTooltipsCallback Callback to determine if tooltips should be shown
+     * @param bool $includeTemplateSelector Whether to include the template selector (only for create mode)
+     * @return array The schema array
+     */
+    public static function getGeneralTabSchema(
+        string $mode = 'create',
+        ?callable $shouldShowTooltipsCallback = null,
+        bool $includeTemplateSelector = false
+    ): array {
+        $disabled = $mode === 'view';
+        $isEdit = $mode === 'edit';
+        $isCreate = $mode === 'create';
+
+        $schema = [];
+
+        // Template selector (only for create mode when explicitly requested)
+        if ($includeTemplateSelector && $isCreate) {
+            $schema[] = Select::make('template_id')
+                ->label('Start from template')
+                ->placeholder('Select a template (optional)')
+                ->options(function () {
+                    $templates = FormElement::templates()
+                        ->with('elementable')
+                        ->get();
+
+                    $availableTypes = FormElement::getAvailableElementTypes();
+                    $groupedOptions = [];
+
+                    foreach ($templates as $template) {
+                        $elementType = $template->elementable_type;
+                        $groupName = $availableTypes[$elementType] ?? class_basename($elementType);
+
+                        if (!isset($groupedOptions[$groupName])) {
+                            $groupedOptions[$groupName] = [];
+                        }
+
+                        $groupedOptions[$groupName][$template->id] = $template->name;
+                    }
+
+                    // Sort groups alphabetically
+                    ksort($groupedOptions);
+
+                    return $groupedOptions;
+                })
+                ->live()
+                ->afterStateUpdated(function ($state, callable $set, callable $get) {
+                    if (!$state) {
+                        return;
+                    }
+
+                    // Load the template element with its relationships
+                    $template = FormElement::with(['elementable', 'tags'])->find($state);
+
+                    if (!$template) {
+                        return;
+                    }
+
+                    // Prefill basic form element data
+                    $set('name', $template->name);
+                    $set('description', $template->description);
+                    $set('help_text', $template->help_text);
+                    $set('elementable_type', $template->elementable_type);
+                    $set('is_required', $template->is_required);
+                    $set('visible_web', $template->visible_web);
+                    $set('visible_pdf', $template->visible_pdf);
+                    $set('is_template', false); // New element should not be a template by default
+
+                    // Prefill tags
+                    if ($template->tags->isNotEmpty()) {
+                        $set('tags', $template->tags->pluck('id')->toArray());
+                    }
+
+                    // Prefill elementable data if it exists
+                    if ($template->elementable) {
+                        $elementableData = $template->elementable->toArray();
+                        // Remove timestamps and primary key
+                        unset($elementableData['id'], $elementableData['created_at'], $elementableData['updated_at']);
+                        $set('elementable_data', $elementableData);
+                    }
+                })
+                ->searchable()
+                ->columnSpanFull();
+        }
+
+        // Name field
+        $nameField = TextInput::make('name')
+            ->required()
+            ->maxLength(255)
+            ->label('Element Name')
+            ->disabled($disabled);
+
+        // Add auto-generation logic for create mode
+        if ($isCreate) {
+            $nameField = $nameField
+                ->live(onBlur: true)
+                ->afterStateUpdated(function ($state, callable $set, callable $get) {
+                    // Auto-generate reference_id if it's empty and we have a name
+                    if (!empty($state) && empty($get('reference_id'))) {
+                        $slug = \Illuminate\Support\Str::slug($state, '-');
+                        $set('reference_id', $slug);
+                    }
+                });
+        }
+
+        // Add tooltip if callback is provided
+        if ($shouldShowTooltipsCallback) {
+            $nameField = $nameField->when($shouldShowTooltipsCallback, function ($component) {
+                return $component->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Human friendly identifier to help you find and reference this element');
+            });
+        }
+
+        $schema[] = $nameField;
+
+        // Reference ID field - only editable on create
+        $referenceIdField = TextInput::make('reference_id')
+            ->label('Reference ID')
+            ->rules(['alpha_dash'])
+            ->disabled($disabled || $isEdit);
+
+        // Add tooltip if callback is provided
+        if ($shouldShowTooltipsCallback) {
+            $referenceIdField = $referenceIdField->when($shouldShowTooltipsCallback, function ($component) {
+                return $component->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Human-readable identifier to aid creating ICM data bindings');
+            });
+        }
+
+        // Add suffix and actions for edit mode
+        if ($isEdit) {
+            $referenceIdField = $referenceIdField
+                ->suffix(function ($get) {
+                    return $get('uuid') ? $get('uuid') : '';
+                })
+                ->suffixAction(
+                    Action::make('copy')
+                        ->icon('heroicon-s-clipboard')
+                        ->action(function ($livewire, $state, $get) {
+                            $fullReference = FormElement::buildFullReferenceId($state, $get('uuid'));
+                            $livewire->dispatch('copy-to-clipboard', text: $fullReference);
+                        })
+                )
+                ->extraAttributes([
+                    'x-data' => '{
+                        copyToClipboard(text) {
+                            if (navigator.clipboard && navigator.clipboard.writeText) {
+                                navigator.clipboard.writeText(text).then(() => {
+                                    $tooltip("Copied to clipboard", { timeout: 1500 });
+                                }).catch(() => {
+                                    $tooltip("Failed to copy", { timeout: 1500 });
+                                });
+                            } else {
+                                const textArea = document.createElement("textarea");
+                                textArea.value = text;
+                                textArea.style.position = "fixed";
+                                textArea.style.opacity = "0";
+                                document.body.appendChild(textArea);
+                                textArea.select();
+                                try {
+                                    document.execCommand("copy");
+                                    $tooltip("Copied to clipboard", { timeout: 1500 });
+                                } catch (err) {
+                                    $tooltip("Failed to copy", { timeout: 1500 });
+                                }
+                                document.body.removeChild(textArea);
+                            }
+                        }
+                    }',
+                    'x-on:copy-to-clipboard.window' => 'copyToClipboard($event.detail.text)',
+                ]);
+        } elseif ($isCreate) {
+            // Add regenerate action for create mode
+            $referenceIdField = $referenceIdField->suffixAction(
+                Action::make('regenerate_reference_id')
+                    ->icon('heroicon-o-arrow-path')
+                    ->tooltip('Regenerate from Element Name')
+                    ->action(function (callable $set, callable $get) {
+                        $name = $get('name');
+                        if (!empty($name)) {
+                            $slug = \Illuminate\Support\Str::slug($name, '-');
+                            $set('reference_id', $slug);
+                        }
+                    })
+            );
+        } elseif ($mode === 'view') {
+            // Add copy functionality for view mode
+            $referenceIdField = $referenceIdField
+                ->suffix(function ($get) {
+                    return $get('uuid') ? $get('uuid') : '';
+                })
+                ->suffixAction(
+                    Action::make('copy')
+                        ->icon('heroicon-s-clipboard')
+                        ->action(function ($livewire, $state, $get) {
+                            $fullReference = FormElement::buildFullReferenceId($state, $get('uuid'));
+                            $livewire->dispatch('copy-to-clipboard', text: $fullReference);
+                        })
+                )
+                ->extraAttributes([
+                    'x-data' => '{
+                        copyToClipboard(text) {
+                            if (navigator.clipboard && navigator.clipboard.writeText) {
+                                navigator.clipboard.writeText(text).then(() => {
+                                    $tooltip("Copied to clipboard", { timeout: 1500 });
+                                }).catch(() => {
+                                    $tooltip("Failed to copy", { timeout: 1500 });
+                                });
+                            } else {
+                                const textArea = document.createElement("textarea");
+                                textArea.value = text;
+                                textArea.style.position = "fixed";
+                                textArea.style.opacity = "0";
+                                document.body.appendChild(textArea);
+                                textArea.select();
+                                try {
+                                    document.execCommand("copy");
+                                    $tooltip("Copied to clipboard", { timeout: 1500 });
+                                } catch (err) {
+                                    $tooltip("Failed to copy", { timeout: 1500 });
+                                }
+                                document.body.removeChild(textArea);
+                            }
+                        }
+                    }',
+                    'x-on:copy-to-clipboard.window' => 'copyToClipboard($event.detail.text)',
+                ]);
+        }
+
+        $schema[] = $referenceIdField;
+
+        // Element type field (different handling for edit vs create/view)
+        if ($isEdit) {
+            // For edit mode, we need both hidden and display fields
+            $schema[] = Hidden::make('elementable_type');
+            $elementTypeField = TextInput::make('elementable_type_display')
+                ->label('Element Type')
+                ->disabled(true)
+                ->dehydrated(false)
+                ->formatStateUsing(function ($state, callable $get) {
+                    $elementType = $get('elementable_type');
+                    return FormElement::getAvailableElementTypes()[$elementType] ?? $elementType;
+                });
+        } else {
+            // For create and view modes
+            $elementTypeField = $isCreate
+                ? Select::make('elementable_type')
+                ->label('Element Type')
+                ->options(FormElement::getAvailableElementTypes())
+                ->required()
+                ->live()
+                ->afterStateUpdated(function ($state, callable $set) {
+                    // Clear existing elementable data when type changes
+                    $set('elementable_data', []);
+                })
+                : TextInput::make('elementable_type')
+                ->label('Element Type')
+                ->disabled(true);
+        }
+
+        // Add tooltip if callback is provided
+        if ($shouldShowTooltipsCallback) {
+            $elementTypeField = $elementTypeField->when($shouldShowTooltipsCallback, function ($component) {
+                return $component->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Various inputs, containers for grouping and repeating, text info for paragraphs, or custom HTML');
+            });
+        }
+
+        $schema[] = $elementTypeField;
+
+        // Description field
+        $schema[] = Textarea::make('description')
+            ->rows(3)
+            ->disabled($disabled);
+
+        // Help text field
+        $helpTextField = TextInput::make('help_text')
+            ->maxLength(500)
+            ->disabled($disabled);
+
+        // Add tooltip if callback is provided
+        if ($shouldShowTooltipsCallback) {
+            $helpTextField = $helpTextField->when($shouldShowTooltipsCallback, function ($component) {
+                return $component->hintIcon('heroicon-m-question-mark-circle', tooltip: 'This text is read aloud by screen readers to describe the element');
+            });
+        }
+
+        $schema[] = $helpTextField;
+
+        // Visibility toggles
+        $schema[] = Grid::make(2)
+            ->schema([
+                Toggle::make('visible_web')
+                    ->label('Visible on Web')
+                    ->default(true)
+                    ->disabled($disabled),
+                Toggle::make('visible_pdf')
+                    ->label('Visible on PDF')
+                    ->default(true)
+                    ->disabled($disabled),
+            ]);
+
+        // Required and Template toggles
+        $templateToggle = Toggle::make('is_template')
+            ->label('Is Template')
+            ->default(false)
+            ->disabled($disabled);
+
+        // Add tooltip if callback is provided
+        if ($shouldShowTooltipsCallback) {
+            $templateToggle = $templateToggle->when($shouldShowTooltipsCallback, function ($component) {
+                return $component->hintIcon('heroicon-m-question-mark-circle', tooltip: 'If this element should be a template for later reuse');
+            });
+        }
+
+        $requirementToggle = Toggle::make('is_required')
+            ->label('Is Required')
+            ->default(false);
+
+        // For view mode, disable the is_required toggle too
+        if ($disabled) {
+            $requirementToggle = $requirementToggle->disabled(true);
+        }
+
+        $schema[] = Grid::make(2)
+            ->schema([
+                $requirementToggle,
+                $templateToggle,
+            ]);
+
+        // Tags field
+        $tagsField = Select::make('tags')
+            ->label('Tags')
+            ->multiple()
+            ->searchable()
+            ->disabled($disabled);
+
+        // Add tooltip if callback is provided
+        if ($shouldShowTooltipsCallback) {
+            $tagsField = $tagsField->when($shouldShowTooltipsCallback, function ($component) {
+                return $component->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Categorize related fields (use camelCase)');
+            });
+        }
+
+        // Different handling for edit vs create modes
+        if ($isEdit || $mode === 'view') {
+            $tagsField = $tagsField->relationship('tags', 'name');
+            if ($mode === 'view') {
+                $tagsField = $tagsField->preload();
+            }
+        }
+
+        if ($isCreate || $isEdit) {
+            $tagsField = $tagsField
+                ->options(fn() => FormElementTag::pluck('name', 'id')->toArray())
+                ->createOptionAction(
+                    fn(Forms\Components\Actions\Action $action) => $action
+                        ->modalHeading('Create Tag')
+                        ->modalWidth('md')
+                )
+                ->createOptionForm([
+                    TextInput::make('name')
+                        ->required()
+                        ->maxLength(255)
+                        ->unique(FormElementTag::class, 'name'),
+                    Textarea::make('description')
+                        ->rows(3),
+                ])
+                ->createOptionUsing(function (array $data) {
+                    $tag = FormElementTag::create($data);
+                    return $tag->id;
+                })
+                ->preload();
+        }
+
+        $schema[] = $tagsField;
+
+        return $schema;
+    }
+
+    /**
+     * Get the General tab schema for create forms (BuildFormVersion)
+     *
+     * @param callable|null $shouldShowTooltipsCallback Callback to determine if tooltips should be shown
+     * @param bool $includeTemplateSelector Whether to include template selector
+     * @return array The schema array
+     */
+    public static function getCreateSchema(
+        ?callable $shouldShowTooltipsCallback = null,
+        bool $includeTemplateSelector = true
+    ): array {
+        return self::getGeneralTabSchema(
+            mode: 'create',
+            shouldShowTooltipsCallback: $shouldShowTooltipsCallback,
+            includeTemplateSelector: $includeTemplateSelector
+        );
+    }
+
+    /**
+     * Get the General tab schema for edit forms (FormElementTreeBuilder edit)
+     *
+     * @param callable|null $shouldShowTooltipsCallback Callback to determine if tooltips should be shown
+     * @return array The schema array
+     */
+    public static function getEditSchema(
+        ?callable $shouldShowTooltipsCallback = null
+    ): array {
+        return self::getGeneralTabSchema(
+            mode: 'edit',
+            shouldShowTooltipsCallback: $shouldShowTooltipsCallback,
+            includeTemplateSelector: false
+        );
+    }
+
+    /**
+     * Get the General tab schema for view forms (FormElementTreeBuilder view)
+     *
+     * @param callable|null $shouldShowTooltipsCallback Callback to determine if tooltips should be shown
+     * @return array The schema array
+     */
+    public static function getViewSchema(
+        ?callable $shouldShowTooltipsCallback = null
+    ): array {
+        return self::getGeneralTabSchema(
+            mode: 'view',
+            shouldShowTooltipsCallback: $shouldShowTooltipsCallback,
+            includeTemplateSelector: false
+        );
+    }
+}

--- a/app/Helpers/GeneralTabHelper.php
+++ b/app/Helpers/GeneralTabHelper.php
@@ -345,19 +345,28 @@ class GeneralTabHelper
                 $templateToggle,
             ]);
 
+        // Read Only and Save on Submit toggles
+        $readOnlyToggle = Toggle::make('is_read_only')
+            ->label('Is Read Only')
+            ->default(true)
+            ->disabled($disabled);
+
+        $saveOnSubmitToggle = Toggle::make('save_on_submit')
+            ->label('Save on Submit')
+            ->default(true)
+            ->disabled($disabled);
+
+        // Add tooltip if callback is provided
+        if ($shouldShowTooltipsCallback) {
+            $saveOnSubmitToggle = $saveOnSubmitToggle->when($shouldShowTooltipsCallback, function ($component) {
+                return $component->hintIcon('heroicon-m-question-mark-circle', tooltip: 'If this element\'s data should be saved when the form is submitted');
+            });
+        }
+
         $schema[] = Grid::make(2)
             ->schema([
-                Toggle::make('is_read_only')
-                    ->label('Is Read Only')
-                    ->default(true)
-                    ->disabled($disabled),
-                Toggle::make('save_on_submit')
-                    ->label('Save on Submit')
-                    ->default(true)
-                    ->disabled($disabled)
-                    ->when($shouldShowTooltipsCallback, function ($component) {
-                        return $component->hintIcon('heroicon-m-question-mark-circle', tooltip: 'If this element\'s data should be saved when the form is submitted');
-                    }),
+                $readOnlyToggle,
+                $saveOnSubmitToggle,
             ]);
 
         // Tags field

--- a/app/Helpers/GeneralTabHelper.php
+++ b/app/Helpers/GeneralTabHelper.php
@@ -348,7 +348,7 @@ class GeneralTabHelper
         // Read Only and Save on Submit toggles
         $readOnlyToggle = Toggle::make('is_read_only')
             ->label('Is Read Only')
-            ->default(true)
+            ->default(false)
             ->disabled($disabled);
 
         $saveOnSubmitToggle = Toggle::make('save_on_submit')

--- a/app/Livewire/FormElementTreeBuilder.php
+++ b/app/Livewire/FormElementTreeBuilder.php
@@ -6,21 +6,18 @@ use App\Models\FormBuilding\FormElement;
 use App\Events\FormVersionUpdateEvent;
 use App\Models\FormBuilding\FormElementTag;
 use App\Models\FormBuilding\FormVersion;
-
 use App\Helpers\DataBindingsHelper;
+use App\Helpers\ElementPropertiesHelper;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\Toggle;
-use Filament\Forms\Components\Repeater;
 use Filament\Forms;
 use SolutionForest\FilamentTree\Actions\DeleteAction;
 use SolutionForest\FilamentTree\Actions\EditAction;
 use SolutionForest\FilamentTree\Actions\ViewAction;
 use SolutionForest\FilamentTree\Widgets\Tree as BaseWidget;
 use Filament\Notifications\Notification;
-use Filament\Forms\Set;
-use Illuminate\Support\Str;
 use Filament\Forms\Components\Actions\Action;
 use Illuminate\Support\Facades\Auth;
 
@@ -185,16 +182,9 @@ class FormElementTreeBuilder extends BaseWidget
                     \Filament\Forms\Components\Tabs\Tab::make('Element Properties')
                         ->icon('heroicon-o-adjustments-horizontal')
                         ->schema(function (callable $get) {
-                            // For edit, get the element type from the form data
-                            $elementType = $get('elementable_type');
-                            if (!$elementType) {
-                                return [
-                                    \Filament\Forms\Components\Placeholder::make('no_element_type')
-                                        ->label('')
-                                        ->content('No element type available.')
-                                ];
-                            }
-                            return $this->getElementSpecificSchema($elementType);
+                            return ElementPropertiesHelper::getEditSchema(
+                                $get('elementable_type')
+                            );
                         }),
                     \Filament\Forms\Components\Tabs\Tab::make('Data Bindings')
                         ->icon('heroicon-o-link')
@@ -316,15 +306,9 @@ class FormElementTreeBuilder extends BaseWidget
                     \Filament\Forms\Components\Tabs\Tab::make('Element Properties')
                         ->icon('heroicon-o-adjustments-horizontal')
                         ->schema(function (callable $get) {
-                            $elementType = $get('elementable_type');
-                            if (!$elementType) {
-                                return [
-                                    \Filament\Forms\Components\Placeholder::make('select_element_type')
-                                        ->label('')
-                                        ->content('No specific properties available.')
-                                ];
-                            }
-                            return $this->getElementSpecificSchema($elementType, true);
+                            return ElementPropertiesHelper::getViewSchema(
+                                $get('elementable_type')
+                            );
                         }),
                     \Filament\Forms\Components\Tabs\Tab::make('Data Bindings')
                         ->icon('heroicon-o-link')
@@ -339,20 +323,7 @@ class FormElementTreeBuilder extends BaseWidget
         ];
     }
 
-    protected function getElementSpecificSchema(string $elementType, bool $disabled = false): array
-    {
-        // Check if the element type class exists and has the getFilamentSchema method
-        if (class_exists($elementType) && method_exists($elementType, 'getFilamentSchema')) {
-            return $elementType::getFilamentSchema($disabled);
-        }
 
-        // Fallback for element types that don't have schema defined yet
-        return [
-            \Filament\Forms\Components\Placeholder::make('no_specific_properties')
-                ->label('')
-                ->content('This element type has no specific properties defined yet.')
-        ];
-    }
 
     protected function getTreeActions(): array
     {

--- a/app/Livewire/FormElementTreeBuilder.php
+++ b/app/Livewire/FormElementTreeBuilder.php
@@ -14,6 +14,7 @@ use SolutionForest\FilamentTree\Actions\ViewAction;
 use SolutionForest\FilamentTree\Widgets\Tree as BaseWidget;
 use Filament\Notifications\Notification;
 use Illuminate\Support\Facades\Auth;
+use App\Helpers\FormElementHelper;
 
 class FormElementTreeBuilder extends BaseWidget
 {
@@ -495,7 +496,7 @@ class FormElementTreeBuilder extends BaseWidget
 
             // Handle options for select/radio elements
             if ($elementableModel && $optionsData && is_array($optionsData)) {
-                $this->createSelectOptions($elementableModel, $optionsData);
+                FormElementHelper::createSelectOptions($elementableModel, $optionsData);
             }
 
             // Clear pending data
@@ -693,49 +694,13 @@ class FormElementTreeBuilder extends BaseWidget
         // The actual class application happens in the getTreeRecordClasses method
     }
 
-    /**
-     * Create select options for select/radio elements
-     */
-    protected function createSelectOptions($elementableModel, array $optionsData): void
-    {
-        if (!$elementableModel || empty($optionsData)) {
-            return;
-        }
 
-        // Check if the model supports options (SelectInputFormElement or RadioInputFormElement)
-        if (!method_exists($elementableModel, 'options')) {
-            return;
-        }
-
-        foreach ($optionsData as $index => $optionData) {
-            if (empty($optionData['label'])) {
-                continue; // Skip options without labels
-            }
-
-            $optionData['order'] = $index + 1;
-
-            // Create the option using the existing helper method
-            if ($elementableModel instanceof \App\Models\FormBuilding\SelectInputFormElement) {
-                \App\Models\FormBuilding\SelectOptionFormElement::createForSelect($elementableModel, $optionData);
-            } elseif ($elementableModel instanceof \App\Models\FormBuilding\RadioInputFormElement) {
-                \App\Models\FormBuilding\SelectOptionFormElement::createForRadio($elementableModel, $optionData);
-            }
-        }
-    }
 
     /**
      * Update select options for select/radio elements
      */
     protected function updateSelectOptions($elementableModel, array $optionsData): void
     {
-        if (!$elementableModel || !method_exists($elementableModel, 'options')) {
-            return;
-        }
-
-        // Delete existing options
-        $elementableModel->options()->delete();
-
-        // Create new options
-        $this->createSelectOptions($elementableModel, $optionsData);
+        FormElementHelper::updateSelectOptions($elementableModel, $optionsData);
     }
 }

--- a/app/Models/FormBuilding/ButtonInputFormElement.php
+++ b/app/Models/FormBuilding/ButtonInputFormElement.php
@@ -28,6 +28,7 @@ class ButtonInputFormElement extends Model
             \Filament\Forms\Components\TextInput::make('elementable_data.label')
                 ->label('Button Text')
                 ->default('Submit')
+                ->required(true)
                 ->disabled($disabled),
             \Filament\Forms\Components\Select::make('elementable_data.button_type')
                 ->label('Button Type')

--- a/app/Models/FormBuilding/CheckboxInputFormElement.php
+++ b/app/Models/FormBuilding/CheckboxInputFormElement.php
@@ -31,6 +31,7 @@ class CheckboxInputFormElement extends Model
         return [
             \Filament\Forms\Components\TextInput::make('elementable_data.label')
                 ->label('Checkbox Label')
+                ->required(true)
                 ->disabled($disabled),
             \Filament\Forms\Components\Toggle::make('elementable_data.visible_label')
                 ->label('Show Label')

--- a/app/Models/FormBuilding/ContainerFormElement.php
+++ b/app/Models/FormBuilding/ContainerFormElement.php
@@ -26,6 +26,7 @@ class ContainerFormElement extends Model
     ];
 
     protected $attributes = [
+        'container_type' => 'section',
         'collapsible' => false,
         'collapsed_by_default' => false,
         'is_repeatable' => false,
@@ -51,6 +52,7 @@ class ContainerFormElement extends Model
                 ->label('Collapsible')
                 ->helperText('Allow users to expand/collapse this container')
                 ->default(false)
+                ->live()
                 ->disabled($disabled),
             \Filament\Forms\Components\Toggle::make('elementable_data.collapsed_by_default')
                 ->label('Collapsed by Default')

--- a/app/Models/FormBuilding/ContainerFormElement.php
+++ b/app/Models/FormBuilding/ContainerFormElement.php
@@ -41,6 +41,7 @@ class ContainerFormElement extends Model
                 ->label('Container Type')
                 ->options(static::getContainerTypes())
                 ->default('section')
+                ->required(true)
                 ->disabled($disabled),
             \Filament\Forms\Components\TextInput::make('elementable_data.legend')
                 ->label('Legend/Title')

--- a/app/Models/FormBuilding/DateSelectInputFormElement.php
+++ b/app/Models/FormBuilding/DateSelectInputFormElement.php
@@ -14,7 +14,6 @@ class DateSelectInputFormElement extends Model
         'placeholder_text',
         'label',
         'visible_label',
-        'repeater_item_label',
         'min_date',
         'max_date',
         'default_date',
@@ -73,10 +72,6 @@ class DateSelectInputFormElement extends Model
                 ->label('Default Date')
                 ->helperText('Pre-selected date')
                 ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.repeater_item_label')
-                ->label('Repeater Item Label')
-                ->helperText('Used when this element is part of a repeater')
-                ->disabled($disabled),
         ];
     }
 
@@ -97,7 +92,6 @@ class DateSelectInputFormElement extends Model
             'placeholder_text' => $this->placeholder_text,
             'label' => $this->label,
             'visible_label' => $this->visible_label,
-            'repeater_item_label' => $this->repeater_item_label,
             'min_date' => $this->min_date,
             'max_date' => $this->max_date,
             'default_date' => $this->default_date,

--- a/app/Models/FormBuilding/HTMLFormElement.php
+++ b/app/Models/FormBuilding/HTMLFormElement.php
@@ -13,9 +13,7 @@ class HTMLFormElement extends Model
     protected $table = 'h_t_m_l_form_elements';
 
     protected $fillable = [
-        'name',
         'html_content',
-        'repeater_item_label',
     ];
 
     /**
@@ -24,16 +22,9 @@ class HTMLFormElement extends Model
     public static function getFilamentSchema(bool $disabled = false): array
     {
         return [
-            \Filament\Forms\Components\TextInput::make('elementable_data.name')
-                ->label('Element Name')
-                ->disabled($disabled),
             \Filament\Forms\Components\Textarea::make('elementable_data.html_content')
                 ->label('HTML Content')
                 ->rows(8)
-                ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.repeater_item_label')
-                ->label('Repeater Item Label')
-                ->helperText('Used when this element is part of a repeater')
                 ->disabled($disabled),
         ];
     }
@@ -52,9 +43,7 @@ class HTMLFormElement extends Model
     public function getData(): array
     {
         return [
-            'name' => $this->name,
             'html_content' => $this->html_content,
-            'repeater_item_label' => $this->repeater_item_label,
         ];
     }
 

--- a/app/Models/FormBuilding/TextInfoFormElement.php
+++ b/app/Models/FormBuilding/TextInfoFormElement.php
@@ -5,7 +5,7 @@ namespace App\Models\FormBuilding;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
-use WeStacks\FilamentMonacoEditor\MonacoEditor;
+use Filament\Forms\Components\Textarea;
 
 class TextInfoFormElement extends Model
 {
@@ -25,9 +25,9 @@ class TextInfoFormElement extends Model
     public static function getFilamentSchema(bool $disabled = false): array
     {
         return [
-            MonacoEditor::make('elementable_data.content')
+            Textarea::make('elementable_data.content')
                 ->label('Content')
-                ->language('html')
+                ->rows(10)
                 ->disabled($disabled),
         ];
     }

--- a/app/Models/FormBuilding/TextInputFormElement.php
+++ b/app/Models/FormBuilding/TextInputFormElement.php
@@ -48,12 +48,12 @@ class TextInputFormElement extends Model
             \Filament\Forms\Components\TextInput::make('elementable_data.mask')
                 ->label('Input Mask')
                 ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.maxlength')
-                ->label('Maximum Length')
-                ->numeric()
-                ->disabled($disabled),
             \Filament\Forms\Components\TextInput::make('elementable_data.minlength')
                 ->label('Minimum Length')
+                ->numeric()
+                ->disabled($disabled),
+            \Filament\Forms\Components\TextInput::make('elementable_data.maxlength')
+                ->label('Maximum Length')
                 ->numeric()
                 ->disabled($disabled),
         ];

--- a/app/Models/FormBuilding/TextareaInputFormElement.php
+++ b/app/Models/FormBuilding/TextareaInputFormElement.php
@@ -62,12 +62,12 @@ class TextareaInputFormElement extends Model
                 ->label('Number of Columns')
                 ->numeric()
                 ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.maxlength')
-                ->label('Maximum Length')
-                ->numeric()
-                ->disabled($disabled),
             \Filament\Forms\Components\TextInput::make('elementable_data.minlength')
                 ->label('Minimum Length')
+                ->numeric()
+                ->disabled($disabled),
+            \Filament\Forms\Components\TextInput::make('elementable_data.maxlength')
+                ->label('Maximum Length')
                 ->numeric()
                 ->disabled($disabled),
         ];

--- a/app/Models/FormBuilding/TextareaInputFormElement.php
+++ b/app/Models/FormBuilding/TextareaInputFormElement.php
@@ -11,7 +11,6 @@ class TextareaInputFormElement extends Model
     use HasFactory;
 
     protected $fillable = [
-        'name',
         'placeholder_text',
         'label',
         'visible_label',
@@ -40,9 +39,6 @@ class TextareaInputFormElement extends Model
     public static function getFilamentSchema(bool $disabled = false): array
     {
         return [
-            \Filament\Forms\Components\TextInput::make('elementable_data.name')
-                ->label('Field Name')
-                ->disabled($disabled),
             \Filament\Forms\Components\TextInput::make('elementable_data.placeholder_text')
                 ->label('Placeholder Text')
                 ->disabled($disabled),
@@ -90,7 +86,8 @@ class TextareaInputFormElement extends Model
             'placeholder_text' => $this->placeholder_text,
             'label' => $this->label,
             'visible_label' => $this->visible_label,
-            'mask' => $this->mask,
+            'rows' => $this->rows,
+            'cols' => $this->cols,
             'maxlength' => $this->maxlength,
             'minlength' => $this->minlength,
         ];

--- a/database/migrations/2025_07_15_212501_remove_repeater_item_label_from_h_t_m_l_form_elements_table.php
+++ b/database/migrations/2025_07_15_212501_remove_repeater_item_label_from_h_t_m_l_form_elements_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('h_t_m_l_form_elements', function (Blueprint $table) {
+            $table->dropColumn(['repeater_item_label', 'name']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('h_t_m_l_form_elements', function (Blueprint $table) {
+            $table->string('repeater_item_label')->nullable();
+            $table->string('name')->nullable();
+        });
+    }
+};

--- a/database/migrations/2025_07_15_212603_remove_repeater_item_label_from_date_select_input_form_elements_table.php
+++ b/database/migrations/2025_07_15_212603_remove_repeater_item_label_from_date_select_input_form_elements_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('date_select_input_form_elements', function (Blueprint $table) {
+            $table->dropColumn('repeater_item_label');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('date_select_input_form_elements', function (Blueprint $table) {
+            $table->string('repeater_item_label')->nullable();
+        });
+    }
+};

--- a/database/migrations/2025_07_15_213044_remove_name_from_textarea_input_form_elements_table.php
+++ b/database/migrations/2025_07_15_213044_remove_name_from_textarea_input_form_elements_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('textarea_input_form_elements', function (Blueprint $table) {
+            $table->dropColumn('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('textarea_input_form_elements', function (Blueprint $table) {
+            $table->string('name')->nullable();
+        });
+    }
+};


### PR DESCRIPTION
## What changes did you make? 

Button label required
Checkbox label required
Container type required

One schema for create, edit and view for the form building modal. The 3 tabs (general, element properties and data bindings) have been abstracted out into helpers.

You can now add element specific properties on creation. Specifically test with things like Text Display content, Select Options and Radio Options.

I had to revert the Text Display from using the Monaco editor since it was causing multiple issues when you switched to style/scripts and when saving on creation. I will try to restore this back to the Monaco editor when I have time, but using a textarea is the best option for now.

I also tested each property in the Element Properties to ensure it is saving in the database.

## Why did you make these changes?

https://dev.azure.com/bc-icm/FODIG/_workitems/edit/8108
https://dev.azure.com/bc-icm/FODIG/_workitems/edit/8109
https://dev.azure.com/bc-icm/FODIG/_workitems/edit/8110
https://dev.azure.com/bc-icm/FODIG/_workitems/edit/8065
https://dev.azure.com/bc-icm/FODIG/_workitems/edit/8067

## What alternatives did you consider?

_Describe any alternative solutions you considered and why._

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**

Testing dropdown and Radio on creation:

https://github.com/user-attachments/assets/dda0b54c-7fad-4df1-b2a2-38161047dbe5

Testing Text Display on creation:


https://github.com/user-attachments/assets/08fab607-8004-4ce5-9a15-7d8e5b75c6e4




