### PR TITLE
Bug/uuids persist for duplication

### DIFF
--- a/app/Filament/Forms/Resources/FormResource/RelationManagers/FormVersionRelationManager.php
+++ b/app/Filament/Forms/Resources/FormResource/RelationManagers/FormVersionRelationManager.php
@@ -103,8 +103,7 @@ class FormVersionRelationManager extends RelationManager
                         // Duplicate all FormElements and map new to old
                         $oldToNewElementMap = [];
                         foreach ($record->formElements()->orderBy('order')->get() as $element) {
-                            $newElement = $element->replicate(['id', 'uuid', 'form_version_id', 'parent_id', 'created_at', 'updated_at']);
-                            $newElement->uuid = (string) Str::uuid();
+                            $newElement = $element->replicate(['id', 'form_version_id', 'parent_id', 'created_at', 'updated_at']);
                             $newElement->form_version_id = $newVersion->id;
                             $newElement->parent_id = null;
                             $newElement->save();

--- a/app/Filament/Forms/Resources/FormVersionResource.php
+++ b/app/Filament/Forms/Resources/FormVersionResource.php
@@ -50,7 +50,8 @@ class FormVersionResource extends Resource
                             ->preload()
                             ->searchable()
                             ->columnSpan(2)
-                            ->default(request()->query('form_id_title')),
+                            ->default(request()->query('form_id_title'))
+                            ->disabled(fn($record) => $record !== null),
                         Select::make('status')
                             ->options(function () {
                                 return FormVersion::getStatusOptions();

--- a/app/Filament/Forms/Resources/FormVersionResource.php
+++ b/app/Filament/Forms/Resources/FormVersionResource.php
@@ -375,12 +375,15 @@ class FormVersionResource extends Resource
                 Action::make('archive')
                     ->label('Archive')
                     ->icon('heroicon-o-archive-box-arrow-down')
-                    ->visible(fn($record) => $record->status === 'published')
+                    ->visible(fn($record) => $record->status !== 'archived' && (Gate::allows('admin') || Gate::allows('form-developer')))
                     ->action(function ($record) {
                         $record->update(['status' => 'archived']);
                     })
                     ->requiresConfirmation()
                     ->color('danger')
+                    ->modalHeading('Archive Form Version')
+                    ->modalDescription('Are you sure you want to archive this form version? This will change its status to archived.')
+                    ->modalSubmitActionLabel('Archive')
                     ->tooltip('Archive this form version'),
             ])
             ->bulkActions([

--- a/app/Filament/Forms/Resources/FormVersionResource/Pages/EditFormVersion.php
+++ b/app/Filament/Forms/Resources/FormVersionResource/Pages/EditFormVersion.php
@@ -31,7 +31,19 @@ class EditFormVersion extends EditRecord
     {
         return [
             Actions\ViewAction::make(),
-            Actions\DeleteAction::make(),
+            Actions\Action::make('archive')
+                ->label('Archive')
+                ->icon('heroicon-o-archive-box-arrow-down')
+                ->color('danger')
+                ->visible(fn() => $this->record->status !== 'archived' && (Gate::allows('admin') || Gate::allows('form-developer')))
+                ->action(function () {
+                    $this->record->update(['status' => 'archived']);
+                    $this->redirect($this->getRedirectUrl());
+                })
+                ->requiresConfirmation()
+                ->modalHeading('Archive Form Version')
+                ->modalDescription('Are you sure you want to archive this form version? This will change its status to archived.')
+                ->modalSubmitActionLabel('Archive'),
             Actions\Action::make('build')
                 ->label('Build')
                 ->icon('heroicon-o-wrench-screwdriver')


### PR DESCRIPTION
## What changes did you make? 

- You can't edit what form a form version belongs to
- You can't delete a form version, just archive it
- When duplicating a form version, the uuid will remain the same for form elements

## Why did you make these changes?

Handful of bugs reported causing issues

## What alternatives did you consider?

N/A

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
