### PR TITLE
Feature/script injection

### DIFF
--- a/app/Filament/Components/FormVersionBuilder.php
+++ b/app/Filament/Components/FormVersionBuilder.php
@@ -20,6 +20,7 @@ use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\Repeater;
+use Illuminate\Support\Facades\Log;
 
 class FormVersionBuilder
 {
@@ -415,9 +416,48 @@ class FormVersionBuilder
                                     ->columnSpan(5)
                                     ->tabs([
                                         Tab::make('web_style_sheet')
-                                            ->label('Web')
+                                            ->label(fn($livewire) => \App\Models\FormBuilding\StyleSheet::where('form_version_id', optional($livewire->getRecord())->id)->where('type', 'pdf')->exists() ? 'Web' : 'Styles')
                                             ->icon('heroicon-o-globe-alt')
                                             ->schema([
+                                                // Updated: ensure attached template styles show as selected on load
+                                                Select::make('attached_style_sheet_ids')
+                                                    ->label('Attach Styles')
+                                                    ->hint('Attach complete templates/constants. If you must modify one, import it in its entirety.')
+                                                    ->hintIcon('heroicon-o-information-circle')
+                                                    ->hintIconTooltip('These are included as-is and require no modification. To change a template or constant, use “Insert CSS" to import the full content and edit the imported copy. If the base attached style is modified, all forms using it will be updated automatically.')
+                                                    ->options($templateStyleSheets)
+                                                    ->multiple()
+                                                    ->preload()
+                                                    ->searchable()
+                                                    ->dehydrated(false)
+                                                    ->default(function ($livewire) {
+                                                        $record = $livewire->getRecord();
+                                                        return $record
+                                                            ? $record->styleSheets()
+                                                            ->where('type', 'template')
+                                                            ->pluck('style_sheets.id')
+                                                            ->map(fn($id) => (string) $id)
+                                                            ->toArray()
+                                                            : [];
+                                                    })
+                                                    ->afterStateHydrated(function ($state, callable $set, $livewire) {
+                                                        if (!empty($state)) return;
+                                                        $record = $livewire->getRecord();
+                                                        $ids = $record
+                                                            ? $record->styleSheets()
+                                                            ->where('type', 'template')
+                                                            ->pluck('style_sheets.id')
+                                                            ->map(fn($id) => (string) $id)
+                                                            ->toArray()
+                                                            : [];
+                                                        $set('attached_style_sheet_ids', $ids);
+                                                    })
+                                                    ->afterStateUpdated(function ($state, callable $set, $livewire) {
+                                                        $record = $livewire->getRecord();
+                                                        if ($record) {
+                                                            $record->styleSheets()->sync($state ?? []);
+                                                        }
+                                                    }),
                                                 Actions::make([
                                                     Action::make('import_css_content_web')
                                                         ->label('Insert CSS')
@@ -433,26 +473,23 @@ class FormVersionBuilder
                                                         ->action(function (callable $get, $livewire) {
                                                             $record = $livewire->getRecord();
                                                             $cssContentWeb = $get('css_content_web') ?? '';
-                                                            $cssContentPdf = $get('css_content_pdf') ?? '';
                                                             StyleSheet::createStyleSheet($record, $cssContentWeb, 'web');
-                                                            StyleSheet::createStyleSheet($record, $cssContentPdf, 'pdf');
                                                             // Fire update event for styles
                                                             FormVersionUpdateEvent::dispatch(
                                                                 $record->id,
                                                                 $record->form_id,
                                                                 $record->version_number,
-                                                                ['web_styles' => $cssContentWeb, 'pdf_styles' => $cssContentPdf],
+                                                                ['web_styles' => $cssContentWeb],
                                                                 'styles',
                                                                 false
                                                             );
                                                             \Filament\Notifications\Notification::make()
                                                                 ->success()
                                                                 ->title('Styles Saved')
-                                                                ->body('CSS stylesheets have been saved successfully.')
+                                                                ->body('CSS stylesheet has been saved successfully.')
                                                                 ->send();
                                                         }),
-                                                ])
-                                                    ->alignment(Alignment::Center),
+                                                ])->alignment(Alignment::Center),
                                                 CustomMonacoEditor::make('css_content_web')
                                                     ->label(false)
                                                     ->language('css')
@@ -466,6 +503,7 @@ class FormVersionBuilder
                                         Tab::make('pdf_style_sheet')
                                             ->label('PDF')
                                             ->icon('heroicon-o-document-text')
+                                            ->visible(fn($livewire) => \App\Models\FormBuilding\StyleSheet::where('form_version_id', optional($livewire->getRecord())->id)->where('type', 'pdf')->exists())
                                             ->schema([
                                                 Actions::make([
                                                     Action::make('import_css_content_pdf')
@@ -500,6 +538,58 @@ class FormVersionBuilder
                                                                 ->body('CSS stylesheets have been saved successfully.')
                                                                 ->send();
                                                         }),
+                                                    Action::make('migrate_pdf_styles_to_web')
+                                                        ->label('Migrate to Web')
+                                                        ->icon('heroicon-o-arrow-right-circle')
+                                                        ->color('warning')
+                                                        ->requiresConfirmation()
+                                                        ->disabled(fn($livewire) => !$editable || ($livewire instanceof ViewRecord))
+                                                        ->action(function (callable $get, callable $set, $livewire) {
+                                                            $record = $livewire->getRecord();
+                                                            if (!$record) {
+                                                                \Filament\Notifications\Notification::make()->danger()->title('No Record')->body('Cannot migrate without a record.')->send();
+                                                                return;
+                                                            }
+                                                            $pdf = \App\Models\FormBuilding\StyleSheet::where('form_version_id', $record->id)->where('type', 'pdf')->first();
+                                                            if (!$pdf) {
+                                                                \Filament\Notifications\Notification::make()->warning()->title('Nothing to Migrate')->body('No PDF stylesheet found.')->send();
+                                                                return;
+                                                            }
+
+                                                            $pdfContent = $pdf->getCssContent() ?? '';
+                                                            $web = \App\Models\FormBuilding\StyleSheet::where('form_version_id', $record->id)->where('type', 'web')->first();
+                                                            $webContent = $web?->getCssContent() ?? '';
+
+                                                            $banner = "/* Migrated from PDF on " . now()->toDateTimeString() . " */\n";
+                                                            $pdfPrintMediaQuery = "@media print {\n" . $pdfContent . "\n}\n";
+                                                            $newWebContent = trim(
+                                                                rtrim($webContent) . "\n\n" . $banner . $pdfPrintMediaQuery
+                                                            );
+
+                                                            if ($web) {
+                                                                $web->saveCssContent($newWebContent);
+                                                            } else {
+                                                                \App\Models\FormBuilding\StyleSheet::createStyleSheet($record, $newWebContent, 'web');
+                                                            }
+
+                                                            // Clear PDF file content (optional) then delete PDF record
+                                                            $pdf->saveCssContent('');
+                                                            try {
+                                                                $pdf->delete();
+                                                            } catch (\Exception $e) {
+                                                                Log::warning('Failed to delete PDF stylesheet during migration', ['id' => $pdf->id, 'error' => $e->getMessage()]);
+                                                            }
+
+                                                            // Update form state
+                                                            $set('css_content_web', $newWebContent);
+                                                            $set('css_content_pdf', '');
+
+                                                            \Filament\Notifications\Notification::make()
+                                                                ->success()
+                                                                ->title('Styles Migrated')
+                                                                ->body('PDF styles migrated to Web and PDF removed.')
+                                                                ->send();
+                                                        }),
                                                 ])
                                                     ->alignment(Alignment::Center),
                                                 CustomMonacoEditor::make('css_content_pdf')
@@ -528,7 +618,7 @@ class FormVersionBuilder
                                     ->contained(false)
                                     ->tabs([
                                         Tab::make('web_form_script')
-                                            ->label('Web')
+                                            ->label(fn($livewire) => \App\Models\FormBuilding\FormScript::where('form_version_id', optional($livewire->getRecord())->id)->where('type', 'pdf')->exists() ? 'Web' : 'Scripts')
                                             ->icon('heroicon-o-globe-alt')
                                             ->schema([
                                                 Actions::make([
@@ -546,29 +636,61 @@ class FormVersionBuilder
                                                         ->action(function (callable $get, $livewire) {
                                                             $record = $livewire->getRecord();
                                                             $jsContentWeb = $get('js_content_web') ?? '';
-                                                            $jsContentPdf = $get('js_content_pdf') ?? '';
-
                                                             FormScript::createFormScript($record, $jsContentWeb, 'web');
-                                                            FormScript::createFormScript($record, $jsContentPdf, 'pdf');
-
                                                             // Fire update event for scripts
                                                             FormVersionUpdateEvent::dispatch(
                                                                 $record->id,
                                                                 $record->form_id,
                                                                 $record->version_number,
-                                                                ['web_scripts' => $jsContentWeb, 'pdf_scripts' => $jsContentPdf],
+                                                                ['web_scripts' => $jsContentWeb],
                                                                 'scripts',
                                                                 false
                                                             );
-
                                                             \Filament\Notifications\Notification::make()
                                                                 ->success()
                                                                 ->title('Scripts Saved')
                                                                 ->body('JavaScript form scripts have been saved successfully.')
                                                                 ->send();
                                                         }),
-                                                ])
-                                                    ->alignment(Alignment::Center),
+                                                ])->alignment(Alignment::Center),
+                                                Select::make('attached_form_script_ids')
+                                                    ->label('Attach Scripts')
+                                                    ->hint('Attach complete templates/constants. If you must modify one, import it in its entirety.')
+                                                    ->hintIcon('heroicon-o-information-circle')
+                                                    ->hintIconTooltip('These are included as-is and require no modification. To change a template or constant, use “Insert Javascript” to import the full content and edit the imported copy. If the base attached style is modified, all forms using it will be updated automatically')
+                                                    ->options($templateScripts)
+                                                    ->multiple()
+                                                    ->preload()
+                                                    ->searchable()
+                                                    ->dehydrated(false)
+                                                    ->default(function ($livewire) {
+                                                        $record = $livewire->getRecord();
+                                                        return $record
+                                                            ? $record->formScripts()
+                                                            ->where('type', 'template')
+                                                            ->pluck('form_scripts.id')
+                                                            ->map(fn($id) => (string) $id)
+                                                            ->toArray()
+                                                            : [];
+                                                    })
+                                                    ->afterStateHydrated(function ($state, callable $set, $livewire) {
+                                                        if (!empty($state)) return;
+                                                        $record = $livewire->getRecord();
+                                                        $ids = $record
+                                                            ? $record->formScripts()
+                                                            ->where('type', 'template')
+                                                            ->pluck('form_scripts.id')
+                                                            ->map(fn($id) => (string) $id)
+                                                            ->toArray()
+                                                            : [];
+                                                        $set('attached_form_script_ids', $ids);
+                                                    })
+                                                    ->afterStateUpdated(function ($state, callable $set, $livewire) {
+                                                        $record = $livewire->getRecord();
+                                                        if ($record) {
+                                                            $record->formScripts()->sync($state ?? []);
+                                                        }
+                                                    }),
                                                 CustomMonacoEditor::make('js_content_web')
                                                     ->label(false)
                                                     ->language('javascript')
@@ -582,6 +704,7 @@ class FormVersionBuilder
                                         Tab::make('pdf_form_script')
                                             ->label('PDF')
                                             ->icon('heroicon-o-document-text')
+                                            ->visible(fn($livewire) => \App\Models\FormBuilding\FormScript::where('form_version_id', optional($livewire->getRecord())->id)->where('type', 'pdf')->exists())
                                             ->schema([
                                                 Actions::make([
                                                     Action::make('import_js_content_pdf')
@@ -619,6 +742,55 @@ class FormVersionBuilder
                                                                 ->body('JavaScript form scripts have been saved successfully.')
                                                                 ->send();
                                                         }),
+                                                    Action::make('migrate_pdf_scripts_to_web')
+                                                        ->label('Migrate to Web')
+                                                        ->icon('heroicon-o-arrow-right-circle')
+                                                        ->color('warning')
+                                                        ->requiresConfirmation()
+                                                        ->disabled(fn($livewire) => !$editable || ($livewire instanceof ViewRecord))
+                                                        ->action(function (callable $get, callable $set, $livewire) {
+                                                            $record = $livewire->getRecord();
+                                                            if (!$record) {
+                                                                \Filament\Notifications\Notification::make()->danger()->title('No Record')->body('Cannot migrate without a record.')->send();
+                                                                return;
+                                                            }
+                                                            $pdf = \App\Models\FormBuilding\FormScript::where('form_version_id', $record->id)->where('type', 'pdf')->first();
+                                                            if (!$pdf) {
+                                                                \Filament\Notifications\Notification::make()->warning()->title('Nothing to Migrate')->body('No PDF script found.')->send();
+                                                                return;
+                                                            }
+
+                                                            $pdfContent = $pdf->getJsContent() ?? '';
+                                                            $web = \App\Models\FormBuilding\FormScript::where('form_version_id', $record->id)->where('type', 'web')->first();
+                                                            $webContent = $web?->getJsContent() ?? '';
+
+                                                            $banner = "/* Migrated from PDF on " . now()->toDateTimeString() . " */\n";
+                                                            $newWebContent = trim(rtrim($webContent) . "\n\n" . $banner . $pdfContent);
+
+                                                            if ($web) {
+                                                                $web->saveJsContent($newWebContent);
+                                                            } else {
+                                                                \App\Models\FormBuilding\FormScript::createFormScript($record, $newWebContent, 'web');
+                                                            }
+
+                                                            // Clear PDF file content (optional) then delete PDF record
+                                                            $pdf->saveJsContent('');
+                                                            try {
+                                                                $pdf->delete();
+                                                            } catch (\Exception $e) {
+                                                                Log::warning('Failed to delete PDF script during migration', ['id' => $pdf->id, 'error' => $e->getMessage()]);
+                                                            }
+
+                                                            // Update form state
+                                                            $set('js_content_web', $newWebContent);
+                                                            $set('js_content_pdf', '');
+
+                                                            \Filament\Notifications\Notification::make()
+                                                                ->success()
+                                                                ->title('Scripts Migrated')
+                                                                ->body('PDF scripts migrated to Web and PDF removed.')
+                                                                ->send();
+                                                        }),
                                                 ])
                                                     ->alignment(Alignment::Center),
 
@@ -633,7 +805,7 @@ class FormVersionBuilder
                                                     ->disabled(!$editable),
                                             ]),
                                     ])
-                                    ->columnSpan(5)
+                                    ->columnSpan(5),
                             ]),
                     ]),
             ]);

--- a/app/Filament/Forms/Resources/FormScriptResource.php
+++ b/app/Filament/Forms/Resources/FormScriptResource.php
@@ -19,6 +19,8 @@ use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Tables;
 
 class FormScriptResource extends Resource
 {
@@ -37,7 +39,7 @@ class FormScriptResource extends Resource
     public static function getEloquentQuery(): Builder
     {
         return parent::getEloquentQuery()
-            ->with('formVersion.form')
+            ->with(['formVersion.form', 'formVersions.form'])
             ->where('type', 'template');
     }
 
@@ -56,6 +58,15 @@ class FormScriptResource extends Resource
                             ->label('Description')
                             ->columnSpanFull()
                             ->rows(5),
+                        Select::make('formVersions')
+                            ->label('Attach to Form Versions')
+                            ->multiple()
+                            ->preload()
+                            ->searchable()
+                            ->relationship('formVersions', 'version_number')
+                            ->getOptionLabelFromRecordUsing(function (\App\Models\FormBuilding\FormVersion $ver) {
+                                return "[{$ver->form->form_id}] {$ver->form->form_title} - v{$ver->version_number}";
+                            }),
                         Section::make('Info')
                             ->collapsible()
                             ->collapsed()
@@ -105,6 +116,37 @@ class FormScriptResource extends Resource
                             return $state;
                         })
                         ->searchable(),
+                    TextColumn::make('formVersions_count')
+                        ->label('Attached Versions')
+                        ->counts('formVersions')
+                        ->sortable()
+                        ->toggleable(),
+                    TextColumn::make('forms_list')
+                        ->label('Attached Forms')
+                        ->state(function ($record) {
+                            return $record->formVersions
+                                ->pluck('form')
+                                ->filter()
+                                ->unique('id')
+                                ->map(function ($f) {
+                                    return "[{$f->form_id}] {$f->form_title}";
+                                })
+                                ->implode(', ');
+                        })
+                        ->wrap()
+                        ->limit(200)
+                        ->toggleable(),
+                    TextColumn::make('formVersions_list')
+                        ->label('Versions')
+                        ->state(function ($record) {
+                            return $record->formVersions->map(function ($v) {
+                                return "[{$v->form->form_id}] {$v->form->form_title} v{$v->version_number}";
+                            })->implode(', ');
+                        })
+                        ->wrap()
+                        ->limit(200)
+                        ->toggleable()
+                        ->toggledHiddenByDefault(true),
                 ]),
             ])
             ->filters([

--- a/app/Filament/Forms/Resources/StyleSheetResource.php
+++ b/app/Filament/Forms/Resources/StyleSheetResource.php
@@ -19,6 +19,8 @@ use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\Select;
+use Filament\Tables;
 
 class StyleSheetResource extends Resource
 {
@@ -37,7 +39,7 @@ class StyleSheetResource extends Resource
     public static function getEloquentQuery(): Builder
     {
         return parent::getEloquentQuery()
-            ->with('formVersion.form')
+            ->with(['formVersion.form', 'formVersions.form'])
             ->where('type', 'template');
     }
 
@@ -56,6 +58,15 @@ class StyleSheetResource extends Resource
                             ->label('Description')
                             ->columnSpanFull()
                             ->rows(5),
+                        Select::make('formVersions')
+                            ->label('Attach to Form Versions')
+                            ->multiple()
+                            ->preload()
+                            ->searchable()
+                            ->relationship('formVersions', 'version_number')
+                            ->getOptionLabelFromRecordUsing(function (\App\Models\FormBuilding\FormVersion $ver) {
+                                return "[{$ver->form->form_id}] {$ver->form->form_title} - v{$ver->version_number}";
+                            }),
                         Section::make('Info')
                             ->collapsible()
                             ->collapsed()
@@ -106,6 +117,37 @@ class StyleSheetResource extends Resource
                             return $state;
                         })
                         ->searchable(),
+                    TextColumn::make('formVersions_count')
+                        ->label('Attached Versions')
+                        ->counts('formVersions')
+                        ->sortable()
+                        ->toggleable(),
+                    TextColumn::make('forms_list')
+                        ->label('Attached Forms')
+                        ->state(function ($record) {
+                            return $record->formVersions
+                                ->pluck('form')
+                                ->filter()
+                                ->unique('id')
+                                ->map(function ($f) {
+                                    return "[{$f->form_id}] {$f->form_title}";
+                                })
+                                ->implode(', ');
+                        })
+                        ->wrap()
+                        ->limit(200)
+                        ->toggleable(),
+                    TextColumn::make('formVersions_list')
+                        ->label('Versions')
+                        ->state(function ($record) {
+                            return $record->formVersions->map(function ($v) {
+                                return "[{$v->form->form_id}] {$v->form->form_title} v{$v->version_number}";
+                            })->implode(', ');
+                        })
+                        ->wrap()
+                        ->limit(200)
+                        ->toggleable()
+                        ->toggledHiddenByDefault(true),
                 ]),
             ])
             ->filters([

--- a/app/Http/Controllers/FormVersionController.php
+++ b/app/Http/Controllers/FormVersionController.php
@@ -145,7 +145,8 @@ class FormVersionController extends Controller
             $cacheTag = $isDraft ? 'draft' : 'form-template';
 
             // Try to get the requested template from cache
-            $cachedTemplate = Cache::tags([$cacheTag])->get($cacheKey);
+            // $cachedTemplate = Cache::tags([$cacheTag])->get($cacheKey);
+            $cachedTemplate = null;
 
             if ($cachedTemplate !== null) {
                 $jsonTemplate = $cachedTemplate;

--- a/app/Models/FormBuilding/FormScript.php
+++ b/app/Models/FormBuilding/FormScript.php
@@ -5,6 +5,7 @@ namespace App\Models\FormBuilding;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use App\Models\FormBuilding\FormVersion;
@@ -186,5 +187,14 @@ class FormScript extends Model
     public function formVersion(): BelongsTo
     {
         return $this->belongsTo(FormVersion::class);
+    }
+
+    /**
+     * Many-to-many relationship with FormVersion
+     */
+    public function formVersions(): BelongsToMany
+    {
+        return $this->belongsToMany(FormVersion::class, 'form_script_form_version')
+            ->withTimestamps();
     }
 }

--- a/app/Models/FormBuilding/FormVersion.php
+++ b/app/Models/FormBuilding/FormVersion.php
@@ -281,4 +281,23 @@ class FormVersion extends Model
             ->withTimestamps()
             ->orderBy('form_version_form_interfaces.order');
     }
+
+    // Added: many-to-many attachments
+    public function styleSheets(): BelongsToMany
+    {
+        return $this->belongsToMany(StyleSheet::class, 'style_sheet_form_version')
+            ->withTimestamps();
+    }
+
+    public function formScripts(): BelongsToMany
+    {
+        return $this->belongsToMany(FormScript::class, 'form_script_form_version')
+            ->withTimestamps();
+    }
+
+    // Convenience: return all attached style sheets
+    public function allStyleSheets()
+    {
+        return $this->styleSheets()->get();
+    }
 }

--- a/app/Models/FormBuilding/StyleSheet.php
+++ b/app/Models/FormBuilding/StyleSheet.php
@@ -163,4 +163,13 @@ class StyleSheet extends Model
     {
         return $this->belongsTo(FormVersion::class);
     }
+
+    /**
+     * Added: many-to-many attachments to form versions
+     */
+    public function formVersions(): BelongsToMany
+    {
+        return $this->belongsToMany(FormVersion::class, 'style_sheet_form_version')
+            ->withTimestamps();
+    }
 }

--- a/database/migrations/2025_08_12_092110_add_injection_options_script_styles.php
+++ b/database/migrations/2025_08_12_092110_add_injection_options_script_styles.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Pivot table to link scripts to multiple form versions
+        Schema::create('form_script_form_version', function (Blueprint $table) {
+            $table->foreignId('form_version_id')->constrained()->onDelete('cascade');
+            $table->foreignId('form_script_id')->constrained('form_scripts')->onDelete('cascade');
+            $table->primary(['form_version_id', 'form_script_id']);
+            $table->timestamps(); // add timestamps for withTimestamps()
+        });
+
+        // Pivot table to link style sheets to multiple form versions
+        Schema::create('style_sheet_form_version', function (Blueprint $table) {
+            $table->foreignId('form_version_id')->constrained()->onDelete('cascade');
+            $table->foreignId('style_sheet_id')->constrained('style_sheets')->onDelete('cascade');
+            $table->primary(['form_version_id', 'style_sheet_id']);
+            $table->timestamps(); // add timestamps for withTimestamps()
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Drop pivot tables
+        Schema::dropIfExists('form_script_form_version');
+        Schema::dropIfExists('style_sheet_form_version');
+    }
+};

--- a/public/js/sveltescript.js
+++ b/public/js/sveltescript.js
@@ -1,0 +1,143 @@
+// Required to dispatch Svelte updates from external scripts
+// This script listens for input changes, attribute mutations, and overrides property setters
+// to ensure Svelte components receive updates when external scripts modify the DOM.
+// It handles inputs, selects, textareas, and options, dispatching 'external-update'
+// events with the current value, and also fires bubbling 'input' events for inputs/selects/textareas.
+(function () {
+    // Track which elements are currently dispatching updates (to prevent recursion)
+    const dispatchingElements = new WeakSet();
+
+    /**
+     * Dispatch Svelte update events on an element.
+     * Fires 'external-update' with current value and
+     * for inputs/selects/textareas, also fires bubbling 'input' event.
+     * Skips if this element is already dispatching to prevent recursion.
+     * @param {HTMLElement} target
+     */
+    function dispatchSvelteUpdate(target) {
+        if (!target || dispatchingElements.has(target)) return;
+
+        dispatchingElements.add(target);
+        try {
+            const tag = target.tagName;
+
+            let value;
+            if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+                value = target.value;
+                target.dispatchEvent(new CustomEvent('external-update', { detail: { value } }));
+                target.dispatchEvent(new Event('input', { bubbles: true }));
+            } else {
+                value = target.textContent;
+                target.dispatchEvent(new CustomEvent('external-update', { detail: { value } }));
+            }
+        } finally {
+            dispatchingElements.delete(target);
+        }
+    }
+
+    // --- Listen globally for user input and change events ---
+    document.addEventListener('input', (e) => {
+        dispatchSvelteUpdate(e.target);
+    }, true);
+
+    document.addEventListener('change', (e) => {
+        dispatchSvelteUpdate(e.target);
+    }, true);
+
+    // --- MutationObserver for attribute changes ---
+    const observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+            if (mutation.type !== 'attributes') continue;
+
+            const { attributeName, target } = mutation;
+
+            // For inputs/selects/textareas, watch 'value' and 'checked'
+            if (
+                (attributeName === 'value' || attributeName === 'checked') &&
+                target instanceof HTMLElement &&
+                ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName)
+            ) {
+                dispatchSvelteUpdate(target);
+            }
+            // For options, watch 'selected' attribute and dispatch on parent select
+            else if (
+                attributeName === 'selected' &&
+                target instanceof HTMLOptionElement
+            ) {
+                const select = target.parentElement;
+                if (select && select.tagName === 'SELECT') {
+                    dispatchSvelteUpdate(select);
+                }
+            }
+        }
+    });
+
+    /**
+     * Observe attribute changes on elements relevant for Svelte updates.
+     * @param {HTMLElement} el
+     */
+    function observeElement(el) {
+        try {
+            const attrs = (el.tagName === 'OPTION') ? ['selected'] : ['value', 'checked'];
+            observer.observe(el, { attributes: true, attributeFilter: attrs });
+        } catch (_) {
+            // Fail silently for detached or restricted elements
+        }
+    }
+
+    // Observe all existing relevant elements initially
+    document.querySelectorAll('input, textarea, select, option').forEach(observeElement);
+
+    // --- Watch for dynamically added elements ---
+    const bodyObserver = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+            for (const node of mutation.addedNodes) {
+                if (node.nodeType !== 1) continue; // element only
+
+                if (node.matches && node.matches('input, textarea, select, option')) {
+                    observeElement(node);
+                }
+
+                if (node.querySelectorAll) {
+                    node.querySelectorAll('input, textarea, select, option').forEach(observeElement);
+                }
+            }
+        }
+    });
+    bodyObserver.observe(document.body, { childList: true, subtree: true });
+
+    // --- Override property setters for direct programmatic assignments ---
+    function overrideProperty(proto, propName) {
+        const descriptor = Object.getOwnPropertyDescriptor(proto, propName);
+        if (!descriptor || !descriptor.set) return;
+
+        Object.defineProperty(proto, propName, {
+            get: descriptor.get,
+            set(value) {
+                const oldValue = this[propName];
+                if (value === oldValue) return;
+                descriptor.set.call(this, value);
+
+                // For option.selected, dispatch on parent select instead
+                if (this instanceof HTMLOptionElement && propName === 'selected') {
+                    const select = this.parentElement;
+                    if (select && select.tagName === 'SELECT') {
+                        dispatchSvelteUpdate(select);
+                        return;
+                    }
+                }
+
+                dispatchSvelteUpdate(this);
+            },
+            configurable: true,
+            enumerable: descriptor.enumerable,
+        });
+    }
+
+    overrideProperty(HTMLInputElement.prototype, 'value');
+    overrideProperty(HTMLInputElement.prototype, 'checked');
+    overrideProperty(HTMLTextAreaElement.prototype, 'value');
+    overrideProperty(HTMLSelectElement.prototype, 'value');
+    overrideProperty(HTMLOptionElement.prototype, 'selected');
+})();
+


### PR DESCRIPTION
## What changes did you make? 
- support consolidation of web and pdf scripts/styles into singular scripts/styles 
- includes migration functionality to copy pdf scripts/styles to web script/styles, and then remove existing pdf version. wraps pdf styles in print media query.
- injects all scripts into form templates through JSON service. for current v1, consolidates script/style into singular file; v2 attaches as separate files, and also includes manual injection of mandatory svelte script to enable bubbling/interactivity of script actions.
- allows users to 'attach' script/style templates to form versions. help language identifies that this should only be done with unchanging scripts/styles, as future changes to these templates will ripple across all forms. This is useful for global styling, or enabling a set of scripts by default on all forms (potentially mustache library where applicable).

## Why did you make these changes?

Move to single style/script editing page, and user management of scripts/styles by environment to support v2 kiln, while enabling ongoing support for v1.

## What alternatives did you consider?

_Describe any alternative solutions you considered and why._

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
