### PR TITLE
Fix to requirements in plugin following update.

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -69,6 +69,7 @@ class AdminPanelProvider extends PanelProvider
                     ->navigationSort(2)
                     ->isResourceActionHidden(true)
                     ->isRestoreModelActionHidden(true)
+                    ->isRestoreActionHidden(false)
                     ->resource(CustomActivitylogResource::class)
                     ->authorize(fn() => CheckRole::hasRole(request(), 'admin'))
             ])

--- a/app/Providers/Filament/FormsPanelProvider.php
+++ b/app/Providers/Filament/FormsPanelProvider.php
@@ -85,6 +85,7 @@ class FormsPanelProvider extends PanelProvider
                     ->navigationSort(2)
                     ->isResourceActionHidden(true)
                     ->isRestoreModelActionHidden(true)
+                    ->isRestoreActionHidden(false)
                     ->resource(CustomActivitylogResource::class)
                     ->authorize(fn() => CheckRole::hasRole(request(), 'admin'))
             ])

--- a/app/Providers/Filament/HomePanelProvider.php
+++ b/app/Providers/Filament/HomePanelProvider.php
@@ -61,6 +61,7 @@ class HomePanelProvider extends PanelProvider
                     ->navigationItem(false)
                     ->isResourceActionHidden(true)
                     ->isRestoreModelActionHidden(true)
+                    ->isRestoreActionHidden(false)
                     ->resource(CustomActivitylogResource::class)
             ])
             ->middleware([


### PR DESCRIPTION
## What changes did you make? 

Recent updates to the Rsramos activity log plugin necessitate additional settings to function properly. Have added those properties to the universal imports on the admin panel, form panel, and home panel.

Without these, the view action was not available for any activity logs across the site.
