### PR TITLE
Bug fixes and small feature add ons

### DIFF
--- a/app/Livewire/FormElementTreeBuilder.php
+++ b/app/Livewire/FormElementTreeBuilder.php
@@ -210,7 +210,12 @@ class FormElementTreeBuilder extends BaseWidget
                     $this->handleRecordUpdate($record, $data);
                 });
 
-            $actions[] = DeleteAction::make();
+            $actions[] = DeleteAction::make()
+                ->modalHeading(fn($record) => sprintf(
+                    'Delete [%s] %s',
+                    FormElement::getElementTypeName($record->elementable_type),
+                    $record->name
+                ));
         }
 
         return $actions;

--- a/app/Livewire/FormElementTreeBuilder.php
+++ b/app/Livewire/FormElementTreeBuilder.php
@@ -442,6 +442,13 @@ class FormElementTreeBuilder extends BaseWidget
                     );
                 }
             }
+
+            // Show success notification
+            \Filament\Notifications\Notification::make()
+                ->success()
+                ->title('Element Updated')
+                ->body("The form element '{$record->name}' has been updated successfully.")
+                ->send();
         } catch (\InvalidArgumentException $e) {
             // Handle our custom validation exceptions
             \Filament\Notifications\Notification::make()
@@ -578,6 +585,13 @@ class FormElementTreeBuilder extends BaseWidget
                     );
                 }
             }
+
+            // Show success notification
+            \Filament\Notifications\Notification::make()
+                ->success()
+                ->title('Element Created')
+                ->body("The form element '{$formElement->name}' has been created successfully.")
+                ->send();
 
             return $formElement;
         } catch (\Exception $e) {

--- a/resources/views/filament/forms/resources/form-version-resource/pages/build-form-version.blade.php
+++ b/resources/views/filament/forms/resources/form-version-resource/pages/build-form-version.blade.php
@@ -5,9 +5,7 @@
         <button type="button"
             class="fi-btn fi-btn-color-success fi-btn-outlined fi-btn-size-sm"
             onclick="openAddElementModal()">
-            <svg class="fi-btn-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v6m3-3H9m12 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-            </svg>
+            @svg('heroicon-o-plus-circle', 'fi-btn-icon')
             <span class="fi-btn-label">Add Element</span>
         </button>
     </div>

--- a/resources/views/filament/forms/resources/form-version-resource/pages/build-form-version.blade.php
+++ b/resources/views/filament/forms/resources/form-version-resource/pages/build-form-version.blade.php
@@ -132,7 +132,7 @@
     @push('scripts')
     <script>
         // Set editable state from PHP
-        const isFormEditable = @json($this - > isEditable());
+        const isFormEditable = @json($this->isEditable());
 
         // Real-time form version update handling
         document.addEventListener('DOMContentLoaded', function() {

--- a/resources/views/filament/forms/resources/form-version-resource/pages/build-form-version.blade.php
+++ b/resources/views/filament/forms/resources/form-version-resource/pages/build-form-version.blade.php
@@ -15,6 +15,12 @@
                 @svg('heroicon-o-plus-circle', 'fi-btn-icon')
                 <span class="fi-btn-label">Add Element</span>
             </button>
+            <button type="button"
+                class="fi-btn fi-btn-color-warning fi-btn-outlined fi-btn-size-sm"
+                onclick="saveFormVersion()">
+                @svg('heroicon-o-check', 'fi-btn-icon')
+                <span class="fi-btn-label">Save</span>
+            </button>
         </div>
     </div>
     @endif
@@ -69,6 +75,11 @@
             color: #10b981;
         }
 
+        .sticky-add-element-button button.fi-btn-color-warning {
+            border: 1px solid #f59e0b;
+            color: #f59e0b;
+        }
+
         .sticky-add-element-button button svg {
             width: 1rem;
             height: 1rem;
@@ -86,6 +97,11 @@
 
         .sticky-add-element-button button.fi-btn-color-success:hover {
             background: #10b981;
+            color: white;
+        }
+
+        .sticky-add-element-button button.fi-btn-color-warning:hover {
+            background: #f59e0b;
             color: white;
         }
 
@@ -231,6 +247,24 @@
             const previewBaseUrl = '{{ env("FORM_PREVIEW_URL", "") }}';
             const previewUrl = previewBaseUrl.replace(/\/$/, '') + '/preview/' + formVersionId;
             window.open(previewUrl, '_blank');
+        }
+
+        // Function to save the form version (triggered by sticky button)
+        function saveFormVersion() {
+            // Find the tree widget's save button and click it
+            const treeSaveButton = document.querySelector('button[data-action="save"]');
+            if (treeSaveButton) {
+                treeSaveButton.click();
+            } else {
+                // Fallback: try to find any save button
+                const saveButtons = document.querySelectorAll('button');
+                for (let button of saveButtons) {
+                    if (button.textContent.includes('Save') && button.hasAttribute('wire:loading')) {
+                        button.click();
+                        break;
+                    }
+                }
+            }
         }
     </script>
     @endpush

--- a/resources/views/filament/forms/resources/form-version-resource/pages/build-form-version.blade.php
+++ b/resources/views/filament/forms/resources/form-version-resource/pages/build-form-version.blade.php
@@ -132,7 +132,7 @@
     @push('scripts')
     <script>
         // Set editable state from PHP
-        const isFormEditable = @json($this->isEditable());
+        const isFormEditable = @json($this - > isEditable());
 
         // Real-time form version update handling
         document.addEventListener('DOMContentLoaded', function() {
@@ -188,6 +188,22 @@
                     // Only allow saving if the form is editable
                     if (isFormEditable) {
                         saveFormVersion();
+                    }
+                }
+
+                // Check if Ctrl+P (Windows/Linux) or Cmd+P (Mac) is pressed
+                if ((event.ctrlKey || event.metaKey) && event.key === 'p') {
+                    event.preventDefault(); // Prevent browser's default print dialog
+                    openPreviewForm();
+                }
+
+                // Check if Ctrl+N (Windows/Linux) or Cmd+N (Mac) is pressed
+                if ((event.ctrlKey || event.metaKey) && event.key === 'n') {
+                    event.preventDefault(); // Prevent browser's default new window dialog
+
+                    // Only allow adding elements if the form is editable
+                    if (isFormEditable) {
+                        openAddElementModal();
                     }
                 }
             });

--- a/resources/views/filament/forms/resources/form-version-resource/pages/build-form-version.blade.php
+++ b/resources/views/filament/forms/resources/form-version-resource/pages/build-form-version.blade.php
@@ -131,6 +131,9 @@
 
     @push('scripts')
     <script>
+        // Set editable state from PHP
+        const isFormEditable = @json($this->isEditable());
+
         // Real-time form version update handling
         document.addEventListener('DOMContentLoaded', function() {
             let updateTimeout;
@@ -175,6 +178,19 @@
             setTimeout(() => {
                 clearInterval(monacoCheckInterval);
             }, 10000);
+
+            // Add keyboard shortcut for saving (Ctrl/Cmd + S)
+            document.addEventListener('keydown', function(event) {
+                // Check if Ctrl+S (Windows/Linux) or Cmd+S (Mac) is pressed
+                if ((event.ctrlKey || event.metaKey) && event.key === 's') {
+                    event.preventDefault(); // Prevent browser's default save dialog
+
+                    // Only allow saving if the form is editable
+                    if (isFormEditable) {
+                        saveFormVersion();
+                    }
+                }
+            });
 
             // Sticky button functionality
             const stickyButton = document.getElementById('sticky-add-element-btn');

--- a/resources/views/filament/forms/resources/form-version-resource/pages/build-form-version.blade.php
+++ b/resources/views/filament/forms/resources/form-version-resource/pages/build-form-version.blade.php
@@ -2,12 +2,20 @@
     <!-- Sticky Add Form Element Button -->
     @if($this->isEditable())
     <div id="sticky-add-element-btn" class="sticky-add-element-button" style="display: none;">
-        <button type="button"
-            class="fi-btn fi-btn-color-success fi-btn-outlined fi-btn-size-sm"
-            onclick="openAddElementModal()">
-            @svg('heroicon-o-plus-circle', 'fi-btn-icon')
-            <span class="fi-btn-label">Add Element</span>
-        </button>
+        <div class="sticky-buttons-container">
+            <button type="button"
+                class="fi-btn fi-btn-color-primary fi-btn-outlined fi-btn-size-sm"
+                onclick="openPreviewForm()">
+                @svg('heroicon-o-tv', 'fi-btn-icon')
+                <span class="fi-btn-label">Preview</span>
+            </button>
+            <button type="button"
+                class="fi-btn fi-btn-color-success fi-btn-outlined fi-btn-size-sm"
+                onclick="openAddElementModal()">
+                @svg('heroicon-o-plus-circle', 'fi-btn-icon')
+                <span class="fi-btn-label">Add Element</span>
+            </button>
+        </div>
     </div>
     @endif
 
@@ -32,6 +40,12 @@
             transform: translateY(0);
         }
 
+        .sticky-buttons-container {
+            display: flex;
+            gap: 0.5rem;
+            align-items: center;
+        }
+
         .sticky-add-element-button button {
             box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
             border-radius: 0.5rem;
@@ -40,11 +54,19 @@
             align-items: center;
             gap: 0.375rem;
             background: white;
-            border: 1px solid #10b981;
-            color: #10b981;
             font-weight: 500;
             font-size: 0.875rem;
             transition: all 0.2s ease;
+        }
+
+        .sticky-add-element-button button.fi-btn-color-primary {
+            border: 1px solid #3b82f6;
+            color: #3b82f6;
+        }
+
+        .sticky-add-element-button button.fi-btn-color-success {
+            border: 1px solid #10b981;
+            color: #10b981;
         }
 
         .sticky-add-element-button button svg {
@@ -53,10 +75,18 @@
         }
 
         .sticky-add-element-button button:hover {
-            background: #10b981;
-            color: white;
             transform: translateY(-1px);
             box-shadow: 0 8px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+        }
+
+        .sticky-add-element-button button.fi-btn-color-primary:hover {
+            background: #3b82f6;
+            color: white;
+        }
+
+        .sticky-add-element-button button.fi-btn-color-success:hover {
+            background: #10b981;
+            color: white;
         }
 
         .sticky-add-element-button button:active {
@@ -193,6 +223,14 @@
                     }
                 }
             }
+        }
+
+        // Function to open the preview form (triggered by sticky button)
+        function openPreviewForm() {
+            const formVersionId = '{{ $this->record->id }}';
+            const previewBaseUrl = '{{ env("FORM_PREVIEW_URL", "") }}';
+            const previewUrl = previewBaseUrl.replace(/\/$/, '') + '/preview/' + formVersionId;
+            window.open(previewUrl, '_blank');
         }
     </script>
     @endpush


### PR DESCRIPTION
## What changes did you make? 

- Uses the svg directly rather than redefining it in the livewire component for the add element
- Adds the preview to the sticky footer in the builder
- Adds the save button to the sticky footer in the builder
- Fixes a bug with the modal header name when deleting an element
- Control/Command + P for Preview
- Control/Command + N for New element (can't override cmd + n for new tab, but control works here for mac)
- Control/Command + S for Save

## Why did you make these changes?

These were a number of QOL changes that Jeremy had requested.

## What alternatives did you consider?

N/A

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
