### PR TITLE
don't show create tags in the edit modal

### DIFF
--- a/app/Helpers/GeneralTabHelper.php
+++ b/app/Helpers/GeneralTabHelper.php
@@ -412,24 +412,29 @@ class GeneralTabHelper
         if ($isCreate || $isEdit) {
             $tagsField = $tagsField
                 ->options(fn() => FormElementTag::pluck('name', 'id')->toArray())
-                ->createOptionAction(
-                    fn(Forms\Components\Actions\Action $action) => $action
-                        ->modalHeading('Create Tag')
-                        ->modalWidth('md')
-                )
-                ->createOptionForm([
-                    TextInput::make('name')
-                        ->required()
-                        ->maxLength(255)
-                        ->unique(FormElementTag::class, 'name'),
-                    Textarea::make('description')
-                        ->rows(3),
-                ])
-                ->createOptionUsing(function (array $data) {
-                    $tag = FormElementTag::create($data);
-                    return $tag->id;
-                })
                 ->preload();
+
+            // Only add createOptionAction for create mode to avoid modal stacking issues
+            if ($isCreate) {
+                $tagsField = $tagsField
+                    ->createOptionAction(
+                        fn(Forms\Components\Actions\Action $action) => $action
+                            ->modalHeading('Create Tag')
+                            ->modalWidth('md')
+                    )
+                    ->createOptionForm([
+                        TextInput::make('name')
+                            ->required()
+                            ->maxLength(255)
+                            ->unique(FormElementTag::class, 'name'),
+                        Textarea::make('description')
+                            ->rows(3),
+                    ])
+                    ->createOptionUsing(function (array $data) {
+                        $tag = FormElementTag::create($data);
+                        return $tag->id;
+                    });
+            }
         }
 
         $schema[] = $tagsField;


### PR DESCRIPTION
## What changes did you make? 

Only show the create tags option in the create modal

## Why did you make these changes?

It was breaking in the edit modal and would likely require changes to the tree package. This was easier.

## What alternatives did you consider?

N/A

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
