### PR TITLE
Add attributes for repeater group id.

### DIFF
--- a/app/Services/FormVersionJsonService.php
+++ b/app/Services/FormVersionJsonService.php
@@ -396,6 +396,7 @@ class FormVersionJsonService
         $attributes = $this->getElementAttributes($element);
         if (!empty($attributes)) {
             $elementData['attributes'] = $this->remapAttributes($attributes);
+            $elementData['attributes']['id'] = $elementData['id'];
         }
 
         $this->addElementStyles($elementData, $element);


### PR DESCRIPTION
## What changes did you make? 

Containers transformed into repeating groups were not including the UUID. This was due to how kiln was setup to handle groups. However, kiln was not currently using a unique id on the parent group element, so by adding the ...item.attributes spread in the groups in kiln in this commit: https://github.com/kiiskila-bcgov/klamm-kiln/commit/abe37c1bcaf0517e6d62f55c36ce2aec84bfd280, we can now pass the UUID directly to kiln and provide repeating groups with custom uuids. This makes styling/calculations substantially easier to manage.

