### PR TITLE
Re-add custom conditional visibility and readonly

### DIFF
--- a/app/Helpers/GeneralTabHelper.php
+++ b/app/Helpers/GeneralTabHelper.php
@@ -353,6 +353,13 @@ class GeneralTabHelper
                     ->default(true)
                     ->disabled($disabled || ($disabledCallback && $disabledCallback())),
             ]);
+        $schema[] = Grid::make(1)
+            ->schema([
+                TextArea::make('custom_visibility')
+                    ->label('Custom Visibility Script')
+                    ->disabled($disabled || ($disabledCallback && $disabledCallback()))
+                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Custom visibility script to control when this element is shown. Use the format: "if (condition) { return true; } else { return false; }". This will be evaluated in the browser.'),
+            ]);
 
         // Required and Template toggles
         $templateToggle = Toggle::make('is_template')
@@ -386,6 +393,7 @@ class GeneralTabHelper
         $readOnlyToggle = Toggle::make('is_read_only')
             ->label('Is Read Only')
             ->default(false)
+            ->live()
             ->disabled($disabled || ($disabledCallback && $disabledCallback()));
 
         $saveOnSubmitToggle = Toggle::make('save_on_submit')
@@ -405,6 +413,17 @@ class GeneralTabHelper
                 $readOnlyToggle,
                 $saveOnSubmitToggle,
             ]);
+
+        $schema[] = Grid::make(1)
+            ->schema([
+                TextArea::make('custom_read_only')
+                    ->label('Custom Read Only Script')
+                    ->visible(fn($get) => $get('is_read_only'))
+                    ->reactive()
+                    ->disabled($disabled || ($disabledCallback && $disabledCallback()))
+                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Custom read only script to control when this element is read only. Use the format: "if (condition) { return true; } else { return false; }". This will be evaluated in the browser.'),
+            ]);
+
 
         // Tags field
         $tagsField = Select::make('tags')

--- a/app/Models/FormBuilding/FormElement.php
+++ b/app/Models/FormBuilding/FormElement.php
@@ -30,10 +30,12 @@ class FormElement extends Model
         'help_text',
         'calculated_value',
         'is_read_only',
+        'custom_read_only',
         'is_required',
         'save_on_submit',
         'visible_web',
         'visible_pdf',
+        'custom_visibility',
         'is_template',
         'source_element_id',
     ];

--- a/app/Services/FormVersionJsonService.php
+++ b/app/Services/FormVersionJsonService.php
@@ -739,16 +739,24 @@ class FormVersionJsonService
             'value' => $element->save_on_submit ? '{return true}' : '{return false}'
         ];
 
-        // Always include readOnly condition with the actual boolean value
-        $conditions[] = [
-            'type' => 'readOnly',
-            'value' => $element->is_read_only ? '{return true}' : '{return false}'
-        ];
+        if (!empty($element->custom_read_only) && $element->is_read_only) {
+            $conditions[] = [
+                'type' => 'readOnly',
+                'value' => $element->custom_read_only
+            ];
+        } else {
+            // If no custom read-only condition, use the default read-only state
+            $conditions[] = [
+                'type' => 'readOnly',
+                'value' => $element->is_read_only ? '{return true}' : '{return false}'
+            ];
+        }
 
-        if (!$element->visible_web && !$element->visible_pdf) {
+        // Only include visibility condition if custom_visibility is set and not empty
+        if (!empty($element->custom_visibility)) {
             $conditions[] = [
                 'type' => 'visibility',
-                'value' => 'NOT visible'
+                'value' => $element->custom_visibility
             ];
         }
 

--- a/database/migrations/2025_07_23_122203_add_custom_visibility_column_form_elements.php
+++ b/database/migrations/2025_07_23_122203_add_custom_visibility_column_form_elements.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('form_elements', function (Blueprint $table) {
+            $table->text('custom_visibility')->nullable()->after('visible_pdf');
+            $table->text('custom_read_only')->nullable()->after('read_only');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('form_elements', function (Blueprint $table) {
+            $table->dropColumn('custom_visibility');
+            $table->dropColumn('custom_read_only');
+        });
+    }
+};


### PR DESCRIPTION
## What changes did you make? 
- Re-enable support for custom scripts to dynamically control the visibility and read-only states of form elements. 
- Added `TextArea` inputs for defining custom visibility/readonly scripts in the form element.
- custom scripts for visibility and read-only conditions are passed on in the JSON v1 if provided. Defaults are used when custom scripts are not set.

## Why did you make these changes?

Per [3034](https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/3034/), required for conditional visibility and readonly status, while still allowing for saveonsubmit, in different server conditions.

## What alternatives did you consider?

Custom Javascript code. However, this is different from base form rendering/conditional visibility. These custom blocks pass information along to Kiln to specially render. This is similar to the [conditions created for the DataBindings](https://github.com/bcgov/klamm/pull/339/commits/bf46ba74752da363fd0888e4b4fd787fa131e719).

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
