### PR TITLE
Bug/template containers

### DIFF
--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/BuildFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/BuildFormVersion.php
@@ -487,7 +487,8 @@ class BuildFormVersion extends Page implements HasForms
                             return ElementPropertiesHelper::getCreateSchema(
                                 $get('elementable_type')
                             );
-                        }),
+                        })
+                        ->hidden(fn(callable $get) => !empty($get('template_id'))),
                     \Filament\Forms\Components\Tabs\Tab::make('Data Bindings')
                         ->icon('heroicon-o-link')
                         ->schema(function (callable $get) {
@@ -495,7 +496,8 @@ class BuildFormVersion extends Page implements HasForms
                                 $this->record,
                                 fn() => $this->shouldShowTooltips()
                             );
-                        }),
+                        })
+                        ->hidden(fn(callable $get) => !empty($get('template_id'))),
                 ])
                 ->columnSpanFull(),
         ];

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/BuildFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/BuildFormVersion.php
@@ -167,9 +167,9 @@ class BuildFormVersion extends Page implements HasForms
                         }
 
                         // Filter out null values from elementable data to let model defaults apply
-                        // Keep false values as they are valid boolean values
+                        // Keep false values and empty strings as they are valid values
                         $elementableData = array_filter($elementableData, function ($value) {
-                            return $value !== null && $value !== '';
+                            return $value !== null;
                         });
 
                         // Set source_element_id if created from template
@@ -213,6 +213,11 @@ class BuildFormVersion extends Page implements HasForms
 
                                 if (!empty($updateData)) {
                                     $formElement->update($updateData);
+                                }
+
+                                // Update elementable data if provided
+                                if (!empty($elementableData) && $formElement->elementable) {
+                                    $formElement->elementable->update($elementableData);
                                 }
 
                                 // Update tags if provided
@@ -501,8 +506,7 @@ class BuildFormVersion extends Page implements HasForms
                             return ElementPropertiesHelper::getCreateSchema(
                                 $get('elementable_type')
                             );
-                        })
-                        ->hidden(fn(callable $get) => !empty($get('template_id'))),
+                        }),
                     \Filament\Forms\Components\Tabs\Tab::make('Data Bindings')
                         ->icon('heroicon-o-link')
                         ->schema(function (callable $get) {
@@ -510,8 +514,7 @@ class BuildFormVersion extends Page implements HasForms
                                 $this->record,
                                 fn() => $this->shouldShowTooltips()
                             );
-                        })
-                        ->hidden(fn(callable $get) => !empty($get('template_id'))),
+                        }),
                 ])
                 ->columnSpanFull(),
         ];

--- a/app/Helpers/ElementPropertiesHelper.php
+++ b/app/Helpers/ElementPropertiesHelper.php
@@ -11,11 +11,13 @@ class ElementPropertiesHelper
      *
      * @param string|null $elementType The element type class name
      * @param bool $disabled Whether the schema should be disabled (for view mode)
+     * @param string $mode The mode ('create' or 'edit')
      * @return array The schema array
      */
     public static function getElementPropertiesSchema(
         ?string $elementType = null,
-        bool $disabled = false
+        bool $disabled = false,
+        string $mode = 'create'
     ): array {
         // Handle case where no element type is available
         if (!$elementType) {
@@ -34,7 +36,7 @@ class ElementPropertiesHelper
 
         // Check if the element type class exists and has the getFilamentSchema method
         if (class_exists($elementType) && method_exists($elementType, 'getFilamentSchema')) {
-            return $elementType::getFilamentSchema($disabled);
+            return $elementType::getFilamentSchema($disabled, $mode);
         }
 
         // Fallback for element types that don't have schema defined yet
@@ -55,7 +57,8 @@ class ElementPropertiesHelper
     {
         return self::getElementPropertiesSchema(
             elementType: $elementType,
-            disabled: false
+            disabled: false,
+            mode: 'create'
         );
     }
 
@@ -69,7 +72,8 @@ class ElementPropertiesHelper
     {
         return self::getElementPropertiesSchema(
             elementType: $elementType,
-            disabled: false
+            disabled: false,
+            mode: 'edit'
         );
     }
 
@@ -83,7 +87,8 @@ class ElementPropertiesHelper
     {
         return self::getElementPropertiesSchema(
             elementType: $elementType,
-            disabled: true
+            disabled: true,
+            mode: 'edit'
         );
     }
 }

--- a/app/Helpers/GeneralTabHelper.php
+++ b/app/Helpers/GeneralTabHelper.php
@@ -36,7 +36,7 @@ class GeneralTabHelper
 
         // Template selector (only for create mode when explicitly requested)
         if ($includeTemplateSelector && $isCreate) {
-            $schema[] = Select::make('template_id')
+            $templateField = Select::make('template_id')
                 ->label('Start from template')
                 ->placeholder('Select a template (optional)')
                 ->options(function () {
@@ -101,6 +101,15 @@ class GeneralTabHelper
                 })
                 ->searchable()
                 ->columnSpanFull();
+
+            // Add tooltip if callback is provided
+            if ($shouldShowTooltipsCallback) {
+                $templateField = $templateField->when($shouldShowTooltipsCallback, function ($component) {
+                    return $component->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Select a template to start with pre-configured settings. For containers, this will also clone all child elements.');
+                });
+            }
+
+            $schema[] = $templateField;
         }
 
         // Name field

--- a/app/Helpers/GeneralTabHelper.php
+++ b/app/Helpers/GeneralTabHelper.php
@@ -21,12 +21,14 @@ class GeneralTabHelper
      * @param string $mode The form mode: 'create', 'edit', or 'view'
      * @param callable|null $shouldShowTooltipsCallback Callback to determine if tooltips should be shown
      * @param bool $includeTemplateSelector Whether to include the template selector (only for create mode)
+     * @param callable|null $disabledCallback Callback to determine if fields should be disabled
      * @return array The schema array
      */
     public static function getGeneralTabSchema(
         string $mode = 'create',
         ?callable $shouldShowTooltipsCallback = null,
-        bool $includeTemplateSelector = false
+        bool $includeTemplateSelector = false,
+        ?callable $disabledCallback = null
     ): array {
         $disabled = $mode === 'view';
         $isEdit = $mode === 'edit';
@@ -117,7 +119,7 @@ class GeneralTabHelper
             ->required()
             ->maxLength(255)
             ->label('Element Name')
-            ->disabled($disabled);
+            ->disabled($disabled || ($disabledCallback && $disabledCallback()));
 
         // Add auto-generation logic for create mode
         if ($isCreate) {
@@ -145,7 +147,7 @@ class GeneralTabHelper
         $referenceIdField = TextInput::make('reference_id')
             ->label('Reference ID')
             ->rules(['alpha_dash'])
-            ->disabled($disabled || $isEdit);
+            ->disabled($disabled || $isEdit || ($disabledCallback && $disabledCallback()));
 
         // Add tooltip if callback is provided
         if ($shouldShowTooltipsCallback) {
@@ -276,6 +278,7 @@ class GeneralTabHelper
                 ->options(FormElement::getAvailableElementTypes())
                 ->required()
                 ->live()
+                ->disabled($disabled || ($disabledCallback && $disabledCallback()))
                 ->afterStateUpdated(function ($state, callable $set) {
                     // Clear existing elementable data when type changes
                     $set('elementable_data', []);
@@ -306,12 +309,12 @@ class GeneralTabHelper
         // Description field
         $schema[] = Textarea::make('description')
             ->rows(3)
-            ->disabled($disabled);
+            ->disabled($disabled || ($disabledCallback && $disabledCallback()));
 
         // Help text field
         $helpTextField = TextInput::make('help_text')
             ->maxLength(500)
-            ->disabled($disabled);
+            ->disabled($disabled || ($disabledCallback && $disabledCallback()));
 
         // Add tooltip if callback is provided
         if ($shouldShowTooltipsCallback) {
@@ -328,18 +331,18 @@ class GeneralTabHelper
                 Toggle::make('visible_web')
                     ->label('Visible on Web')
                     ->default(true)
-                    ->disabled($disabled),
+                    ->disabled($disabled || ($disabledCallback && $disabledCallback())),
                 Toggle::make('visible_pdf')
                     ->label('Visible on PDF')
                     ->default(true)
-                    ->disabled($disabled),
+                    ->disabled($disabled || ($disabledCallback && $disabledCallback())),
             ]);
 
         // Required and Template toggles
         $templateToggle = Toggle::make('is_template')
             ->label('Is Template')
             ->default(false)
-            ->disabled($disabled);
+            ->disabled($disabled || ($disabledCallback && $disabledCallback()));
 
         // Add tooltip if callback is provided
         if ($shouldShowTooltipsCallback) {
@@ -352,8 +355,8 @@ class GeneralTabHelper
             ->label('Is Required')
             ->default(false);
 
-        // For view mode, disable the is_required toggle too
-        if ($disabled) {
+        // For view mode or when disabled callback is true, disable the is_required toggle too
+        if ($disabled || ($disabledCallback && $disabledCallback())) {
             $requirementToggle = $requirementToggle->disabled(true);
         }
 
@@ -367,12 +370,12 @@ class GeneralTabHelper
         $readOnlyToggle = Toggle::make('is_read_only')
             ->label('Is Read Only')
             ->default(false)
-            ->disabled($disabled);
+            ->disabled($disabled || ($disabledCallback && $disabledCallback()));
 
         $saveOnSubmitToggle = Toggle::make('save_on_submit')
             ->label('Save on Submit')
             ->default(true)
-            ->disabled($disabled);
+            ->disabled($disabled || ($disabledCallback && $disabledCallback()));
 
         // Add tooltip if callback is provided
         if ($shouldShowTooltipsCallback) {
@@ -392,7 +395,7 @@ class GeneralTabHelper
             ->label('Tags')
             ->multiple()
             ->searchable()
-            ->disabled($disabled);
+            ->disabled($disabled || ($disabledCallback && $disabledCallback()));
 
         // Add tooltip if callback is provided
         if ($shouldShowTooltipsCallback) {
@@ -447,16 +450,19 @@ class GeneralTabHelper
      *
      * @param callable|null $shouldShowTooltipsCallback Callback to determine if tooltips should be shown
      * @param bool $includeTemplateSelector Whether to include template selector
+     * @param callable|null $disabledCallback Callback to determine if fields should be disabled
      * @return array The schema array
      */
     public static function getCreateSchema(
         ?callable $shouldShowTooltipsCallback = null,
-        bool $includeTemplateSelector = true
+        bool $includeTemplateSelector = true,
+        ?callable $disabledCallback = null
     ): array {
         return self::getGeneralTabSchema(
             mode: 'create',
             shouldShowTooltipsCallback: $shouldShowTooltipsCallback,
-            includeTemplateSelector: $includeTemplateSelector
+            includeTemplateSelector: $includeTemplateSelector,
+            disabledCallback: $disabledCallback
         );
     }
 

--- a/app/Livewire/FormElementTreeBuilder.php
+++ b/app/Livewire/FormElementTreeBuilder.php
@@ -309,9 +309,21 @@ class FormElementTreeBuilder extends BaseWidget
         $elementableData = $data['elementable_data'] ?? [];
 
         // Filter out null values from elementable data to let model defaults apply
-        $elementableData = array_filter($elementableData, function ($value) {
-            return $value !== null;
-        });
+        // But convert null values to empty strings for text fields that the user might want to clear
+        $textFields = ['labelText', 'placeholder', 'helperText', 'mask', 'defaultValue', 'content', 'legend', 'repeater_item_label'];
+
+        $filteredElementableData = [];
+        foreach ($elementableData as $key => $value) {
+            if ($value !== null) {
+                $filteredElementableData[$key] = $value;
+            } elseif (in_array($key, $textFields)) {
+                // For text fields, convert null to empty string (user wants to clear the field)
+                $filteredElementableData[$key] = '';
+            }
+            // For other fields, skip null values to let model defaults apply
+        }
+
+        $elementableData = $filteredElementableData;
 
         // Remove elementable_data from main form data as it will be handled separately
         unset($data['elementable_data']);
@@ -452,9 +464,21 @@ class FormElementTreeBuilder extends BaseWidget
         unset($data['elementable_data']);
 
         // Filter out null values from elementable data to let model defaults apply
-        $elementableData = array_filter($elementableData, function ($value) {
-            return $value !== null;
-        });
+        // But convert null values to empty strings for text fields that the user might want to clear
+        $textFields = ['labelText', 'placeholder', 'helperText', 'mask', 'defaultValue', 'content', 'legend', 'repeater_item_label'];
+
+        $filteredElementableData = [];
+        foreach ($elementableData as $key => $value) {
+            if ($value !== null) {
+                $filteredElementableData[$key] = $value;
+            } elseif (in_array($key, $textFields)) {
+                // For text fields, convert null to empty string (user wants to clear the field)
+                $filteredElementableData[$key] = '';
+            }
+            // For other fields, skip null values to let model defaults apply
+        }
+
+        $elementableData = $filteredElementableData;
 
         // Store for use after main record creation
         $this->pendingElementableData = $elementableData;

--- a/app/Models/FormBuilding/TextInfoFormElement.php
+++ b/app/Models/FormBuilding/TextInfoFormElement.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Filament\Forms\Components\Textarea;
+use WeStacks\FilamentMonacoEditor\MonacoEditor;
 
 class TextInfoFormElement extends Model
 {
@@ -21,13 +22,26 @@ class TextInfoFormElement extends Model
 
     /**
      * Get the Filament form schema for this element type.
+     * 
+     * @param bool $disabled Whether the schema should be disabled
+     * @param string $mode The mode ('create' or 'edit')
      */
-    public static function getFilamentSchema(bool $disabled = false): array
+    public static function getFilamentSchema(bool $disabled = false, string $mode = 'create'): array
     {
+        if ($mode === 'create') {
+            return [
+                Textarea::make('elementable_data.content')
+                    ->label('Content')
+                    ->rows(10)
+                    ->disabled($disabled),
+            ];
+        }
+
         return [
-            Textarea::make('elementable_data.content')
+            MonacoEditor::make('elementable_data.content')
                 ->label('Content')
-                ->rows(10)
+                ->language('html')
+                ->theme('vs-dark')
                 ->disabled($disabled),
         ];
     }


### PR DESCRIPTION
## What changes did you make? 

- You can start from template for a container and it will bring in all child elements
- Also dropdowns and radios properly bring in their options when starting from template
- For Text Display it shows TextArea on create, and Monaco editor for edit
- Also fixing a bug when you try to save an empty field it wouldn't save. (for example if you previously had a placeholder and you try to update it to an empty string, it would just leave whatever value was previously there)

I should note that when you start from a template it disabled all the fields. You can still edit them after it's been cloned but not in the create screen anymore.

## Why did you make these changes?

Fixing some bugs and nice to haves

## What alternatives did you consider?

N/A

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**


https://github.com/user-attachments/assets/fa1093ef-59b0-42dc-877e-3dc9f47dff92



