### PR TITLE
map dates to fix display issue

### DIFF
--- a/app/Models/FormBuilding/DateSelectInputFormElement.php
+++ b/app/Models/FormBuilding/DateSelectInputFormElement.php
@@ -108,4 +108,38 @@ class DateSelectInputFormElement extends Model
             'MMMM, YYYY' => 'MMMM, YYYY',
         ];
     }
+
+    /**
+     * Convert date format from current format to Flatpickr format.
+     * 
+     * @param string $format The current date format
+     * @return string The Flatpickr-compatible date format
+     */
+    public static function convertToFlatpickrFormat(string $format): string
+    {
+        $formatMapping = [
+            'DD/MM/YY' => 'd/m/y',
+            'D-MMM-YY' => 'j-M-y',
+            'MMMM D, YYYY' => 'F j, Y',
+            'EEEE, MMMM D, YYYY' => 'l, F j, Y',
+            'YYYY-MM-DD' => 'Y-m-d',
+            'YYYY-MMM-DD' => 'Y-M-d',
+            'YY-MM-DD' => 'y-m-d',
+            'DD/MM/YYYY' => 'd/m/Y',
+            'D/M/YY' => 'j/n/y',
+            'M/DD/YY' => 'n/d/y',
+            'DD-MMM-YY' => 'd-M-y',
+            'DD-MMM-YYYY' => 'd-M-Y',
+            'M/D/YYYY' => 'n/j/Y',
+            'M/D/YY' => 'n/j/y',
+            'MM/DD/YY' => 'm/d/y',
+            'MM/DD/YYYY' => 'm/d/Y',
+            'EEEE, MMMM DD, YYYY' => 'l, F d, Y',
+            'MMMM-DD-YY' => 'F-d-y',
+            'MMMM DD, YYYY' => 'F d, Y',
+            'MMMM, YYYY' => 'F, Y',
+        ];
+
+        return $formatMapping[$format] ?? $format;
+    }
 }

--- a/app/Services/FormVersionJsonService.php
+++ b/app/Services/FormVersionJsonService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\FormBuilding\FormVersion;
 use App\Models\FormBuilding\FormElement;
 use Illuminate\Support\Str;
+use App\Models\FormBuilding\DateSelectInputFormElement;
 
 class FormVersionJsonService
 {
@@ -901,6 +902,8 @@ class FormVersionJsonService
         switch ($key) {
             case 'defaultValue':
                 return ['value', $value];
+            case 'dateFormat':
+                return ['dateFormat', DateSelectInputFormElement::convertToFlatpickrFormat($value)];
             default:
                 return null;
         }


### PR DESCRIPTION
## What changes did you make? 

Maps the date-fns dates to flatpicker

## Why did you make these changes?

the list is from https://flatpickr.js.org/formatting/#date-formatting-tokens but Carbon expects these date tokens https://date-fns.org/v4.1.0/docs/format

Right now to get a bug fix out the door, we are just going to map them. But it should be refactored so you pick the date format in the style of flatpickr

## What alternatives did you consider?

Doing a bigger rework, but that can come later.

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
