### PR TITLE
remove duplicate helper text field

### DIFF
--- a/app/Helpers/SchemaHelper.php
+++ b/app/Helpers/SchemaHelper.php
@@ -39,9 +39,6 @@ class SchemaHelper
             TextInput::make('elementable_data.placeholder')
                 ->label('Placeholder Text')
                 ->disabled($disabled),
-            Textarea::make('elementable_data.helperText')
-                ->label('Helper Text')
-                ->disabled($disabled),
         ];
     }
 
@@ -79,13 +76,6 @@ class SchemaHelper
     {
         return TextInput::make('elementable_data.placeholder')
             ->label('Placeholder Text')
-            ->disabled($disabled);
-    }
-
-    public static function getHelperTextField(bool $disabled = false)
-    {
-        return Textarea::make('elementable_data.helperText')
-            ->label('Helper Text')
             ->disabled($disabled);
     }
 }

--- a/app/Models/FormBuilding/CheckboxInputFormElement.php
+++ b/app/Models/FormBuilding/CheckboxInputFormElement.php
@@ -15,7 +15,6 @@ class CheckboxInputFormElement extends Model
         'labelText',
         'hideLabel',
         'defaultChecked',
-        'helperText',
     ];
 
     protected $casts = [
@@ -42,7 +41,6 @@ class CheckboxInputFormElement extends Model
                 ->label('Default Checked')
                 ->default(false)
                 ->disabled($disabled),
-            SchemaHelper::getHelperTextField($disabled),
         ];
     }
 
@@ -63,7 +61,6 @@ class CheckboxInputFormElement extends Model
             'labelText' => $this->labelText,
             'hideLabel' => $this->hideLabel,
             'defaultChecked' => $this->defaultChecked,
-            'helperText' => $this->helperText,
         ];
     }
 

--- a/app/Models/FormBuilding/DateSelectInputFormElement.php
+++ b/app/Models/FormBuilding/DateSelectInputFormElement.php
@@ -15,7 +15,6 @@ class DateSelectInputFormElement extends Model
         'placeholder',
         'labelText',
         'hideLabel',
-        'helperText',
         'minDate',
         'maxDate',
         'dateFormat',
@@ -77,7 +76,6 @@ class DateSelectInputFormElement extends Model
             'minDate' => $this->minDate,
             'maxDate' => $this->maxDate,
             'dateFormat' => $this->dateFormat,
-            'helperText' => $this->helperText,
         ];
     }
 

--- a/app/Models/FormBuilding/NumberInputFormElement.php
+++ b/app/Models/FormBuilding/NumberInputFormElement.php
@@ -19,7 +19,6 @@ class NumberInputFormElement extends Model
         'max',
         'step',
         'defaultValue',
-        'helperText',
         'formatStyle',
     ];
 
@@ -102,7 +101,6 @@ class NumberInputFormElement extends Model
             'max' => $this->max,
             'step' => $this->step,
             'defaultValue' => $this->defaultValue,
-            'helperText' => $this->helperText,
             'formatStyle' => $this->formatStyle,
         ];
     }

--- a/app/Models/FormBuilding/RadioInputFormElement.php
+++ b/app/Models/FormBuilding/RadioInputFormElement.php
@@ -17,7 +17,6 @@ class RadioInputFormElement extends Model
         'hideLabel',
         'defaultSelected',
         'labelPosition',
-        'helperText',
         'orientation',
     ];
 
@@ -50,7 +49,6 @@ class RadioInputFormElement extends Model
                 ->default('right')
                 ->visible(fn(callable $get): bool => !$get('elementable_data.hideLabel'))
                 ->disabled($disabled),
-            SchemaHelper::getHelperTextField($disabled),
             \Filament\Forms\Components\Select::make('elementable_data.orientation')
                 ->label('Orientation')
                 ->options([
@@ -133,7 +131,6 @@ class RadioInputFormElement extends Model
             'hideLabel' => $this->hideLabel,
             'defaultSelected' => $this->defaultSelected,
             'labelPosition' => $this->labelPosition,
-            'helperText' => $this->helperText,
             'orientation' => $this->orientation,
         ];
     }

--- a/app/Models/FormBuilding/SelectInputFormElement.php
+++ b/app/Models/FormBuilding/SelectInputFormElement.php
@@ -15,7 +15,6 @@ class SelectInputFormElement extends Model
     protected $fillable = [
         'labelText',
         'hideLabel',
-        'helperText',
         'defaultSelected',
     ];
 
@@ -38,7 +37,6 @@ class SelectInputFormElement extends Model
             SchemaHelper::getLabelTextField($disabled)
                 ->required(),
             SchemaHelper::getHideLabelToggle($disabled),
-            SchemaHelper::getHelperTextField($disabled),
             \Filament\Forms\Components\Select::make('elementable_data.defaultSelected')
                 ->label('Default Selected Value')
                 ->options(function (callable $get) {
@@ -111,7 +109,6 @@ class SelectInputFormElement extends Model
         return [
             'labelText' => $this->labelText,
             'hideLabel' => $this->hideLabel,
-            'helperText' => $this->helperText,
             'defaultSelected' => $this->defaultSelected,
         ];
     }

--- a/app/Models/FormBuilding/TextInputFormElement.php
+++ b/app/Models/FormBuilding/TextInputFormElement.php
@@ -15,7 +15,6 @@ class TextInputFormElement extends Model
         'placeholder',
         'labelText',
         'hideLabel',
-        'helperText',
         'mask',
         'maxCount',
         'defaultValue',
@@ -72,7 +71,6 @@ class TextInputFormElement extends Model
             'mask' => $this->mask,
             'maxCount' => $this->maxCount,
             'defaultValue' => $this->defaultValue,
-            'helperText' => $this->helperText,
         ];
     }
 }

--- a/app/Models/FormBuilding/TextareaInputFormElement.php
+++ b/app/Models/FormBuilding/TextareaInputFormElement.php
@@ -15,7 +15,6 @@ class TextareaInputFormElement extends Model
         'placeholder',
         'labelText',
         'hideLabel',
-        'helperText',
         'rows',
         'cols',
         'maxCount',
@@ -83,7 +82,6 @@ class TextareaInputFormElement extends Model
             'cols' => $this->cols,
             'maxCount' => $this->maxCount,
             'defaultValue' => $this->defaultValue,
-            'helperText' => $this->helperText,
         ];
     }
 }

--- a/database/migrations/2025_07_22_173755_remove_helper_text_from_form_elements.php
+++ b/database/migrations/2025_07_22_173755_remove_helper_text_from_form_elements.php
@@ -1,0 +1,76 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('text_input_form_elements', function (Blueprint $table) {
+            $table->dropColumn('helperText');
+        });
+
+        Schema::table('number_input_form_elements', function (Blueprint $table) {
+            $table->dropColumn('helperText');
+        });
+
+        Schema::table('textarea_input_form_elements', function (Blueprint $table) {
+            $table->dropColumn('helperText');
+        });
+
+        Schema::table('date_select_input_form_elements', function (Blueprint $table) {
+            $table->dropColumn('helperText');
+        });
+
+        Schema::table('checkbox_input_form_elements', function (Blueprint $table) {
+            $table->dropColumn('helperText');
+        });
+
+        Schema::table('radio_input_form_elements', function (Blueprint $table) {
+            $table->dropColumn('helperText');
+        });
+
+        Schema::table('select_input_form_elements', function (Blueprint $table) {
+            $table->dropColumn('helperText');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('text_input_form_elements', function (Blueprint $table) {
+            $table->text('helperText')->nullable();
+        });
+
+        Schema::table('number_input_form_elements', function (Blueprint $table) {
+            $table->text('helperText')->nullable();
+        });
+
+        Schema::table('textarea_input_form_elements', function (Blueprint $table) {
+            $table->text('helperText')->nullable();
+        });
+
+        Schema::table('date_select_input_form_elements', function (Blueprint $table) {
+            $table->text('helperText')->nullable();
+        });
+
+        Schema::table('checkbox_input_form_elements', function (Blueprint $table) {
+            $table->text('helperText')->nullable();
+        });
+
+        Schema::table('radio_input_form_elements', function (Blueprint $table) {
+            $table->text('helperText')->nullable();
+        });
+
+        Schema::table('select_input_form_elements', function (Blueprint $table) {
+            $table->text('helperText')->nullable();
+        });
+    }
+};


### PR DESCRIPTION
## What changes did you make? 

Some fields like text input had a helper text field but it is already a field that existed in the form element

## Why did you make these changes?

https://dev.azure.com/bc-icm/FODIG/_workitems/edit/8163

## What alternatives did you consider?

Things like TextInfo probably shouldn't have a help text so it shouldn't be as part of the form element, but it doesn't hurt to leave it there for now.

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
