### PR TITLE
Add handling for header levels in containers/groups.

### DIFF
--- a/app/Livewire/FormElementTreeBuilder.php
+++ b/app/Livewire/FormElementTreeBuilder.php
@@ -341,6 +341,7 @@ class FormElementTreeBuilder extends BaseWidget
         // But convert null values to empty strings for text fields that the user might want to clear
         $textFields = ['labelText', 'placeholder', 'helperText', 'mask', 'content', 'legend', 'repeater_item_label'];
         $numericFields = ['min', 'max', 'step', 'defaultValue', 'maxCount', 'rows', 'cols', 'order'];
+        $nullableFields = ['level'];
 
         $filteredElementableData = [];
         foreach ($elementableData as $key => $value) {
@@ -352,6 +353,9 @@ class FormElementTreeBuilder extends BaseWidget
             } elseif (in_array($key, $numericFields) && ($value === null || $value === '')) {
                 // For numeric fields, convert null or empty string to null to allow nullable fields
                 $filteredElementableData[$key] = null;
+            } elseif (in_array($key, $nullableFields)) {
+                // For nullable fields, explicitly preserve null values
+                $filteredElementableData[$key] = $value; // This will be null when user selects "No override"
             }
             // For other fields, skip null values to let model defaults apply
         }
@@ -507,6 +511,7 @@ class FormElementTreeBuilder extends BaseWidget
         // But convert null values to empty strings for text fields that the user might want to clear
         $textFields = ['labelText', 'placeholder', 'helperText', 'mask', 'content', 'legend', 'repeater_item_label'];
         $numericFields = ['min', 'max', 'step', 'defaultValue', 'maxCount', 'rows', 'cols', 'order'];
+        $nullableFields = ['level'];
 
         $filteredElementableData = [];
         foreach ($elementableData as $key => $value) {
@@ -518,6 +523,9 @@ class FormElementTreeBuilder extends BaseWidget
             } elseif (in_array($key, $numericFields) && ($value === null || $value === '')) {
                 // For numeric fields, convert null or empty string to null to allow nullable fields
                 $filteredElementableData[$key] = null;
+            } elseif (in_array($key, $nullableFields)) {
+                // For nullable fields, explicitly preserve null values
+                $filteredElementableData[$key] = $value; // This will be null when user selects "No override"
             }
             // For other fields, skip null values to let model defaults apply
         }

--- a/app/Models/FormBuilding/ContainerFormElement.php
+++ b/app/Models/FormBuilding/ContainerFormElement.php
@@ -16,6 +16,7 @@ class ContainerFormElement extends Model
         'is_repeatable',
         'repeater_item_label',
         'legend',
+        'level'
     ];
 
     protected $casts = [
@@ -38,6 +39,19 @@ class ContainerFormElement extends Model
                 ->options(static::getContainerTypes())
                 ->default('section')
                 ->required(true)
+                ->disabled($disabled),
+            \Filament\Forms\Components\Select::make('elementable_data.level')
+                ->label('Label Level')
+                ->options([
+                    '2' => 'H2',
+                    '3' => 'H3',
+                    '4' => 'H4',
+                    '5' => 'H5',
+                    '6' => 'H6',
+                ])
+                ->placeholder('No override (default styling)')
+                ->nullable()
+                ->helperText('Optional level override for the label (e.g., h2, h3, etc.)')
                 ->disabled($disabled),
             \Filament\Forms\Components\TextInput::make('elementable_data.legend')
                 ->label('Legend/Title')
@@ -84,6 +98,7 @@ class ContainerFormElement extends Model
             'is_repeatable' => $this->is_repeatable,
             'repeater_item_label' => $this->repeater_item_label,
             'legend' => $this->legend,
+            'level' => $this->level,
         ];
     }
 
@@ -111,6 +126,7 @@ class ContainerFormElement extends Model
             'is_repeatable' => false,
             'legend' => '',
             'repeater_item_label' => '',
+            'level' => null,
         ];
     }
 

--- a/database/migrations/2025_07_30_133636_add_label_level_container_form_element.php
+++ b/database/migrations/2025_07_30_133636_add_label_level_container_form_element.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('container_form_elements', function (Blueprint $table) {
+            // Add a nullable string column for label_level (e.g., 'h1', 'h2', etc)
+            $table->string('level', 8)->nullable()->after('container_type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('container_form_elements', function (Blueprint $table) {
+            $table->dropColumn('level');
+        });
+    }
+};


### PR DESCRIPTION
## What changes did you make? 
- add optional "label level" (`level`) field for container form elements. 
- allowing users to choose a label level (e.g., `H2`, `H3`, etc.) or leave it as "No override" for default styling.
- Added a `nullableFields` array in both `mutateFormDataBeforeSave` and `mutateFormDataBeforeCreate` to allow values to be set back to null in the component attributes panel

## Why did you make these changes?

Requested per [3095](https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/3095/)

## What alternatives did you consider?

N/A

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
