### PR TITLE
Feature/form interfaces

### DIFF
--- a/app/Filament/Forms/Resources/FormInterfaceResource.php
+++ b/app/Filament/Forms/Resources/FormInterfaceResource.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace App\Filament\Forms\Resources;
+
+use App\Filament\Forms\Resources\FormInterfaceResource\Pages;
+use App\Models\FormMetadata\FormInterface;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use App\Http\Middleware\CheckRole;
+use Filament\Forms\Components\Grid;
+
+class FormInterfaceResource extends Resource
+{
+    protected static ?string $model = FormInterface::class;
+
+    protected static ?string $navigationIcon = 'icon-terminal';
+
+    protected static ?string $navigationGroup = 'Form Building';
+
+    protected static ?string $navigationLabel = 'Form Interfaces';
+
+    public static function shouldRegisterNavigation(): bool
+    {
+        return CheckRole::hasRole(request(), 'admin', 'form-developer');
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Grid::make(1)
+                    ->schema([
+                        Forms\Components\TextInput::make('label')
+                            ->maxLength(255),
+                        Forms\Components\TextInput::make('description')
+                            ->maxLength(1000),
+                        Forms\Components\TextInput::make('type')
+                            ->required()
+                            ->maxLength(255),
+                        Forms\Components\TextInput::make('style')
+                            ->maxLength(255),
+                        Forms\Components\Textarea::make('condition')
+                            ->label('Conditional Logic'),
+                    ]),
+                Forms\Components\Repeater::make('actions')
+                    ->relationship('actions')
+                    ->orderColumn('order')
+                    ->reorderable()
+                    ->collapsible()
+                    ->schema([
+                        Forms\Components\TextInput::make('label')
+                            ->required()
+                            ->maxLength(255),
+                        Forms\Components\TextInput::make('action_type')->maxLength(255),
+                        Forms\Components\TextInput::make('type')->maxLength(255),
+                        Forms\Components\TextInput::make('host')->maxLength(255),
+                        Forms\Components\TextInput::make('path')->maxLength(255),
+                        Forms\Components\TextInput::make('authentication')->maxLength(255),
+                        Forms\Components\Repeater::make('headers')
+                            ->label('Headers')
+                            ->orderColumn('order')
+                            ->reorderable()
+                            ->schema([
+                                Forms\Components\TextInput::make('key')->required(),
+                                Forms\Components\TextInput::make('value')->required(),
+                                Forms\Components\Hidden::make('order'),
+                            ])
+                            ->default([]),
+                        Forms\Components\Repeater::make('body')
+                            ->label('Body')
+                            ->orderColumn('order')
+                            ->reorderable()
+                            ->schema([
+                                Forms\Components\TextInput::make('key')->required(),
+                                Forms\Components\TextInput::make('value')->required(),
+                                Forms\Components\Hidden::make('order'),
+                            ])
+                            ->default([]),
+                        Forms\Components\Repeater::make('parameters')
+                            ->label('Parameters')
+                            ->orderColumn('order')
+                            ->reorderable()
+                            ->schema([
+                                Forms\Components\TextInput::make('key')->required(),
+                                Forms\Components\TextInput::make('value')->required(),
+                                Forms\Components\Hidden::make('order'),
+                            ])
+                            ->default([]),
+                        Forms\Components\Hidden::make('order'),
+                    ])
+                    ->label('Actions')
+                    ->itemLabel(
+                        fn(array $state, ?int $index = null) =>
+                        // Prefer $index (provided by Filament), fallback to 'order', fallback to 0
+                        (isset($state['label']) && $state['label'] ? $state['label'] : '')
+                    )
+                    ->columnSpanFull(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('label')->searchable(),
+                Tables\Columns\TextColumn::make('description')->searchable(),
+                Tables\Columns\TextColumn::make('formVersion.form.name')->label('Form Name')->searchable(),
+                Tables\Columns\TextColumn::make('type')->searchable(),
+                Tables\Columns\TextColumn::make('style')->searchable(),
+
+                Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable()->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')->dateTime()->sortable()->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListFormInterfaces::route('/'),
+            'create' => Pages\CreateFormInterface::route('/create'),
+            'view' => Pages\ViewFormInterface::route('/{record}'),
+            'edit' => Pages\EditFormInterface::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getModelLabel(): string
+    {
+        return 'Form Interface';
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return 'Form Interfaces';
+    }
+}

--- a/app/Filament/Forms/Resources/FormInterfaceResource/Pages/CreateFormInterface.php
+++ b/app/Filament/Forms/Resources/FormInterfaceResource/Pages/CreateFormInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Forms\Resources\FormInterfaceResource\Pages;
+
+use App\Filament\Forms\Resources\FormInterfaceResource;
+use Filament\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateFormInterface extends CreateRecord
+{
+    protected static string $resource = FormInterfaceResource::class;
+}

--- a/app/Filament/Forms/Resources/FormInterfaceResource/Pages/EditFormInterface.php
+++ b/app/Filament/Forms/Resources/FormInterfaceResource/Pages/EditFormInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Filament\Forms\Resources\FormInterfaceResource\Pages;
+
+use App\Filament\Forms\Resources\FormInterfaceResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditFormInterface extends EditRecord
+{
+    protected static string $resource = FormInterfaceResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\ViewAction::make(),
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Forms/Resources/FormInterfaceResource/Pages/ListFormInterfaces.php
+++ b/app/Filament/Forms/Resources/FormInterfaceResource/Pages/ListFormInterfaces.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Filament\Forms\Resources\FormInterfaceResource\Pages;
+
+use App\Filament\Forms\Resources\FormInterfaceResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListFormInterfaces extends ListRecords
+{
+    protected static string $resource = FormInterfaceResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Filament/Forms/Resources/FormInterfaceResource/Pages/ListFormInterfaces.php
+++ b/app/Filament/Forms/Resources/FormInterfaceResource/Pages/ListFormInterfaces.php
@@ -5,6 +5,11 @@ namespace App\Filament\Forms\Resources\FormInterfaceResource\Pages;
 use App\Filament\Forms\Resources\FormInterfaceResource;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Tables\Filters\SelectFilter;
+use App\Models\FormBuilding\FormVersion;
+use App\Models\FormMetadata\FormInterface;
 
 class ListFormInterfaces extends ListRecords
 {
@@ -15,6 +20,89 @@ class ListFormInterfaces extends ListRecords
         return [
             Actions\CreateAction::make(),
         ];
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('label')->searchable()->sortable(),
+                Tables\Columns\TextColumn::make('description')->searchable()->sortable()->toggleable(isToggledHiddenByDefault: false)->wrap(),
+                Tables\Columns\TextColumn::make('formVersions')
+                    ->label('Active Forms')
+                    ->toggleable(isToggledHiddenByDefault: false)
+                    ->wrap()
+                    ->formatStateUsing(function ($record) {
+                        $formNames = $record->formVersions
+                            ->map(function ($formVersion) {
+                                return optional($formVersion->form)->form_id_title ?? optional($formVersion->form)->name;
+                            })
+                            ->filter()
+                            ->unique()
+                            ->values();
+                        return $formNames->isNotEmpty() ? $formNames->implode(', ') : '-';
+                    })
+                    ->searchable(query: function ($query, $search) {
+                        return $query->whereHas('formVersions.form', function ($q) use ($search) {
+                            $q->where('form_id_title', 'like', "%$search%");
+                        });
+                    }),
+                Tables\Columns\TextColumn::make('type')->searchable()->sortable()->toggleable(isToggledHiddenByDefault: false),
+                Tables\Columns\TextColumn::make('style')->searchable()->sortable()->toggleable(isToggledHiddenByDefault: true)->wrap(),
+                Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable()->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')->dateTime()->sortable()->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('type')
+                    ->options(FormInterface::types())
+                    ->label('Type')
+                    ->multiple()
+                    ->searchable()
+                    ->placeholder('All Types')
+                    ->query(function ($query, array $data) {
+                        $values = $data['values'] ?? $data['value'] ?? [];
+                        if (empty($values)) {
+                            return $query;
+                        }
+                        if (!is_array($values)) {
+                            $values = [$values];
+                        }
+                        return $query->whereIn('type', $values);
+                    }),
+                SelectFilter::make('form_name')
+                    ->label('Active Forms')
+                    ->options(function () {
+                        return FormVersion::with('form')
+                            ->get()
+                            ->map(function ($formVersion) {
+                                return optional($formVersion->form)->form_id_title ?? optional($formVersion->form)->name;
+                            })
+                            ->filter()
+                            ->unique()
+                            ->sort()
+                            ->mapWithKeys(fn($name) => [$name => $name])
+                            ->toArray();
+                    })
+                    ->placeholder('All Forms')
+                    ->multiple()
+                    ->searchable()
+                    ->query(function ($query, array $data) {
+                        $values = $data['values'] ?? $data['value'] ?? [];
+                        if (empty($values)) {
+                            return $query;
+                        }
+                        return $query->whereHas('formVersions.form', function ($q) use ($values) {
+                            $q->whereIn('form_id_title', (array) $values);
+                        });
+                    }),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                //
+            ]);
     }
 
     public function getBreadcrumbs(): array

--- a/app/Filament/Forms/Resources/FormInterfaceResource/Pages/ViewFormInterface.php
+++ b/app/Filament/Forms/Resources/FormInterfaceResource/Pages/ViewFormInterface.php
@@ -5,6 +5,8 @@ namespace App\Filament\Forms\Resources\FormInterfaceResource\Pages;
 use App\Filament\Forms\Resources\FormInterfaceResource;
 use Filament\Actions;
 use Filament\Resources\Pages\ViewRecord;
+use Illuminate\Support\Facades\Gate;
+use App\Filament\Forms\Resources\FormInterfaceResource\RelationManagers\FormVersionsRelationManager;
 
 class ViewFormInterface extends ViewRecord
 {
@@ -15,5 +17,25 @@ class ViewFormInterface extends ViewRecord
         return [
             Actions\EditAction::make(),
         ];
+    }
+
+    protected const DEFAULT_RELATION_MANAGERS = [
+        FormVersionsRelationManager::class,
+    ];
+
+    public function getRelationManagers(): array
+    {
+        if (Gate::allows('admin') || Gate::allows('form-developer')) {
+            return self::DEFAULT_RELATION_MANAGERS;
+        }
+        if ($this->hasBusinessAreaAccess()) {
+            $formVersion = $this->getRecord();
+
+            if ($this->hasAccessToFormVersion($formVersion)) {
+                return self::DEFAULT_RELATION_MANAGERS;
+            }
+        }
+
+        return [];
     }
 }

--- a/app/Filament/Forms/Resources/FormInterfaceResource/Pages/ViewFormInterface.php
+++ b/app/Filament/Forms/Resources/FormInterfaceResource/Pages/ViewFormInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Forms\Resources\FormInterfaceResource\Pages;
+
+use App\Filament\Forms\Resources\FormInterfaceResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewFormInterface extends ViewRecord
+{
+    protected static string $resource = FormInterfaceResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Forms/Resources/FormInterfaceResource/RelationManagers/FormVersionsRelationManager.php
+++ b/app/Filament/Forms/Resources/FormInterfaceResource/RelationManagers/FormVersionsRelationManager.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Filament\Forms\Resources\FormInterfaceResource\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Table;
+use App\Models\FormBuilding\FormVersion;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+
+class FormVersionsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'formVersions';
+    protected static ?string $title = 'Form Versions Using This Interface';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+
+                TextColumn::make('form.form_id_title')
+                    ->label('Form')
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('version_number')
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('status')
+                    ->sortable()
+                    ->searchable()
+                    ->badge()
+                    ->color(fn($state) => FormVersion::getStatusColour($state))
+                    ->getStateUsing(fn($record) => $record->getFormattedStatusName()),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->options(FormVersion::getStatusOptions())
+                    ->label('Status')
+                    ->placeholder('All Statuses'),
+            ])
+            ->recordUrl(function ($record) {
+                return route('filament.forms.resources.form-versions.view', ['record' => $record->id]);
+            });
+    }
+}

--- a/app/Filament/Forms/Resources/FormResource/RelationManagers/FormVersionRelationManager.php
+++ b/app/Filament/Forms/Resources/FormResource/RelationManagers/FormVersionRelationManager.php
@@ -159,6 +159,15 @@ class FormVersionRelationManager extends RelationManager
                             ]);
                         }
 
+                        // Duplicate form interfaces
+                        foreach ($record->formVersionFormInterfaces as $formInterface) {
+                            \App\Models\FormBuilding\FormVersionFormInterface::create([
+                                'form_version_id' => $newVersion->id,
+                                'form_interface_id' => $formInterface->form_interface_id,
+                                'order' => $formInterface->order,
+                            ]);
+                        }
+
                         // Redirect to build the new version
                         if (Gate::allows('form-developer')) {
                             return redirect()->to('/forms/form-versions/' . $newVersion->id . '/build');

--- a/app/Filament/Forms/Resources/FormVersionResource.php
+++ b/app/Filament/Forms/Resources/FormVersionResource.php
@@ -354,6 +354,15 @@ class FormVersionResource extends Resource
                             ]);
                         }
 
+                        // Duplicate form interfaces
+                        foreach ($record->formVersionFormInterfaces as $formInterface) {
+                            \App\Models\FormBuilding\FormVersionFormInterface::create([
+                                'form_version_id' => $newVersion->id,
+                                'form_interface_id' => $formInterface->form_interface_id,
+                                'order' => $formInterface->order,
+                            ]);
+                        }
+
                         // Redirect to build the new version
                         if (Gate::allows('form-developer')) {
                             return redirect()->to('/forms/form-versions/' . $newVersion->id . '/build');

--- a/app/Models/FormBuilding/FormVersion.php
+++ b/app/Models/FormBuilding/FormVersion.php
@@ -20,7 +20,9 @@ use App\Models\User;
 use App\Models\FormApprovalRequest;
 use App\Models\FormMetadata\FormDataSource;
 use App\Models\FormBuilding\FormVersionFormDataSource;
+use App\Models\FormBuilding\FormVersionFormInterface;
 use Spatie\Activitylog\Models\Activity;
+use App\Models\FormMetadata\FormInterface;
 
 class FormVersion extends Model
 {
@@ -265,5 +267,18 @@ class FormVersion extends Model
     public function formElements(): HasMany
     {
         return $this->hasMany(FormElement::class)->orderBy('order');
+    }
+
+    public function formVersionFormInterfaces(): HasMany
+    {
+        return $this->hasMany(FormVersionFormInterface::class)->orderBy('order');
+    }
+
+    public function formInterfaces(): BelongsToMany
+    {
+        return $this->belongsToMany(FormInterface::class, 'form_version_form_interfaces')
+            ->withPivot('order')
+            ->withTimestamps()
+            ->orderBy('form_version_form_interfaces.order');
     }
 }

--- a/app/Models/FormBuilding/FormVersionFormInterface.php
+++ b/app/Models/FormBuilding/FormVersionFormInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models\FormBuilding;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Models\FormMetadata\FormInterface;
+
+class FormVersionFormInterface extends Pivot
+{
+    protected $table = 'form_version_form_interfaces';
+
+    public $incrementing = true;
+
+    protected $fillable = [
+        'form_version_id',
+        'form_interface_id',
+        'order',
+    ];
+
+    public function formVersion(): BelongsTo
+    {
+        return $this->belongsTo(FormVersion::class);
+    }
+
+    public function formInterface(): BelongsTo
+    {
+        return $this->belongsTo(FormInterface::class);
+    }
+}

--- a/app/Models/FormMetadata/FormInterface.php
+++ b/app/Models/FormMetadata/FormInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models\FormMetadata;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use App\Models\FormBuilding\FormVersion;
+
+class FormInterface extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'type',
+        'description',
+        'form_version_id',
+        'label',
+        'style',
+        'condition',
+    ];
+
+
+    public function actions(): HasMany
+    {
+        return $this->hasMany(InterfaceAction::class, 'form_interface_id');
+    }
+
+    public function formVersions(): BelongsToMany
+    {
+        return $this->belongsToMany(FormVersion::class, 'form_version_form_interfaces')
+            ->withPivot('order')
+            ->withTimestamps();
+    }
+}

--- a/app/Models/FormMetadata/FormInterface.php
+++ b/app/Models/FormMetadata/FormInterface.php
@@ -27,6 +27,20 @@ class FormInterface extends Model
         return $this->hasMany(InterfaceAction::class, 'form_interface_id');
     }
 
+    public static function types(): array
+    {
+        return self::query()
+            ->distinct()
+            ->whereNotNull('type')
+            ->where('type', '!=', '')
+            ->pluck('type')
+            ->filter()
+            ->sort()
+            ->values()
+            ->mapWithKeys(fn($type) => [$type => $type])
+            ->toArray();
+    }
+
     public function formVersions(): BelongsToMany
     {
         return $this->belongsToMany(FormVersion::class, 'form_version_form_interfaces')

--- a/app/Models/FormMetadata/InterfaceAction.php
+++ b/app/Models/FormMetadata/InterfaceAction.php
@@ -5,10 +5,12 @@ namespace App\Models\FormMetadata;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Spatie\Activitylog\Traits\LogsActivity;
+use Spatie\Activitylog\LogOptions;
 
 class InterfaceAction extends Model
 {
-    use HasFactory;
+    use HasFactory, LogsActivity;
 
     protected $fillable = [
         'form_interface_id',
@@ -30,9 +32,60 @@ class InterfaceAction extends Model
         'parameters' => 'array',
     ];
 
+    protected static $logAttributes = [
+        'label',
+        'action_type',
+        'type',
+        'host',
+        'path',
+        'authentication',
+        'order',
+        'headers',
+        'body',
+        'parameters',
+    ];
+
     public function formInterface(): BelongsTo
     {
         return $this->belongsTo(FormInterface::class, 'form_interface_id');
+    }
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(self::$logAttributes)
+            ->dontSubmitEmptyLogs()
+            ->logOnlyDirty()
+            ->setDescriptionForEvent(function (string $eventName) {
+                $actionName = $this->label ?: 'Unnamed Action';
+                $actionType = $this->action_type ?: 'Unknown Type';
+                $interfaceName = $this->formInterface ? $this->formInterface->label : 'Unknown Interface';
+
+                if ($eventName === 'created') {
+                    return "Action '{$actionName}' ({$actionType}) was created for interface '{$interfaceName}'";
+                }
+
+                $changes = array_keys($this->getDirty());
+                $changes = array_filter($changes, function ($change) {
+                    return !in_array($change, ['updated_at']);
+                });
+
+                if (!empty($changes)) {
+                    $changes = array_map(function ($change) {
+                        return str_replace('_', ' ', $change);
+                    }, $changes);
+
+                    $changesStr = implode(', ', array_unique($changes));
+                    return "Action '{$actionName}' ({$actionType}) had changes to: {$changesStr} for interface '{$interfaceName}'";
+                }
+
+                return "Action '{$actionName}' ({$actionType}) was {$eventName} for interface '{$interfaceName}'";
+            });
+    }
+
+    public function getLogNameToUse(): string
+    {
+        return 'interface_actions';
     }
 
     public static function actionTypes(): array

--- a/app/Models/FormMetadata/InterfaceAction.php
+++ b/app/Models/FormMetadata/InterfaceAction.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models\FormMetadata;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class InterfaceAction extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'form_interface_id',
+        'label',
+        'action_type',
+        'type',
+        'host',
+        'path',
+        'authentication',
+        'headers',
+        'body',
+        'parameters',
+    ];
+
+    protected $casts = [
+        'headers' => 'array',
+        'body' => 'array',
+        'parameters' => 'array',
+    ];
+
+    public function formInterface(): BelongsTo
+    {
+        return $this->belongsTo(FormInterface::class, 'form_interface_id');
+    }
+}

--- a/app/Models/FormMetadata/InterfaceAction.php
+++ b/app/Models/FormMetadata/InterfaceAction.php
@@ -21,6 +21,7 @@ class InterfaceAction extends Model
         'headers',
         'body',
         'parameters',
+        'order',
     ];
 
     protected $casts = [
@@ -32,5 +33,33 @@ class InterfaceAction extends Model
     public function formInterface(): BelongsTo
     {
         return $this->belongsTo(FormInterface::class, 'form_interface_id');
+    }
+
+    public static function actionTypes(): array
+    {
+        return self::query()
+            ->distinct()
+            ->whereNotNull('action_type')
+            ->where('action_type', '!=', '')
+            ->pluck('action_type')
+            ->filter()
+            ->sort()
+            ->values()
+            ->mapWithKeys(fn($type) => [$type => $type])
+            ->toArray();
+    }
+
+    public static function types(): array
+    {
+        return self::query()
+            ->distinct()
+            ->whereNotNull('type')
+            ->where('type', '!=', '')
+            ->pluck('type')
+            ->filter()
+            ->sort()
+            ->values()
+            ->mapWithKeys(fn($type) => [$type => $type])
+            ->toArray();
     }
 }

--- a/app/Policies/FormDataSourcePolicy.php
+++ b/app/Policies/FormDataSourcePolicy.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\FormMetadata\FormDataSource;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class FormDataSourcePolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->can('view-any FormDataSource');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, FormDataSource $formDataSource): bool
+    {
+        return $user->can('view FormDataSource');
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->can('create FormDataSource');
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, FormDataSource $formDataSource): bool
+    {
+        return $user->can('update FormDataSource');
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, FormDataSource $formDataSource): bool
+    {
+        return $user->can('delete FormDataSource');
+    }
+}

--- a/app/Policies/FormInterfacePolicy.php
+++ b/app/Policies/FormInterfacePolicy.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\FormMetadata\FormInterface;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class FormInterfacePolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->can('view-any FormInterface');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, FormInterface $formInterface): bool
+    {
+        return $user->can('view FormInterface');
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->can('create FormInterface');
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, FormInterface $formInterface): bool
+    {
+        return $user->can('update FormInterface');
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, FormInterface $formInterface): bool
+    {
+        return $user->can('delete FormInterface');
+    }
+}

--- a/app/Services/FormVersionJsonService.php
+++ b/app/Services/FormVersionJsonService.php
@@ -838,6 +838,7 @@ class FormVersionJsonService
                 'source' => $dataBinding->formDataSource->name ?? 'Unknown',
                 'path' => $dataBinding->path,
                 'order' => $dataBinding->order,
+                'condition' => $dataBinding->condition,
             ];
         }
 
@@ -909,7 +910,9 @@ class FormVersionJsonService
             case 'defaultValue':
                 return ['value', $value];
             case 'dateFormat':
-                return ['dateFormat', DateSelectInputFormElement::convertToFlatpickrFormat($value)];
+                if ($value) {
+                    return ['dateFormat', DateSelectInputFormElement::convertToFlatpickrFormat($value)];
+                }
             default:
                 return null;
         }

--- a/app/Services/FormVersionJsonService.php
+++ b/app/Services/FormVersionJsonService.php
@@ -6,6 +6,7 @@ use App\Models\FormBuilding\FormVersion;
 use App\Models\FormBuilding\FormElement;
 use Illuminate\Support\Str;
 use App\Models\FormBuilding\DateSelectInputFormElement;
+use App\Models\FormMetadata\FormInterface;
 
 class FormVersionJsonService
 {
@@ -18,6 +19,9 @@ class FormVersionJsonService
             'formElements.dataBindings.formDataSource',
             'formDataSources' => function ($query) {
                 $query->orderBy('form_versions_form_data_sources.order');
+            },
+            'formInterfaces' => function ($query) {
+                $query->orderBy('form_version_form_interfaces.order');
             },
             'webStyleSheet',
             'pdfStyleSheet',
@@ -32,6 +36,7 @@ class FormVersionJsonService
             'status' => $formVersion->status,
             'data' => $this->getFormVersionData($formVersion),
             'dataSources' => $this->getDataSources($formVersion),
+            'interface' => $this->getFormInterfaces($formVersion),
             'styles' => $this->getStyles($formVersion),
             'scripts' => $this->getScripts($formVersion),
             'elements' => $this->getElements($formVersion)
@@ -62,6 +67,9 @@ class FormVersionJsonService
             'formDataSources' => function ($query) {
                 $query->orderBy('form_versions_form_data_sources.order');
             },
+            'formInterfaces' => function ($query) {
+                $query->orderBy('form_version_form_interfaces.order');
+            },
             'webStyleSheet',
             'pdfStyleSheet',
             'webFormScript',
@@ -77,6 +85,7 @@ class FormVersionJsonService
             'deployed_to' => '',
             'ministry_id' => $formVersion->form->ministry_id ?? null,
             'dataSources' => $this->getDataSources($formVersion),
+            'interface' => $this->getFormInterfaces($formVersion),
             'data' => [
                 'styles' => $this->getStyles($formVersion),
                 'scripts' => $this->getScripts($formVersion),
@@ -373,6 +382,12 @@ class FormVersionJsonService
         $conditions = $this->transformConditions($element);
         if (!empty($conditions)) {
             $elementData['conditions'] = $conditions;
+        }
+
+        // Add data bindings if they exist
+        $dataBindings = $this->getDataBindings($element);
+        if (!empty($dataBindings)) {
+            $elementData['databindings'] = $dataBindings;
         }
 
         // Get children and transform them as group fields
@@ -866,6 +881,66 @@ class FormVersionJsonService
         return $dataSources;
     }
 
+    protected function getFormInterfaces(FormVersion $formVersion): array
+    {
+        $interfaces = [];
+
+        foreach ($formVersion->formInterfaces as $interface) {
+            $interfaces[] = [
+                'label' => $interface->label,
+                'type' => $interface->type,
+                'description' => $interface->description,
+                'style' => $interface->style,
+                'condition' => $interface->condition,
+                'actions' => $this->getFormInterfaceActions($interface),
+                'order' => $interface->pivot->order ?? 0,
+            ];
+        }
+
+        return $interfaces;
+    }
+
+    protected function getFormInterfaceActions(FormInterface $formInterface): array
+    {
+        $actions = [];
+        $sortedActions = $formInterface->actions()->orderBy('order')->get();
+
+        foreach ($sortedActions as $action) {
+            $actions[] = [
+                'label' => $action->label,
+                'action_type' => $action->action_type,
+                'type' => $action->type,
+                'host' => $action->host,
+                'path' => $action->path,
+                'authentication' => $action->authentication,
+                'headers' => $this->convertKeyValueArrayToObject($action->headers),
+                'body' => $this->convertKeyValueArrayToObject($action->body),
+                'params' => $this->convertKeyValueArrayToObject($action->parameters),
+                'order' => $action->order ?? 0,
+            ];
+        }
+        return $actions;
+    }
+
+    /**
+     * Convert key-value array format to object
+     */
+    protected function convertKeyValueArrayToObject($keyValueArray): object
+    {
+        if (!is_array($keyValueArray)) {
+            return (object)[];
+        }
+
+        $result = [];
+        foreach ($keyValueArray as $item) {
+            if (is_array($item) && isset($item['key']) && isset($item['value'])) {
+                $result[$item['key']] = $item['value'];
+            }
+        }
+
+        return (object)$result;
+    }
+
     /**
      * Utility to convert snake_case to camelCase.
      */
@@ -879,9 +954,14 @@ class FormVersionJsonService
     /**
      * Decode JSON field to object/array, return empty object if invalid or empty.
      */
-    protected function decodeJsonField(?string $jsonString): array|object
+    protected function decodeJsonField($jsonString): array|object
     {
-        if (empty($jsonString)) {
+        // If already an array or object, return as-is
+        if (is_array($jsonString) || is_object($jsonString)) {
+            return $jsonString;
+        }
+
+        if (empty($jsonString) || !is_string($jsonString)) {
             return (object)[];
         }
 

--- a/database/migrations/2025_07_28_122027_create_interfaces_and_actions_tables.php
+++ b/database/migrations/2025_07_28_122027_create_interfaces_and_actions_tables.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('form_interfaces', function (Blueprint $table) {
+            $table->id();
+            $table->string('label');
+            $table->text('description')->nullable();
+            $table->string('type')->nullable();
+            $table->string('style')->nullable();
+            $table->text('condition')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('interface_actions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('form_interface_id')->constrained('form_interfaces')->onDelete('cascade');
+            $table->string('label');
+            $table->string('action_type')->nullable();
+            $table->string('type')->nullable();
+            $table->string('host')->nullable();
+            $table->string('path')->nullable();
+            $table->string('authentication')->nullable();
+            $table->json('headers')->nullable();
+            $table->json('body')->nullable();
+            $table->json('parameters')->nullable();
+            $table->integer('order')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('form_version_form_interfaces', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('form_version_id')->constrained('form_versions')->onDelete('cascade');
+            $table->foreignId('form_interface_id')->constrained('form_interfaces')->onDelete('cascade');
+            $table->integer('order')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('form_version_form_interfaces');
+        Schema::dropIfExists('interface_actions');
+        Schema::dropIfExists('form_interfaces');
+    }
+};

--- a/database/seeders/PermissionsSeeder.php
+++ b/database/seeders/PermissionsSeeder.php
@@ -392,6 +392,16 @@ class PermissionsSeeder extends Seeder
             'create FormVersion',
             'update FormVersion',
             'delete FormVersion',
+            'view-any FormInterface',
+            'view FormInterface',
+            'create FormInterface',
+            'update FormInterface',
+            'delete FormInterface',
+            'view-any FormDataSource',
+            'view FormDataSource',
+            'create FormDataSource',
+            'update FormDataSource',
+            'delete FormDataSource',
         ])->where('guard_name', 'web')->get());
     }
 }


### PR DESCRIPTION
## What changes did you make? 
- new `FormInterfaceResource`, including the creation of a resource for managing form interfaces, the addition of CRUD pages for these interfaces, and updates to existing resources to integrate the new functionality.
- includes relation manager view to see which form versions are implementing an interface.
- Interfaces can be added to form versions in the same way as datasources are currently added - through the edit form page.
- Interfaces are also duplicated in the same way that datasources are when duplicating a form_version
- activity log integration to include updates/changes made to interfaces so these are tracked in the system. Currently only displayed on personal profile and admin view.

### Fixes:
- additional fixes to generation for databindings, including:
  -  databindings for containers converted to groups as repeaters has been added, as was missing. 
  - conditions have been added to databindings in the export.
- update to dateformat export to prevent null dates from being passed through

## Why did you make these changes?

Ticket [3073](https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/3073/), and fixes related to [3104](https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/3104) and [3086](https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/3086).

## What alternatives did you consider?

N/A

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
