### PR TITLE
Fix - stylesheet cascade and add mode to interfaces

### DIFF
--- a/app/Filament/Components/FormVersionBuilder.php
+++ b/app/Filament/Components/FormVersionBuilder.php
@@ -78,9 +78,15 @@ class FormVersionBuilder
             if ($sheet->type === 'template') {
                 $templateStyleSheets[$sheet->id] = "Template Stylesheet ({$sheet->filename})";
             } else {
-                $form = $sheet->formVersion->form;
-                $version = $sheet->formVersion;
-                $otherStyleSheets[$sheet->id] = "[{$form->form_id}] {$form->form_title} - v{$version->version_number} ({$sheet->type})";
+                $formVersion = $sheet->formVersion;
+                $form = $formVersion?->form;
+
+                if ($formVersion && $form) {
+                    $otherStyleSheets[$sheet->id] = "[{$form->form_id}] {$form->form_title} - v{$formVersion->version_number} ({$sheet->type})";
+                } else {
+                    $name = $sheet->filename ?? "Stylesheet #{$sheet->id}";
+                    $otherStyleSheets[$sheet->id] = "[Orphan] {$name} ({$sheet->type})";
+                }
             }
         }
 
@@ -97,10 +103,16 @@ class FormVersionBuilder
         foreach ($formScripts as $script) {
             if ($script->type === 'template') {
                 $templateScripts[$script->id] = "Template Script ({$script->filename})";
-            } else if ($script->formVersion && $script->formVersion->form) {
-                $form = $script->formVersion->form;
-                $version = $script->formVersion;
-                $otherScripts[$script->id] = "[{$form->form_id}] {$form->form_title} - v{$version->version_number} ({$script->type})";
+            } else {
+                $formVersion = $script->formVersion;
+                $form = $formVersion?->form;
+
+                if ($formVersion && $form) {
+                    $otherScripts[$script->id] = "[{$form->form_id}] {$form->form_title} - v{$formVersion->version_number} ({$script->type})";
+                } else {
+                    $name = $script->filename ?? "Script #{$script->id}";
+                    $otherScripts[$script->id] = "[Orphan] {$name} ({$script->type})";
+                }
             }
         }
 

--- a/app/Filament/Forms/Resources/FormInterfaceResource.php
+++ b/app/Filament/Forms/Resources/FormInterfaceResource.php
@@ -41,6 +41,14 @@ class FormInterfaceResource extends Resource
                             ->autocomplete(false)
                             ->datalist(FormInterface::types())
                             ->maxLength(255),
+                        Forms\Components\Select::make('mode')
+                            ->options(FormInterface::modes())
+                            ->nullable()
+                            ->multiple()
+                            ->searchable()
+                            ->label('Mode')
+                            ->placeholder('Select Mode')
+                            ->columnSpanFull(),
                         Forms\Components\TextInput::make('style')
                             ->maxLength(255),
                         Forms\Components\Textarea::make('condition')
@@ -60,7 +68,13 @@ class FormInterfaceResource extends Resource
                             ->datalist(InterfaceAction::actionTypes()),
                         Forms\Components\TextInput::make('type')->maxLength(255)
                             ->autocomplete(false)
+                            ->badge()
                             ->datalist(InterfaceAction::types()),
+                        Forms\Components\TextInput::make('mode')
+                            ->autocomplete(false)
+                            ->badge()
+                            ->datalist(InterfaceAction::modes())
+                            ->label('Mode'),
                         Forms\Components\TextInput::make('host')->maxLength(255),
                         Forms\Components\TextInput::make('path')->maxLength(255),
                         Forms\Components\TextInput::make('authentication')->maxLength(255),

--- a/app/Filament/Forms/Resources/FormInterfaceResource.php
+++ b/app/Filament/Forms/Resources/FormInterfaceResource.php
@@ -41,14 +41,11 @@ class FormInterfaceResource extends Resource
                             ->autocomplete(false)
                             ->datalist(FormInterface::types())
                             ->maxLength(255),
-                        Forms\Components\Select::make('mode')
-                            ->options(FormInterface::modes())
-                            ->nullable()
-                            ->multiple()
-                            ->searchable()
-                            ->label('Mode')
-                            ->placeholder('Select Mode')
-                            ->columnSpanFull(),
+                        Forms\Components\TextInput::make('mode')
+                            ->required()
+                            ->autocomplete(false)
+                            ->datalist(FormInterface::modes())
+                            ->maxLength(255),
                         Forms\Components\TextInput::make('style')
                             ->maxLength(255),
                         Forms\Components\Textarea::make('condition')
@@ -68,13 +65,7 @@ class FormInterfaceResource extends Resource
                             ->datalist(InterfaceAction::actionTypes()),
                         Forms\Components\TextInput::make('type')->maxLength(255)
                             ->autocomplete(false)
-                            ->badge()
                             ->datalist(InterfaceAction::types()),
-                        Forms\Components\TextInput::make('mode')
-                            ->autocomplete(false)
-                            ->badge()
-                            ->datalist(InterfaceAction::modes())
-                            ->label('Mode'),
                         Forms\Components\TextInput::make('host')->maxLength(255),
                         Forms\Components\TextInput::make('path')->maxLength(255),
                         Forms\Components\TextInput::make('authentication')->maxLength(255),

--- a/app/Filament/Forms/Resources/FormInterfaceResource/Pages/ListFormInterfaces.php
+++ b/app/Filament/Forms/Resources/FormInterfaceResource/Pages/ListFormInterfaces.php
@@ -48,6 +48,7 @@ class ListFormInterfaces extends ListRecords
                         });
                     }),
                 Tables\Columns\TextColumn::make('type')->searchable()->sortable()->toggleable(isToggledHiddenByDefault: false),
+                Tables\Columns\TextColumn::make('mode')->searchable()->sortable()->toggleable(isToggledHiddenByDefault: false),
                 Tables\Columns\TextColumn::make('style')->searchable()->sortable()->toggleable(isToggledHiddenByDefault: true)->wrap(),
                 Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable()->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('updated_at')->dateTime()->sortable()->toggleable(isToggledHiddenByDefault: true),
@@ -68,6 +69,22 @@ class ListFormInterfaces extends ListRecords
                             $values = [$values];
                         }
                         return $query->whereIn('type', $values);
+                    }),
+                SelectFilter::make('mode')
+                    ->options(FormInterface::modes())
+                    ->label('Mode')
+                    ->multiple()
+                    ->searchable()
+                    ->placeholder('All Modes')
+                    ->query(function ($query, array $data) {
+                        $values = $data['values'] ?? $data['value'] ?? [];
+                        if (empty($values)) {
+                            return $query;
+                        }
+                        if (!is_array($values)) {
+                            $values = [$values];
+                        }
+                        return $query->whereIn('mode', $values);
                     }),
                 SelectFilter::make('form_name')
                     ->label('Active Forms')

--- a/app/Models/FormMetadata/FormInterface.php
+++ b/app/Models/FormMetadata/FormInterface.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Builder;
 use App\Models\FormBuilding\FormVersion;
 use Spatie\Activitylog\Traits\LogsActivity;
 use Spatie\Activitylog\LogOptions;
@@ -21,6 +22,8 @@ class FormInterface extends Model
         'label',
         'style',
         'condition',
+        'mode',
+        'mode_config',
     ];
 
     protected static $logAttributes = [
@@ -29,8 +32,13 @@ class FormInterface extends Model
         'label',
         'style',
         'condition',
+        'mode',
+        'mode_config',
     ];
 
+    protected $casts = [
+        'mode_config' => 'array',
+    ];
 
     public function actions(): HasMany
     {
@@ -49,6 +57,25 @@ class FormInterface extends Model
             ->values()
             ->mapWithKeys(fn($type) => [$type => $type])
             ->toArray();
+    }
+
+    public static function modes(): array
+    {
+        return self::query()
+            ->distinct()
+            ->whereNotNull('mode')
+            ->where('mode', '!=', '')
+            ->pluck('mode')
+            ->filter()
+            ->sort()
+            ->values()
+            ->mapWithKeys(fn($mode) => [$mode => $mode])
+            ->toArray();
+    }
+
+    public function scopeMode(Builder $query, ?string $mode): Builder
+    {
+        return $mode === null ? $query->whereNull('mode') : $query->where('mode', $mode);
     }
 
     public function formVersions(): BelongsToMany

--- a/database/migrations/2025_08_20_121033_add_interface_column_mode.php
+++ b/database/migrations/2025_08_20_121033_add_interface_column_mode.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('form_interfaces', function (Blueprint $table) {
+            $table->string('mode')->nullable()->after('type')->index();
+            $table->json('mode_config')->nullable()->after('mode');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('form_interfaces', function (Blueprint $table) {
+            $table->dropColumn(['mode_config', 'mode']);
+        });
+    }
+};


### PR DESCRIPTION
## What changes did you make? 

- add "mode" property to the `FormInterface` model.
- Enable null gating for stylesheet and script labeling in the form version builder to prevent errors when scripts/styles are not deleted with form versions.
- enhance attribute normalization to omit nullish or undefined values (causing issues with react carbon components when null values are set).

## Why did you make these changes?

- followup to ticket [3127](https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/3127)
- additional functionality in preparation for api interface integration
