### PR TITLE
Feature/clean up all form elements

### DIFF
--- a/app/Helpers/SchemaHelper.php
+++ b/app/Helpers/SchemaHelper.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Helpers;
+
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Forms\Components\Textarea;
+
+class SchemaHelper
+{
+    /**
+     * Get the common Carbon Design System fields for form elements
+     * 
+     * @param bool $disabled Whether the fields should be disabled
+     * @return array Array of Filament form components
+     */
+    public static function getCommonCarbonFields(bool $disabled = false): array
+    {
+        return [
+            TextInput::make('elementable_data.labelText')
+                ->label('Field Label')
+                ->disabled($disabled),
+            Toggle::make('elementable_data.hideLabel')
+                ->label('Hide Label')
+                ->default(false)
+                ->disabled($disabled),
+            TextInput::make('elementable_data.placeholder')
+                ->label('Placeholder Text')
+                ->disabled($disabled),
+            Textarea::make('elementable_data.helperText')
+                ->label('Helper Text')
+                ->disabled($disabled),
+        ];
+    }
+
+    /**
+     * Get individual Carbon Design System field components
+     */
+    public static function getLabelTextField(bool $disabled = false)
+    {
+        return TextInput::make('elementable_data.labelText')
+            ->label('Field Label')
+            ->disabled($disabled);
+    }
+
+    public static function getHideLabelToggle(bool $disabled = false)
+    {
+        return Toggle::make('elementable_data.hideLabel')
+            ->label('Hide Label')
+            ->default(false)
+            ->disabled($disabled);
+    }
+
+    public static function getPlaceholderField(bool $disabled = false)
+    {
+        return TextInput::make('elementable_data.placeholder')
+            ->label('Placeholder Text')
+            ->disabled($disabled);
+    }
+
+    public static function getHelperTextField(bool $disabled = false)
+    {
+        return Textarea::make('elementable_data.helperText')
+            ->label('Helper Text')
+            ->disabled($disabled);
+    }
+}

--- a/app/Helpers/SchemaHelper.php
+++ b/app/Helpers/SchemaHelper.php
@@ -48,6 +48,7 @@ class SchemaHelper
         return Toggle::make('elementable_data.hideLabel')
             ->label('Hide Label')
             ->default(false)
+            ->live()
             ->disabled($disabled);
     }
 

--- a/app/Models/FormBuilding/ButtonInputFormElement.php
+++ b/app/Models/FormBuilding/ButtonInputFormElement.php
@@ -11,12 +11,12 @@ class ButtonInputFormElement extends Model
     use HasFactory;
 
     protected $fillable = [
-        'label',
-        'button_type',
+        'text',
+        'kind',
     ];
 
     protected $casts = [
-        'button_type' => 'string',
+        'kind' => 'string',
     ];
 
     /**
@@ -25,15 +25,15 @@ class ButtonInputFormElement extends Model
     public static function getFilamentSchema(bool $disabled = false): array
     {
         return [
-            \Filament\Forms\Components\TextInput::make('elementable_data.label')
+            \Filament\Forms\Components\TextInput::make('elementable_data.text')
                 ->label('Button Text')
                 ->default('Submit')
                 ->required(true)
                 ->disabled($disabled),
-            \Filament\Forms\Components\Select::make('elementable_data.button_type')
-                ->label('Button Type')
+            \Filament\Forms\Components\Select::make('elementable_data.kind')
+                ->label('Button Kind')
                 ->options(static::getButtonTypes())
-                ->default('submit')
+                ->default('primary')
                 ->disabled($disabled),
         ];
     }
@@ -52,8 +52,8 @@ class ButtonInputFormElement extends Model
     public function getData(): array
     {
         return [
-            'label' => $this->label,
-            'button_type' => $this->button_type,
+            'text' => $this->text,
+            'kind' => $this->kind,
         ];
     }
 

--- a/app/Models/FormBuilding/CheckboxInputFormElement.php
+++ b/app/Models/FormBuilding/CheckboxInputFormElement.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\FormBuilding;
 
+use App\Helpers\SchemaHelper;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
@@ -11,16 +12,20 @@ class CheckboxInputFormElement extends Model
     use HasFactory;
 
     protected $fillable = [
-        'label',
-        'visible_label',
+        'labelText',
+        'hideLabel',
+        'defaultChecked',
+        'helperText',
     ];
 
     protected $casts = [
-        'visible_label' => 'boolean',
+        'hideLabel' => 'boolean',
+        'defaultChecked' => 'boolean',
     ];
 
     protected $attributes = [
-        'visible_label' => true,
+        'hideLabel' => false,
+        'defaultChecked' => false,
     ];
 
     /**
@@ -29,14 +34,15 @@ class CheckboxInputFormElement extends Model
     public static function getFilamentSchema(bool $disabled = false): array
     {
         return [
-            \Filament\Forms\Components\TextInput::make('elementable_data.label')
+            SchemaHelper::getLabelTextField($disabled)
                 ->label('Checkbox Label')
-                ->required(true)
+                ->required(),
+            SchemaHelper::getHideLabelToggle($disabled),
+            \Filament\Forms\Components\Toggle::make('elementable_data.defaultChecked')
+                ->label('Default Checked')
+                ->default(false)
                 ->disabled($disabled),
-            \Filament\Forms\Components\Toggle::make('elementable_data.visible_label')
-                ->label('Show Label')
-                ->default(true)
-                ->disabled($disabled),
+            SchemaHelper::getHelperTextField($disabled),
         ];
     }
 
@@ -54,8 +60,10 @@ class CheckboxInputFormElement extends Model
     public function getData(): array
     {
         return [
-            'label' => $this->label,
-            'visible_label' => $this->visible_label,
+            'labelText' => $this->labelText,
+            'hideLabel' => $this->hideLabel,
+            'defaultChecked' => $this->defaultChecked,
+            'helperText' => $this->helperText,
         ];
     }
 }

--- a/app/Models/FormBuilding/ContainerFormElement.php
+++ b/app/Models/FormBuilding/ContainerFormElement.php
@@ -12,23 +12,17 @@ class ContainerFormElement extends Model
 
     protected $fillable = [
         'container_type',
-        'collapsible',
-        'collapsed_by_default',
         'is_repeatable',
         'repeater_item_label',
         'legend',
     ];
 
     protected $casts = [
-        'collapsible' => 'boolean',
-        'collapsed_by_default' => 'boolean',
         'is_repeatable' => 'boolean',
     ];
 
     protected $attributes = [
         'container_type' => 'section',
-        'collapsible' => false,
-        'collapsed_by_default' => false,
         'is_repeatable' => false,
     ];
 
@@ -48,18 +42,6 @@ class ContainerFormElement extends Model
                 ->label('Legend/Title')
                 ->helperText('Optional title for the container')
                 ->disabled($disabled),
-            \Filament\Forms\Components\Toggle::make('elementable_data.collapsible')
-                ->label('Collapsible')
-                ->helperText('Allow users to expand/collapse this container')
-                ->default(false)
-                ->live()
-                ->disabled($disabled),
-            \Filament\Forms\Components\Toggle::make('elementable_data.collapsed_by_default')
-                ->label('Collapsed by Default')
-                ->helperText('Start with container collapsed')
-                ->default(false)
-                ->disabled($disabled)
-                ->visible(fn(callable $get) => $get('elementable_data.collapsible')),
             \Filament\Forms\Components\Toggle::make('elementable_data.is_repeatable')
                 ->label('Repeatable')
                 ->helperText('Allow users to add multiple instances of this container')
@@ -89,11 +71,9 @@ class ContainerFormElement extends Model
     {
         return [
             'container_type' => $this->container_type,
-            'collapsible' =>         $this->collapsible,
-            'collapsed_by_default' =>         $this->collapsed_by_default,
-            'is_repeatable' =>         $this->is_repeatable,
-            'repeater_item_label' =>         $this->repeater_item_label,
-            'legend' =>         $this->legend,
+            'is_repeatable' => $this->is_repeatable,
+            'repeater_item_label' => $this->repeater_item_label,
+            'legend' => $this->legend,
         ];
     }
 
@@ -106,6 +86,8 @@ class ContainerFormElement extends Model
             'page' => 'Page',
             'fieldset' => 'Fieldset',
             'section' => 'Section',
+            'header' => 'Header',
+            'footer' => 'Footer',
         ];
     }
 
@@ -114,6 +96,6 @@ class ContainerFormElement extends Model
      */
     public function canHaveChildren(): bool
     {
-        return in_array($this->container_type, ['page', 'fieldset', 'section']);
+        return in_array($this->container_type, ['page', 'fieldset', 'section', 'header', 'footer']);
     }
 }

--- a/app/Models/FormBuilding/DateSelectInputFormElement.php
+++ b/app/Models/FormBuilding/DateSelectInputFormElement.php
@@ -11,27 +11,23 @@ class DateSelectInputFormElement extends Model
     use HasFactory;
 
     protected $fillable = [
-        'placeholder_text',
-        'label',
-        'visible_label',
-        'min_date',
-        'max_date',
-        'default_date',
-        'date_format',
-        'include_time',
+        'placeholder',
+        'labelText',
+        'hideLabel',
+        'minDate',
+        'maxDate',
+        'dateFormat',
+        'helperText',
     ];
 
     protected $casts = [
-        'visible_label' => 'boolean',
-        'min_date' => 'date',
-        'max_date' => 'date',
-        'default_date' => 'date',
-        'include_time' => 'boolean',
+        'hideLabel' => 'boolean',
+        'minDate' => 'date',
+        'maxDate' => 'date',
     ];
 
     protected $attributes = [
-        'visible_label' => true,
-        'include_time' => false,
+        'hideLabel' => false,
     ];
 
     /**
@@ -40,37 +36,31 @@ class DateSelectInputFormElement extends Model
     public static function getFilamentSchema(bool $disabled = false): array
     {
         return [
-            \Filament\Forms\Components\TextInput::make('elementable_data.label')
+            \Filament\Forms\Components\TextInput::make('elementable_data.labelText')
                 ->label('Field Label')
                 ->disabled($disabled),
-            \Filament\Forms\Components\Toggle::make('elementable_data.visible_label')
-                ->label('Show Label')
-                ->default(true)
+            \Filament\Forms\Components\Toggle::make('elementable_data.hideLabel')
+                ->label('Hide Label')
+                ->default(false)
                 ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.placeholder_text')
+            \Filament\Forms\Components\TextInput::make('elementable_data.placeholder')
                 ->label('Placeholder Text')
                 ->disabled($disabled),
-            \Filament\Forms\Components\Select::make('elementable_data.date_format')
+            \Filament\Forms\Components\Select::make('elementable_data.dateFormat')
                 ->label('Date Format')
                 ->options(static::getDateFormats())
                 ->default('Y-m-d')
                 ->disabled($disabled),
-            \Filament\Forms\Components\Toggle::make('elementable_data.include_time')
-                ->label('Include Time')
-                ->helperText('Allow users to select time in addition to date')
-                ->default(false)
-                ->disabled($disabled),
-            \Filament\Forms\Components\DatePicker::make('elementable_data.min_date')
+            \Filament\Forms\Components\DatePicker::make('elementable_data.minDate')
                 ->label('Minimum Date')
                 ->helperText('Earliest date users can select')
                 ->disabled($disabled),
-            \Filament\Forms\Components\DatePicker::make('elementable_data.max_date')
+            \Filament\Forms\Components\DatePicker::make('elementable_data.maxDate')
                 ->label('Maximum Date')
                 ->helperText('Latest date users can select')
                 ->disabled($disabled),
-            \Filament\Forms\Components\DatePicker::make('elementable_data.default_date')
-                ->label('Default Date')
-                ->helperText('Pre-selected date')
+            \Filament\Forms\Components\Textarea::make('elementable_data.helperText')
+                ->label('Helper Text')
                 ->disabled($disabled),
         ];
     }
@@ -89,14 +79,13 @@ class DateSelectInputFormElement extends Model
     public function getData(): array
     {
         return [
-            'placeholder_text' => $this->placeholder_text,
-            'label' => $this->label,
-            'visible_label' => $this->visible_label,
-            'min_date' => $this->min_date,
-            'max_date' => $this->max_date,
-            'default_date' => $this->default_date,
-            'date_format' => $this->date_format,
-            'include_time' => $this->include_time,
+            'placeholder' => $this->placeholder,
+            'labelText' => $this->labelText,
+            'hideLabel' => $this->hideLabel,
+            'minDate' => $this->minDate,
+            'maxDate' => $this->maxDate,
+            'dateFormat' => $this->dateFormat,
+            'helperText' => $this->helperText,
         ];
     }
 

--- a/app/Models/FormBuilding/DateSelectInputFormElement.php
+++ b/app/Models/FormBuilding/DateSelectInputFormElement.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\FormBuilding;
 
+use App\Helpers\SchemaHelper;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
@@ -14,10 +15,10 @@ class DateSelectInputFormElement extends Model
         'placeholder',
         'labelText',
         'hideLabel',
+        'helperText',
         'minDate',
         'maxDate',
         'dateFormat',
-        'helperText',
     ];
 
     protected $casts = [
@@ -35,34 +36,24 @@ class DateSelectInputFormElement extends Model
      */
     public static function getFilamentSchema(bool $disabled = false): array
     {
-        return [
-            \Filament\Forms\Components\TextInput::make('elementable_data.labelText')
-                ->label('Field Label')
-                ->disabled($disabled),
-            \Filament\Forms\Components\Toggle::make('elementable_data.hideLabel')
-                ->label('Hide Label')
-                ->default(false)
-                ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.placeholder')
-                ->label('Placeholder Text')
-                ->disabled($disabled),
-            \Filament\Forms\Components\Select::make('elementable_data.dateFormat')
-                ->label('Date Format')
-                ->options(static::getDateFormats())
-                ->default('Y-m-d')
-                ->disabled($disabled),
-            \Filament\Forms\Components\DatePicker::make('elementable_data.minDate')
-                ->label('Minimum Date')
-                ->helperText('Earliest date users can select')
-                ->disabled($disabled),
-            \Filament\Forms\Components\DatePicker::make('elementable_data.maxDate')
-                ->label('Maximum Date')
-                ->helperText('Latest date users can select')
-                ->disabled($disabled),
-            \Filament\Forms\Components\Textarea::make('elementable_data.helperText')
-                ->label('Helper Text')
-                ->disabled($disabled),
-        ];
+        return array_merge(
+            SchemaHelper::getCommonCarbonFields($disabled),
+            [
+                \Filament\Forms\Components\Select::make('elementable_data.dateFormat')
+                    ->label('Date Format')
+                    ->options(static::getDateFormats())
+                    ->default('Y-m-d')
+                    ->disabled($disabled),
+                \Filament\Forms\Components\DatePicker::make('elementable_data.minDate')
+                    ->label('Minimum Date')
+                    ->helperText('Earliest date users can select')
+                    ->disabled($disabled),
+                \Filament\Forms\Components\DatePicker::make('elementable_data.maxDate')
+                    ->label('Maximum Date')
+                    ->helperText('Latest date users can select')
+                    ->disabled($disabled),
+            ]
+        );
     }
 
     /**

--- a/app/Models/FormBuilding/NumberInputFormElement.php
+++ b/app/Models/FormBuilding/NumberInputFormElement.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\FormBuilding;
 
+use App\Helpers\SchemaHelper;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
@@ -11,26 +12,29 @@ class NumberInputFormElement extends Model
     use HasFactory;
 
     protected $fillable = [
-        'placeholder_text',
-        'label',
-        'visible_label',
+        'placeholder',
+        'labelText',
+        'hideLabel',
         'min',
         'max',
         'step',
-        'default_value',
+        'defaultValue',
+        'helperText',
+        'formatStyle',
     ];
 
     protected $casts = [
-        'visible_label' => 'boolean',
-        'min' => 'integer',
-        'max' => 'integer',
-        'step' => 'integer',
-        'default_value' => 'integer',
+        'hideLabel' => 'boolean',
+        'min' => 'decimal:2',
+        'max' => 'decimal:2',
+        'step' => 'decimal:2',
+        'defaultValue' => 'decimal:2',
     ];
 
     protected $attributes = [
-        'visible_label' => true,
+        'hideLabel' => false,
         'step' => 1,
+        'formatStyle' => 'decimal',
     ];
 
     /**
@@ -38,35 +42,43 @@ class NumberInputFormElement extends Model
      */
     public static function getFilamentSchema(bool $disabled = false): array
     {
-        return [
-            \Filament\Forms\Components\TextInput::make('elementable_data.placeholder_text')
-                ->label('Placeholder Text')
-                ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.label')
-                ->label('Field Label')
-                ->disabled($disabled),
-            \Filament\Forms\Components\Toggle::make('elementable_data.visible_label')
-                ->label('Show Label')
-                ->default(true)
-                ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.min')
-                ->label('Minimum Value')
-                ->numeric()
-                ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.max')
-                ->label('Maximum Value')
-                ->numeric()
-                ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.step')
-                ->label('Step Size')
-                ->numeric()
-                ->default(1)
-                ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.default_value')
-                ->label('Default Value')
-                ->numeric()
-                ->disabled($disabled),
-        ];
+        return array_merge(
+            SchemaHelper::getCommonCarbonFields($disabled),
+            [
+                \Filament\Forms\Components\TextInput::make('elementable_data.min')
+                    ->label('Minimum Value')
+                    ->numeric()
+                    ->step(1)
+                    ->disabled($disabled),
+                \Filament\Forms\Components\TextInput::make('elementable_data.max')
+                    ->label('Maximum Value')
+                    ->numeric()
+                    ->step(1)
+                    ->disabled($disabled),
+                \Filament\Forms\Components\TextInput::make('elementable_data.step')
+                    ->label('Step Size')
+                    ->numeric()
+                    ->step(1)
+                    ->default(1)
+                    ->minValue(0)
+                    ->disabled($disabled),
+                \Filament\Forms\Components\TextInput::make('elementable_data.defaultValue')
+                    ->label('Default Value')
+                    ->numeric()
+                    ->step(1)
+                    ->disabled($disabled),
+                \Filament\Forms\Components\Select::make('elementable_data.formatStyle')
+                    ->label('Format Style')
+                    ->options([
+                        'decimal' => 'Decimal',
+                        'currency' => 'Currency',
+                        'integer' => 'Integer',
+                    ])
+                    ->default('decimal')
+                    ->live()
+                    ->disabled($disabled),
+            ]
+        );
     }
 
     /**
@@ -83,13 +95,15 @@ class NumberInputFormElement extends Model
     public function getData(): array
     {
         return [
-            'placeholder_text' => $this->placeholder_text,
-            'label' => $this->label,
-            'visible_label' => $this->visible_label,
+            'placeholder' => $this->placeholder,
+            'labelText' => $this->labelText,
+            'hideLabel' => $this->hideLabel,
             'min' => $this->min,
             'max' => $this->max,
             'step' => $this->step,
-            'default_value' => $this->default_value,
+            'defaultValue' => $this->defaultValue,
+            'helperText' => $this->helperText,
+            'formatStyle' => $this->formatStyle,
         ];
     }
 }

--- a/app/Models/FormBuilding/RadioInputFormElement.php
+++ b/app/Models/FormBuilding/RadioInputFormElement.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\FormBuilding;
 
+use App\Helpers\SchemaHelper;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
@@ -12,18 +13,23 @@ class RadioInputFormElement extends Model
     use HasFactory;
 
     protected $fillable = [
-        'label',
-        'visible_label',
-        'default_value',
+        'labelText',
+        'hideLabel',
+        'defaultSelected',
+        'labelPosition',
+        'helperText',
+        'orientation',
     ];
 
     protected $casts = [
-        'visible_label' => 'boolean',
+        'hideLabel' => 'boolean',
     ];
 
     protected $attributes = [
-        'visible_label' => true,
-        'label' => '',
+        'hideLabel' => false,
+        'labelText' => '',
+        'labelPosition' => 'right',
+        'orientation' => 'vertical',
     ];
 
     /**
@@ -32,16 +38,39 @@ class RadioInputFormElement extends Model
     public static function getFilamentSchema(bool $disabled = false): array
     {
         return [
-            \Filament\Forms\Components\TextInput::make('elementable_data.label')
-                ->label('Field Label')
-                ->required()
+            SchemaHelper::getLabelTextField($disabled)
+                ->required(),
+            SchemaHelper::getHideLabelToggle($disabled),
+            \Filament\Forms\Components\Select::make('elementable_data.labelPosition')
+                ->label('Label Position')
+                ->options([
+                    'left' => 'Left',
+                    'right' => 'Right',
+                ])
+                ->default('right')
+                ->visible(fn(callable $get): bool => !$get('elementable_data.hideLabel'))
                 ->disabled($disabled),
-            \Filament\Forms\Components\Toggle::make('elementable_data.visible_label')
-                ->label('Show Label')
-                ->default(true)
+            SchemaHelper::getHelperTextField($disabled),
+            \Filament\Forms\Components\Select::make('elementable_data.orientation')
+                ->label('Orientation')
+                ->options([
+                    'horizontal' => 'Horizontal',
+                    'vertical' => 'Vertical',
+                ])
+                ->default('vertical')
                 ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.default_value')
+            \Filament\Forms\Components\Select::make('elementable_data.defaultSelected')
                 ->label('Default Selected Value')
+                ->options(function (callable $get) {
+                    $options = $get('elementable_data.options') ?? [];
+                    $selectOptions = [];
+                    foreach ($options as $option) {
+                        if (!empty($option['value'])) {
+                            $selectOptions[$option['value']] = $option['label'] ?? $option['value'];
+                        }
+                    }
+                    return $selectOptions;
+                })
                 ->disabled($disabled),
             \Filament\Forms\Components\Repeater::make('elementable_data.options')
                 ->label('Options')
@@ -100,9 +129,12 @@ class RadioInputFormElement extends Model
     public function getData(): array
     {
         return [
-            'label' => $this->label,
-            'visible_label' => $this->visible_label,
-            'default_value' => $this->default_value,
+            'labelText' => $this->labelText,
+            'hideLabel' => $this->hideLabel,
+            'defaultSelected' => $this->defaultSelected,
+            'labelPosition' => $this->labelPosition,
+            'helperText' => $this->helperText,
+            'orientation' => $this->orientation,
         ];
     }
 

--- a/app/Models/FormBuilding/SelectInputFormElement.php
+++ b/app/Models/FormBuilding/SelectInputFormElement.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\FormBuilding;
 
+use App\Helpers\SchemaHelper;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
@@ -12,17 +13,18 @@ class SelectInputFormElement extends Model
     use HasFactory;
 
     protected $fillable = [
-        'label',
-        'visible_label',
+        'labelText',
+        'hideLabel',
+        'helperText',
     ];
 
     protected $casts = [
-        'visible_label' => 'boolean',
+        'hideLabel' => 'boolean',
     ];
 
     protected $attributes = [
-        'visible_label' => true,
-        'label' => '',
+        'hideLabel' => false,
+        'labelText' => '',
     ];
 
     /**
@@ -31,14 +33,10 @@ class SelectInputFormElement extends Model
     public static function getFilamentSchema(bool $disabled = false): array
     {
         return [
-            \Filament\Forms\Components\TextInput::make('elementable_data.label')
-                ->label('Field Label')
-                ->required()
-                ->disabled($disabled),
-            \Filament\Forms\Components\Toggle::make('elementable_data.visible_label')
-                ->label('Show Label')
-                ->default(true)
-                ->disabled($disabled),
+            SchemaHelper::getLabelTextField($disabled)
+                ->required(),
+            SchemaHelper::getHideLabelToggle($disabled),
+            SchemaHelper::getHelperTextField($disabled),
             \Filament\Forms\Components\Repeater::make('elementable_data.options')
                 ->label('Options')
                 ->schema([
@@ -96,8 +94,9 @@ class SelectInputFormElement extends Model
     public function getData(): array
     {
         return [
-            'label' => $this->label,
-            'visible_label' => $this->visible_label,
+            'labelText' => $this->labelText,
+            'hideLabel' => $this->hideLabel,
+            'helperText' => $this->helperText,
         ];
     }
 

--- a/app/Models/FormBuilding/TextInputFormElement.php
+++ b/app/Models/FormBuilding/TextInputFormElement.php
@@ -11,22 +11,22 @@ class TextInputFormElement extends Model
     use HasFactory;
 
     protected $fillable = [
-        'placeholder_text',
-        'label',
-        'visible_label',
+        'placeholder',
+        'labelText',
+        'hideLabel',
         'mask',
-        'maxlength',
-        'minlength',
+        'maxCount',
+        'defaultValue',
+        'helperText',
     ];
 
     protected $casts = [
-        'visible_label' => 'boolean',
-        'maxlength' => 'integer',
-        'minlength' => 'integer',
+        'hideLabel' => 'boolean',
+        'maxCount' => 'integer',
     ];
 
     protected $attributes = [
-        'visible_label' => true,
+        'hideLabel' => false,
     ];
 
     /**
@@ -35,26 +35,28 @@ class TextInputFormElement extends Model
     public static function getFilamentSchema(bool $disabled = false): array
     {
         return [
-            \Filament\Forms\Components\TextInput::make('elementable_data.placeholder_text')
+            \Filament\Forms\Components\TextInput::make('elementable_data.placeholder')
                 ->label('Placeholder Text')
                 ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.label')
+            \Filament\Forms\Components\TextInput::make('elementable_data.labelText')
                 ->label('Field Label')
                 ->disabled($disabled),
-            \Filament\Forms\Components\Toggle::make('elementable_data.visible_label')
-                ->label('Show Label')
-                ->default(true)
+            \Filament\Forms\Components\Toggle::make('elementable_data.hideLabel')
+                ->label('Hide Label')
+                ->default(false)
                 ->disabled($disabled),
             \Filament\Forms\Components\TextInput::make('elementable_data.mask')
                 ->label('Input Mask')
                 ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.minlength')
-                ->label('Minimum Length')
+            \Filament\Forms\Components\TextInput::make('elementable_data.maxCount')
+                ->label('Maximum Character Count')
                 ->numeric()
                 ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.maxlength')
-                ->label('Maximum Length')
-                ->numeric()
+            \Filament\Forms\Components\TextInput::make('elementable_data.defaultValue')
+                ->label('Default Value')
+                ->disabled($disabled),
+            \Filament\Forms\Components\Textarea::make('elementable_data.helperText')
+                ->label('Helper Text')
                 ->disabled($disabled),
         ];
     }
@@ -73,12 +75,13 @@ class TextInputFormElement extends Model
     public function getData(): array
     {
         return [
-            'placeholder_text' => $this->placeholder_text,
-            'label' => $this->label,
-            'visible_label' => $this->visible_label,
+            'placeholder' => $this->placeholder,
+            'labelText' => $this->labelText,
+            'hideLabel' => $this->hideLabel,
             'mask' => $this->mask,
-            'maxlength' => $this->maxlength,
-            'minlength' => $this->minlength,
+            'maxCount' => $this->maxCount,
+            'defaultValue' => $this->defaultValue,
+            'helperText' => $this->helperText,
         ];
     }
 }

--- a/app/Models/FormBuilding/TextInputFormElement.php
+++ b/app/Models/FormBuilding/TextInputFormElement.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\FormBuilding;
 
+use App\Helpers\SchemaHelper;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
@@ -14,10 +15,10 @@ class TextInputFormElement extends Model
         'placeholder',
         'labelText',
         'hideLabel',
+        'helperText',
         'mask',
         'maxCount',
         'defaultValue',
-        'helperText',
     ];
 
     protected $casts = [
@@ -34,31 +35,21 @@ class TextInputFormElement extends Model
      */
     public static function getFilamentSchema(bool $disabled = false): array
     {
-        return [
-            \Filament\Forms\Components\TextInput::make('elementable_data.placeholder')
-                ->label('Placeholder Text')
-                ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.labelText')
-                ->label('Field Label')
-                ->disabled($disabled),
-            \Filament\Forms\Components\Toggle::make('elementable_data.hideLabel')
-                ->label('Hide Label')
-                ->default(false)
-                ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.mask')
-                ->label('Input Mask')
-                ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.maxCount')
-                ->label('Maximum Character Count')
-                ->numeric()
-                ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.defaultValue')
-                ->label('Default Value')
-                ->disabled($disabled),
-            \Filament\Forms\Components\Textarea::make('elementable_data.helperText')
-                ->label('Helper Text')
-                ->disabled($disabled),
-        ];
+        return array_merge(
+            SchemaHelper::getCommonCarbonFields($disabled),
+            [
+                \Filament\Forms\Components\TextInput::make('elementable_data.mask')
+                    ->label('Input Mask')
+                    ->disabled($disabled),
+                \Filament\Forms\Components\TextInput::make('elementable_data.maxCount')
+                    ->label('Maximum Character Count')
+                    ->numeric()
+                    ->disabled($disabled),
+                \Filament\Forms\Components\TextInput::make('elementable_data.defaultValue')
+                    ->label('Default Value')
+                    ->disabled($disabled),
+            ]
+        );
     }
 
     /**

--- a/app/Models/FormBuilding/TextareaInputFormElement.php
+++ b/app/Models/FormBuilding/TextareaInputFormElement.php
@@ -11,25 +11,25 @@ class TextareaInputFormElement extends Model
     use HasFactory;
 
     protected $fillable = [
-        'placeholder_text',
-        'label',
-        'visible_label',
+        'placeholder',
+        'labelText',
+        'hideLabel',
         'rows',
         'cols',
-        'maxlength',
-        'minlength',
+        'maxCount',
+        'defaultValue',
+        'helperText',
     ];
 
     protected $casts = [
-        'visible_label' => 'boolean',
+        'hideLabel' => 'boolean',
         'rows' => 'integer',
         'cols' => 'integer',
-        'maxlength' => 'integer',
-        'minlength' => 'integer',
+        'maxCount' => 'integer',
     ];
 
     protected $attributes = [
-        'visible_label' => true,
+        'hideLabel' => false,
         'rows' => 3,
     ];
 
@@ -39,15 +39,15 @@ class TextareaInputFormElement extends Model
     public static function getFilamentSchema(bool $disabled = false): array
     {
         return [
-            \Filament\Forms\Components\TextInput::make('elementable_data.placeholder_text')
+            \Filament\Forms\Components\TextInput::make('elementable_data.placeholder')
                 ->label('Placeholder Text')
                 ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.label')
+            \Filament\Forms\Components\TextInput::make('elementable_data.labelText')
                 ->label('Field Label')
                 ->disabled($disabled),
-            \Filament\Forms\Components\Toggle::make('elementable_data.visible_label')
-                ->label('Show Label')
-                ->default(true)
+            \Filament\Forms\Components\Toggle::make('elementable_data.hideLabel')
+                ->label('Hide Label')
+                ->default(false)
                 ->disabled($disabled),
             \Filament\Forms\Components\TextInput::make('elementable_data.rows')
                 ->label('Number of Rows')
@@ -58,13 +58,15 @@ class TextareaInputFormElement extends Model
                 ->label('Number of Columns')
                 ->numeric()
                 ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.minlength')
-                ->label('Minimum Length')
+            \Filament\Forms\Components\TextInput::make('elementable_data.maxCount')
+                ->label('Maximum Character Count')
                 ->numeric()
                 ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.maxlength')
-                ->label('Maximum Length')
-                ->numeric()
+            \Filament\Forms\Components\TextInput::make('elementable_data.defaultValue')
+                ->label('Default Value')
+                ->disabled($disabled),
+            \Filament\Forms\Components\Textarea::make('elementable_data.helperText')
+                ->label('Helper Text')
                 ->disabled($disabled),
         ];
     }
@@ -83,13 +85,14 @@ class TextareaInputFormElement extends Model
     public function getData(): array
     {
         return [
-            'placeholder_text' => $this->placeholder_text,
-            'label' => $this->label,
-            'visible_label' => $this->visible_label,
+            'placeholder' => $this->placeholder,
+            'labelText' => $this->labelText,
+            'hideLabel' => $this->hideLabel,
             'rows' => $this->rows,
             'cols' => $this->cols,
-            'maxlength' => $this->maxlength,
-            'minlength' => $this->minlength,
+            'maxCount' => $this->maxCount,
+            'defaultValue' => $this->defaultValue,
+            'helperText' => $this->helperText,
         ];
     }
 }

--- a/app/Models/FormBuilding/TextareaInputFormElement.php
+++ b/app/Models/FormBuilding/TextareaInputFormElement.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\FormBuilding;
 
+use App\Helpers\SchemaHelper;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
@@ -14,11 +15,11 @@ class TextareaInputFormElement extends Model
         'placeholder',
         'labelText',
         'hideLabel',
+        'helperText',
         'rows',
         'cols',
         'maxCount',
         'defaultValue',
-        'helperText',
     ];
 
     protected $casts = [
@@ -38,37 +39,27 @@ class TextareaInputFormElement extends Model
      */
     public static function getFilamentSchema(bool $disabled = false): array
     {
-        return [
-            \Filament\Forms\Components\TextInput::make('elementable_data.placeholder')
-                ->label('Placeholder Text')
-                ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.labelText')
-                ->label('Field Label')
-                ->disabled($disabled),
-            \Filament\Forms\Components\Toggle::make('elementable_data.hideLabel')
-                ->label('Hide Label')
-                ->default(false)
-                ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.rows')
-                ->label('Number of Rows')
-                ->numeric()
-                ->default(3)
-                ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.cols')
-                ->label('Number of Columns')
-                ->numeric()
-                ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.maxCount')
-                ->label('Maximum Character Count')
-                ->numeric()
-                ->disabled($disabled),
-            \Filament\Forms\Components\TextInput::make('elementable_data.defaultValue')
-                ->label('Default Value')
-                ->disabled($disabled),
-            \Filament\Forms\Components\Textarea::make('elementable_data.helperText')
-                ->label('Helper Text')
-                ->disabled($disabled),
-        ];
+        return array_merge(
+            SchemaHelper::getCommonCarbonFields($disabled),
+            [
+                \Filament\Forms\Components\TextInput::make('elementable_data.rows')
+                    ->label('Number of Rows')
+                    ->numeric()
+                    ->default(3)
+                    ->disabled($disabled),
+                \Filament\Forms\Components\TextInput::make('elementable_data.cols')
+                    ->label('Number of Columns')
+                    ->numeric()
+                    ->disabled($disabled),
+                \Filament\Forms\Components\TextInput::make('elementable_data.maxCount')
+                    ->label('Maximum Character Count')
+                    ->numeric()
+                    ->disabled($disabled),
+                \Filament\Forms\Components\TextInput::make('elementable_data.defaultValue')
+                    ->label('Default Value')
+                    ->disabled($disabled),
+            ]
+        );
     }
 
     /**

--- a/database/migrations/2025_07_15_214651_update_textarea_input_form_elements_for_carbon_design_system.php
+++ b/database/migrations/2025_07_15_214651_update_textarea_input_form_elements_for_carbon_design_system.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('textarea_input_form_elements', function (Blueprint $table) {
+            // Rename existing columns to match Carbon Design System
+            $table->renameColumn('placeholder_text', 'placeholder');
+            $table->renameColumn('label', 'labelText');
+            $table->renameColumn('visible_label', 'hideLabel');
+            $table->renameColumn('maxlength', 'maxCount');
+
+            // Add new Carbon Design System fields
+            $table->string('defaultValue')->nullable();
+            $table->text('helperText')->nullable();
+
+            // Remove field not used in Carbon Design System
+            $table->dropColumn('minlength');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('textarea_input_form_elements', function (Blueprint $table) {
+            // Reverse the column renames
+            $table->renameColumn('placeholder', 'placeholder_text');
+            $table->renameColumn('labelText', 'label');
+            $table->renameColumn('hideLabel', 'visible_label');
+            $table->renameColumn('maxCount', 'maxlength');
+
+            // Remove the new fields
+            $table->dropColumn(['defaultValue', 'helperText']);
+
+            // Add back the removed field
+            $table->integer('minlength')->nullable();
+        });
+    }
+};

--- a/database/migrations/2025_07_16_042512_update_text_input_form_elements_for_carbon_design_system.php
+++ b/database/migrations/2025_07_16_042512_update_text_input_form_elements_for_carbon_design_system.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('text_input_form_elements', function (Blueprint $table) {
+            // Rename existing columns to match Carbon Design System
+            $table->renameColumn('placeholder_text', 'placeholder');
+            $table->renameColumn('label', 'labelText');
+            $table->renameColumn('visible_label', 'hideLabel');
+            $table->renameColumn('maxlength', 'maxCount');
+
+            // Add new Carbon Design System fields
+            $table->string('defaultValue')->nullable();
+            $table->text('helperText')->nullable();
+
+            // Remove field not used in Carbon Design System (keep mask)
+            $table->dropColumn('minlength');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('text_input_form_elements', function (Blueprint $table) {
+            // Reverse the column renames
+            $table->renameColumn('placeholder', 'placeholder_text');
+            $table->renameColumn('labelText', 'label');
+            $table->renameColumn('hideLabel', 'visible_label');
+            $table->renameColumn('maxCount', 'maxlength');
+
+            // Remove the new fields
+            $table->dropColumn(['defaultValue', 'helperText']);
+
+            // Add back the removed field
+            $table->integer('minlength')->nullable();
+        });
+    }
+};

--- a/database/migrations/2025_07_16_043416_update_date_select_input_form_elements_for_carbon_design_system.php
+++ b/database/migrations/2025_07_16_043416_update_date_select_input_form_elements_for_carbon_design_system.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('date_select_input_form_elements', function (Blueprint $table) {
+            // Rename existing columns to match Carbon Design System
+            $table->renameColumn('placeholder_text', 'placeholder');
+            $table->renameColumn('label', 'labelText');
+            $table->renameColumn('visible_label', 'hideLabel');
+            $table->renameColumn('min_date', 'minDate');
+            $table->renameColumn('max_date', 'maxDate');
+            $table->renameColumn('date_format', 'dateFormat');
+
+            // Add new Carbon Design System fields
+            $table->text('helperText')->nullable();
+
+            // Remove fields not used in Carbon Design System
+            $table->dropColumn(['default_date', 'include_time']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('date_select_input_form_elements', function (Blueprint $table) {
+            // Reverse the column renames
+            $table->renameColumn('placeholder', 'placeholder_text');
+            $table->renameColumn('labelText', 'label');
+            $table->renameColumn('hideLabel', 'visible_label');
+            $table->renameColumn('minDate', 'min_date');
+            $table->renameColumn('maxDate', 'max_date');
+            $table->renameColumn('dateFormat', 'date_format');
+
+            // Remove the new fields
+            $table->dropColumn('helperText');
+
+            // Add back the removed fields
+            $table->date('default_date')->nullable();
+            $table->boolean('include_time')->default(false);
+        });
+    }
+};

--- a/database/migrations/2025_07_16_044826_update_radio_input_form_elements_for_carbon_design_system.php
+++ b/database/migrations/2025_07_16_044826_update_radio_input_form_elements_for_carbon_design_system.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('radio_input_form_elements', function (Blueprint $table) {
+            // Rename existing columns to match Carbon Design System
+            $table->renameColumn('label', 'labelText');
+            $table->renameColumn('visible_label', 'hideLabel');
+            $table->renameColumn('default_value', 'defaultSelected');
+
+            // Add new Carbon Design System fields
+            $table->enum('labelPosition', ['left', 'right'])->default('right');
+            $table->text('helperText')->nullable();
+            $table->enum('orientation', ['horizontal', 'vertical'])->default('vertical');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('radio_input_form_elements', function (Blueprint $table) {
+            // Reverse the column renames
+            $table->renameColumn('labelText', 'label');
+            $table->renameColumn('hideLabel', 'visible_label');
+            $table->renameColumn('defaultSelected', 'default_value');
+
+            // Remove the new fields
+            $table->dropColumn(['labelPosition', 'helperText', 'orientation']);
+        });
+    }
+};

--- a/database/migrations/2025_07_16_045832_update_select_input_form_elements_for_carbon_design_system.php
+++ b/database/migrations/2025_07_16_045832_update_select_input_form_elements_for_carbon_design_system.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('select_input_form_elements', function (Blueprint $table) {
+            // Rename existing columns to match Carbon Design System
+            $table->renameColumn('label', 'labelText');
+            $table->renameColumn('visible_label', 'hideLabel');
+
+            // Add new Carbon Design System fields
+            $table->text('helperText')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('select_input_form_elements', function (Blueprint $table) {
+            // Reverse the column renames
+            $table->renameColumn('labelText', 'label');
+            $table->renameColumn('hideLabel', 'visible_label');
+
+            // Remove the new fields
+            $table->dropColumn('helperText');
+        });
+    }
+};

--- a/database/migrations/2025_07_16_050259_update_checkbox_input_form_elements_for_carbon_design_system.php
+++ b/database/migrations/2025_07_16_050259_update_checkbox_input_form_elements_for_carbon_design_system.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('checkbox_input_form_elements', function (Blueprint $table) {
+            // Rename existing columns to match Carbon Design System
+            $table->renameColumn('label', 'labelText');
+            $table->renameColumn('visible_label', 'hideLabel');
+
+            // Add new Carbon Design System fields
+            $table->boolean('defaultChecked')->default(false);
+            $table->text('helperText')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('checkbox_input_form_elements', function (Blueprint $table) {
+            // Reverse the column renames
+            $table->renameColumn('labelText', 'label');
+            $table->renameColumn('hideLabel', 'visible_label');
+
+            // Remove the new fields
+            $table->dropColumn(['defaultChecked', 'helperText']);
+        });
+    }
+};

--- a/database/migrations/2025_07_16_051156_update_number_input_form_elements_for_carbon_design_system.php
+++ b/database/migrations/2025_07_16_051156_update_number_input_form_elements_for_carbon_design_system.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('number_input_form_elements', function (Blueprint $table) {
+            // Rename existing columns to match Carbon Design System
+            $table->renameColumn('placeholder_text', 'placeholder');
+            $table->renameColumn('label', 'labelText');
+            $table->renameColumn('visible_label', 'hideLabel');
+            $table->renameColumn('default_value', 'defaultValue');
+
+            // Add new Carbon Design System fields
+            $table->text('helperText')->nullable();
+            $table->enum('formatStyle', ['decimal', 'currency', 'integer'])->default('decimal');
+        });
+
+        // Change numeric columns to support decimals
+        Schema::table('number_input_form_elements', function (Blueprint $table) {
+            $table->decimal('min', 10, 2)->nullable()->change();
+            $table->decimal('max', 10, 2)->nullable()->change();
+            $table->decimal('step', 10, 2)->nullable()->change();
+            $table->decimal('defaultValue', 10, 2)->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('number_input_form_elements', function (Blueprint $table) {
+            // Reverse the column renames
+            $table->renameColumn('placeholder', 'placeholder_text');
+            $table->renameColumn('labelText', 'label');
+            $table->renameColumn('hideLabel', 'visible_label');
+            $table->renameColumn('defaultValue', 'default_value');
+
+            // Remove the new fields
+            $table->dropColumn(['helperText', 'formatStyle']);
+        });
+
+        // Change numeric columns back to integers
+        Schema::table('number_input_form_elements', function (Blueprint $table) {
+            $table->integer('min')->nullable()->change();
+            $table->integer('max')->nullable()->change();
+            $table->integer('step')->nullable()->change();
+            $table->integer('default_value')->nullable()->change();
+        });
+    }
+};

--- a/database/migrations/2025_07_16_053139_update_button_input_form_elements_for_carbon_design_system.php
+++ b/database/migrations/2025_07_16_053139_update_button_input_form_elements_for_carbon_design_system.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('button_input_form_elements', function (Blueprint $table) {
+            // Rename existing columns to match Carbon Design System
+            $table->renameColumn('label', 'text');
+            $table->renameColumn('button_type', 'kind');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('button_input_form_elements', function (Blueprint $table) {
+            // Reverse the column renames
+            $table->renameColumn('text', 'label');
+            $table->renameColumn('kind', 'button_type');
+        });
+    }
+};

--- a/database/migrations/2025_07_16_054142_cleanup_container_form_elements_and_add_header_footer.php
+++ b/database/migrations/2025_07_16_054142_cleanup_container_form_elements_and_add_header_footer.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // First, remove the collapsible-related columns
+        Schema::table('container_form_elements', function (Blueprint $table) {
+            $table->dropColumn(['collapsible', 'collapsed_by_default']);
+        });
+
+        // Update the container_type enum to include header and footer
+        // For PostgreSQL, we need to drop and recreate the check constraint
+
+        // Drop the existing check constraint
+        DB::statement("ALTER TABLE container_form_elements DROP CONSTRAINT IF EXISTS container_form_elements_container_type_check");
+
+        // Add new check constraint with additional values
+        DB::statement("ALTER TABLE container_form_elements ADD CONSTRAINT container_form_elements_container_type_check CHECK (container_type IN ('page', 'fieldset', 'section', 'header', 'footer'))");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // First, handle any header/footer types by converting them to section
+        DB::table('container_form_elements')
+            ->whereIn('container_type', ['header', 'footer'])
+            ->update(['container_type' => 'section']);
+
+        // Revert the enum back to original values
+
+        // Drop the current check constraint
+        DB::statement("ALTER TABLE container_form_elements DROP CONSTRAINT IF EXISTS container_form_elements_container_type_check");
+
+        // Add back the original check constraint
+        DB::statement("ALTER TABLE container_form_elements ADD CONSTRAINT container_form_elements_container_type_check CHECK (container_type IN ('page', 'fieldset', 'section'))");
+
+
+        // Add back the collapsible columns
+        Schema::table('container_form_elements', function (Blueprint $table) {
+            $table->boolean('collapsible')->default(false);
+            $table->boolean('collapsed_by_default')->default(false);
+        });
+    }
+};


### PR DESCRIPTION
## What changes did you make? 

Cleans up the elements to ensure they use the properties of the Carbon Design System react implementation so Kiln can use them.

For example date is here: https://react.carbondesignsystem.com/?path=/docs/components-datepicker--overview&args=inline:!false#component-api

## Why did you make these changes?

We didn't want to set or pass properties that Kiln couldn't use. This way we are passing all the fields Kiln can easily make use of.

## What alternatives did you consider?

Leaving it as is, but I think this is an important one to fix.

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
