### PR TITLE
allow changing the reference ID

### DIFF
--- a/app/Helpers/GeneralTabHelper.php
+++ b/app/Helpers/GeneralTabHelper.php
@@ -143,11 +143,12 @@ class GeneralTabHelper
 
         $schema[] = $nameField;
 
-        // Reference ID field - only editable on create
+        // Reference ID field - editable on create and edit
         $referenceIdField = TextInput::make('reference_id')
             ->label('Reference ID')
             ->rules(['alpha_dash'])
-            ->disabled($disabled || $isEdit || ($disabledCallback && $disabledCallback()));
+            ->live()
+            ->disabled($disabled || ($disabledCallback && $disabledCallback()));
 
         // Add tooltip if callback is provided
         if ($shouldShowTooltipsCallback) {
@@ -158,7 +159,18 @@ class GeneralTabHelper
 
         // Add suffix and actions for edit mode
         if ($isEdit) {
+            $schema[] = Hidden::make('reference_id_locked');
             $referenceIdField = $referenceIdField
+                ->prefixAction(
+                    Action::make('toggleLock')
+                        ->icon(fn($get) => $get('reference_id_locked') ? 'heroicon-s-lock-open' : 'heroicon-s-lock-closed')
+                        ->tooltip(fn($get) => $get('reference_id_locked')
+                            ? ''
+                            : 'Click to unlock and edit the Reference ID. Changing this value may break ICM data bindings.')->action(function ($set, $get) {
+                            $set('reference_id_locked', true);
+                        })
+                )
+                ->disabled(fn($get) => !$get('reference_id_locked'))
                 ->suffix(function ($get) {
                     return $get('uuid') ? $get('uuid') : '';
                 })


### PR DESCRIPTION
## What changes did you make? 

Allows changing the reference ID after clicking a little lock



https://github.com/user-attachments/assets/794e2856-3c5e-4320-962b-584f9b8bbd38


## Why did you make these changes?

The forms team mentioned they needed to change the reference IDs (especially when importing forms), but it shouldn't be super easy, there should be another action like a confirmation modal.

## What alternatives did you consider?

Confirmation modals don't work inside the tree editor page, so this was the best alternative I could come up with.

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
