### PR TITLE
export json as copy-paste

### DIFF
--- a/database/seeders/UserTypeSeeder.php
+++ b/database/seeders/UserTypeSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use App\Models\UserType;
+use App\Models\FormMetadata\UserType;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 

--- a/resources/views/filament/forms/resources/form-version-resource/pages/build-form-version.blade.php
+++ b/resources/views/filament/forms/resources/form-version-resource/pages/build-form-version.blade.php
@@ -298,6 +298,41 @@
                 }
             }
         }
+
+        // Function to copy text to clipboard
+        async function copyToClipboard(text) {
+            try {
+                if (navigator.clipboard && window.isSecureContext) {
+                    await navigator.clipboard.writeText(text);
+                } else {
+                    // Fallback for older browsers or non-secure contexts
+                    const textArea = document.createElement('textarea');
+                    textArea.value = text;
+                    textArea.style.position = 'fixed';
+                    textArea.style.left = '-999999px';
+                    textArea.style.top = '-999999px';
+                    document.body.appendChild(textArea);
+                    textArea.focus();
+                    textArea.select();
+                    document.execCommand('copy');
+                    textArea.remove();
+                }
+                return true;
+            } catch (err) {
+                console.error('Failed to copy to clipboard:', err);
+                return false;
+            }
+        }
+
+        // Listen for Livewire events
+        document.addEventListener('livewire:init', () => {
+            Livewire.on('copy-to-clipboard', (event) => {
+                const content = event.content || event[0]?.content;
+                if (content) {
+                    copyToClipboard(content);
+                }
+            });
+        });
     </script>
     @endpush
 </x-filament-panels::page>


### PR DESCRIPTION
## What changes did you make? 

Allows user to copy the json structure as a "copy to clipboard"

## Why did you make these changes?

I tried to refactor a little bit to make it easier to reuse the download and copy components

## What alternatives did you consider?

duplicating the code for each, but this was better although it took a little longer.

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
