### PR TITLE
ADO-3196 - Fix date picker min/max date not clearing

### DIFF
--- a/app/Livewire/FormElementTreeBuilder.php
+++ b/app/Livewire/FormElementTreeBuilder.php
@@ -390,7 +390,7 @@ class FormElementTreeBuilder extends BaseWidget implements HasForms
         // But convert null values to empty strings for text fields that the user might want to clear
         $textFields = ['labelText', 'placeholder', 'helperText', 'mask', 'maskErrorMessage', 'content', 'legend', 'repeater_item_label'];
         $numericFields = ['min', 'max', 'step', 'defaultValue', 'maxCount', 'rows', 'cols', 'order'];
-        $nullableFields = ['level'];
+        $nullableFields = ['level', 'minDate', 'maxDate'];
 
         $filteredElementableData = [];
         foreach ($elementableData as $key => $value) {
@@ -559,7 +559,7 @@ class FormElementTreeBuilder extends BaseWidget implements HasForms
         // But convert null values to empty strings for text fields that the user might want to clear
         $textFields = ['labelText', 'placeholder', 'helperText', 'mask', 'maskErrorMessage', 'content', 'legend', 'repeater_item_label'];
         $numericFields = ['min', 'max', 'step', 'defaultValue', 'maxCount', 'rows', 'cols', 'order'];
-        $nullableFields = ['level'];
+        $nullableFields = ['level', 'minDate', 'maxDate'];
 
         $filteredElementableData = [];
         foreach ($elementableData as $key => $value) {


### PR DESCRIPTION
## What changes did you make? 

Added minDate and maxDate to the $nullableFields list in FormElementTreeBuilder.php

## Why did you make these changes?

Cleared date values were silently dropped during save, leaving the old min/max date in the database.

## What alternatives did you consider?

### Checklist

- [X] **I have assigned at least one reviewer**
- [X] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
