### PR TITLE
ADO-3750 - Add custom validation message support for input masks in form builder

### DIFF
--- a/app/Livewire/FormElementTreeBuilder.php
+++ b/app/Livewire/FormElementTreeBuilder.php
@@ -388,7 +388,7 @@ class FormElementTreeBuilder extends BaseWidget implements HasForms
 
         // Filter out null values from elementable data to let model defaults apply
         // But convert null values to empty strings for text fields that the user might want to clear
-        $textFields = ['labelText', 'placeholder', 'helperText', 'mask', 'content', 'legend', 'repeater_item_label'];
+        $textFields = ['labelText', 'placeholder', 'helperText', 'mask', 'maskErrorMessage', 'content', 'legend', 'repeater_item_label'];
         $numericFields = ['min', 'max', 'step', 'defaultValue', 'maxCount', 'rows', 'cols', 'order'];
         $nullableFields = ['level'];
 
@@ -557,7 +557,7 @@ class FormElementTreeBuilder extends BaseWidget implements HasForms
 
         // Filter out null values from elementable data to let model defaults apply
         // But convert null values to empty strings for text fields that the user might want to clear
-        $textFields = ['labelText', 'placeholder', 'helperText', 'mask', 'content', 'legend', 'repeater_item_label'];
+        $textFields = ['labelText', 'placeholder', 'helperText', 'mask', 'maskErrorMessage', 'content', 'legend', 'repeater_item_label'];
         $numericFields = ['min', 'max', 'step', 'defaultValue', 'maxCount', 'rows', 'cols', 'order'];
         $nullableFields = ['level'];
 

--- a/app/Models/FormBuilding/TextInputFormElement.php
+++ b/app/Models/FormBuilding/TextInputFormElement.php
@@ -22,6 +22,7 @@ class TextInputFormElement extends Model
         'enableVarSub',
         'maskType',
         'mask',
+        'maskErrorMessage',
         'maxCount',
         'defaultValue',
     ];
@@ -76,6 +77,12 @@ class TextInputFormElement extends Model
                             ->autocomplete(false)
                             ->hint('Supports Maska syntax, regular expressions, or character classes like "a-zA-Z0-9"')
                             ->disabled($disabled),
+                        TextInput::make('elementable_data.maskErrorMessage')
+                            ->label('Validation Message')
+                            ->placeholder('e.g. Only letters and spaces are allowed')
+                            ->hint('Displayed when input doesn\'t match the mask')
+                            ->visible(fn ($get) => $get('elementable_data.maskType') === 'custom')
+                            ->disabled($disabled),
                     ])
                     ->columns(1),
             ]
@@ -101,6 +108,7 @@ class TextInputFormElement extends Model
             'hideLabel' => $this->hideLabel,
             'enableVarSub' => $this->enableVarSub,
             'mask' => $this->mask,
+            'maskErrorMessage' => $this->maskErrorMessage,
             'maxCount' => $this->maxCount,
             'defaultValue' => $this->defaultValue,
         ];
@@ -117,6 +125,7 @@ class TextInputFormElement extends Model
             'hideLabel' => false,
             'enableVarSub' => false,
             'mask' => '',
+            'maskErrorMessage' => '',
             'maxCount' => null,
             'defaultValue' => '',
         ];

--- a/database/migrations/2026_02_12_000000_add_mask_error_message_to_text_input_form_elements.php
+++ b/database/migrations/2026_02_12_000000_add_mask_error_message_to_text_input_form_elements.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('text_input_form_elements', function (Blueprint $table) {
+            $table->string('maskErrorMessage')->nullable()->after('mask');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('text_input_form_elements', function (Blueprint $table) {
+            $table->dropColumn('maskErrorMessage');
+        });
+    }
+};


### PR DESCRIPTION
## What changes did you make? 

Added a maskErrorMessage column to the text input form element and a "Validation Message" field in the form builder UI, visible when the custom mask type is selected.

## Why did you make these changes?

To allow form developers to provide user-friendly validation messages for custom input masks, instead of showing raw regex patterns to end users.

## What alternatives did you consider?

### Checklist

- [X] **I have assigned at least one reviewer**
- [X] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**

---

<img width="662" height="864" alt="image" src="https://github.com/user-attachments/assets/7f22918a-1479-43b3-a905-5520ab71151d" />

## Kiln-v2 PR:
https://github.com/bcgov/kiln-v2/pull/140

