### PR TITLE
ADO-3769 Disable form version duplication

### DIFF
--- a/app/Filament/Forms/Resources/FormResource/RelationManagers/FormVersionRelationManager.php
+++ b/app/Filament/Forms/Resources/FormResource/RelationManagers/FormVersionRelationManager.php
@@ -86,6 +86,7 @@ class FormVersionRelationManager extends RelationManager
                 Tables\Actions\EditAction::make()
                     ->url(fn(FormVersion $record) => FormVersionResource::getUrl('edit', ['record' => $record]))
                     ->visible(fn($record) => (in_array($record->status, ['draft', 'testing'])) && Gate::allows('form-developer')),
+                // Duplicate form version currently disabled due to ADO bugs 3302 and 3303
                 // Action::make('duplicate')
                 //     ->label('Duplicate')
                 //     ->icon('heroicon-o-document-duplicate')

--- a/app/Filament/Forms/Resources/FormResource/RelationManagers/FormVersionRelationManager.php
+++ b/app/Filament/Forms/Resources/FormResource/RelationManagers/FormVersionRelationManager.php
@@ -86,96 +86,96 @@ class FormVersionRelationManager extends RelationManager
                 Tables\Actions\EditAction::make()
                     ->url(fn(FormVersion $record) => FormVersionResource::getUrl('edit', ['record' => $record]))
                     ->visible(fn($record) => (in_array($record->status, ['draft', 'testing'])) && Gate::allows('form-developer')),
-                Action::make('duplicate')
-                    ->label('Duplicate')
-                    ->icon('heroicon-o-document-duplicate')
-                    ->color('info')
-                    ->visible(fn($record) => (in_array($record->status, ['draft', 'testing'])) && Gate::allows('form-developer'))
-                    ->action(function ($record) {
-                        // Create a new version with incremented version number
-                        $newVersion = $record->replicate(['version_number', 'status', 'created_at', 'updated_at']);
-                        $newVersion->version_number = FormVersion::where('form_id', $record->form_id)->max('version_number') + 1;
-                        $newVersion->status = 'draft';
-                        $newVersion->form_developer_id = Auth::id();
-                        $newVersion->comments = 'Duplicated from version ' . $record->version_number;
-                        $newVersion->save();
+                // Action::make('duplicate')
+                //     ->label('Duplicate')
+                //     ->icon('heroicon-o-document-duplicate')
+                //     ->color('info')
+                //     ->visible(fn($record) => (in_array($record->status, ['draft', 'testing'])) && Gate::allows('form-developer'))
+                //     ->action(function ($record) {
+                //         // Create a new version with incremented version number
+                //         $newVersion = $record->replicate(['version_number', 'status', 'created_at', 'updated_at']);
+                //         $newVersion->version_number = FormVersion::where('form_id', $record->form_id)->max('version_number') + 1;
+                //         $newVersion->status = 'draft';
+                //         $newVersion->form_developer_id = Auth::id();
+                //         $newVersion->comments = 'Duplicated from version ' . $record->version_number;
+                //         $newVersion->save();
 
-                        // Duplicate all FormElements and map new to old
-                        $oldToNewElementMap = [];
-                        foreach ($record->formElements()->orderBy('order')->get() as $element) {
-                            $newElement = $element->replicate(['id', 'form_version_id', 'parent_id', 'created_at', 'updated_at']);
-                            $newElement->form_version_id = $newVersion->id;
-                            $newElement->parent_id = null;
-                            $newElement->save();
+                //         // Duplicate all FormElements and map new to old
+                //         $oldToNewElementMap = [];
+                //         foreach ($record->formElements()->orderBy('order')->get() as $element) {
+                //             $newElement = $element->replicate(['id', 'form_version_id', 'parent_id', 'created_at', 'updated_at']);
+                //             $newElement->form_version_id = $newVersion->id;
+                //             $newElement->parent_id = null;
+                //             $newElement->save();
 
-                            // Map old element ID to new element for parent relationship updates
-                            $oldToNewElementMap[$element->id] = [
-                                'new_element' => $newElement,
-                                'old_parent_id' => $element->parent_id
-                            ];
+                //             // Map old element ID to new element for parent relationship updates
+                //             $oldToNewElementMap[$element->id] = [
+                //                 'new_element' => $newElement,
+                //                 'old_parent_id' => $element->parent_id
+                //             ];
 
-                            // Attach tags
-                            $newElement->tags()->attach($element->tags->pluck('id'));
+                //             // Attach tags
+                //             $newElement->tags()->attach($element->tags->pluck('id'));
 
-                            // Duplicate data bindings
-                            foreach ($element->dataBindings as $dataBinding) {
-                                FormElementDataBinding::create([
-                                    'form_element_id' => $newElement->id,
-                                    'form_data_source_id' => $dataBinding->form_data_source_id,
-                                    'path' => $dataBinding->path,
-                                    'condition' => $dataBinding->condition,
-                                    'order' => $dataBinding->order,
-                                ]);
-                            }
+                //             // Duplicate data bindings
+                //             foreach ($element->dataBindings as $dataBinding) {
+                //                 FormElementDataBinding::create([
+                //                     'form_element_id' => $newElement->id,
+                //                     'form_data_source_id' => $dataBinding->form_data_source_id,
+                //                     'path' => $dataBinding->path,
+                //                     'condition' => $dataBinding->condition,
+                //                     'order' => $dataBinding->order,
+                //                 ]);
+                //             }
 
-                            // Duplicate polymorphic elementable and link to new element
-                            if ($element->elementable) {
-                                $elementableData = $element->elementable->getData();
-                                $newElementable = $element->elementable_type::create($elementableData);
-                                $newElement->update(['elementable_id' => $newElementable->id]);
-                            }
-                        }
+                //             // Duplicate polymorphic elementable and link to new element
+                //             if ($element->elementable) {
+                //                 $elementableData = $element->elementable->getData();
+                //                 $newElementable = $element->elementable_type::create($elementableData);
+                //                 $newElement->update(['elementable_id' => $newElementable->id]);
+                //             }
+                //         }
 
-                        // Update parent_id relationships for nested elements
-                        foreach ($oldToNewElementMap as $data) {
-                            if ($data['old_parent_id'] && isset($oldToNewElementMap[$data['old_parent_id']])) {
-                                $data['new_element']->update([
-                                    'parent_id' => $oldToNewElementMap[$data['old_parent_id']]['new_element']->id
-                                ]);
-                            }
-                        }
+                //         // Update parent_id relationships for nested elements
+                //         foreach ($oldToNewElementMap as $data) {
+                //             if ($data['old_parent_id'] && isset($oldToNewElementMap[$data['old_parent_id']])) {
+                //                 $data['new_element']->update([
+                //                     'parent_id' => $oldToNewElementMap[$data['old_parent_id']]['new_element']->id
+                //                 ]);
+                //             }
+                //         }
 
-                        // Duplicate related models using a helper method
-                        FormVersionHelper::duplicateRelatedModels($record->id, $newVersion->id, StyleSheet::class);
-                        FormVersionHelper::duplicateRelatedModels($record->id, $newVersion->id, FormScript::class);
+                //         // Duplicate related models using a helper method
+                //         FormVersionHelper::duplicateRelatedModels($record->id, $newVersion->id, StyleSheet::class);
+                //         FormVersionHelper::duplicateRelatedModels($record->id, $newVersion->id, FormScript::class);
 
-                        // Duplicate form data sources with their order
-                        foreach ($record->formVersionFormDataSources as $formDataSource) {
-                            FormVersionFormDataSource::create([
-                                'form_version_id' => $newVersion->id,
-                                'form_data_source_id' => $formDataSource->form_data_source_id,
-                                'order' => $formDataSource->order,
-                            ]);
-                        }
+                //         // Duplicate form data sources with their order
+                //         foreach ($record->formVersionFormDataSources as $formDataSource) {
+                //             FormVersionFormDataSource::create([
+                //                 'form_version_id' => $newVersion->id,
+                //                 'form_data_source_id' => $formDataSource->form_data_source_id,
+                //                 'order' => $formDataSource->order,
+                //             ]);
+                //         }
 
-                        // Duplicate form interfaces
-                        foreach ($record->formVersionFormInterfaces as $formInterface) {
-                            \App\Models\FormBuilding\FormVersionFormInterface::create([
-                                'form_version_id' => $newVersion->id,
-                                'form_interface_id' => $formInterface->form_interface_id,
-                                'order' => $formInterface->order,
-                            ]);
-                        }
+                //         // Duplicate form interfaces
+                //         foreach ($record->formVersionFormInterfaces as $formInterface) {
+                //             \App\Models\FormBuilding\FormVersionFormInterface::create([
+                //                 'form_version_id' => $newVersion->id,
+                //                 'form_interface_id' => $formInterface->form_interface_id,
+                //                 'order' => $formInterface->order,
+                //             ]);
+                //         }
 
-                        // Redirect to build the new version
-                        if (Gate::allows('form-developer')) {
-                            return redirect()->to('/forms/form-versions/' . $newVersion->id . '/build');
-                        } else {
-                            return redirect()->to(FormVersionResource::getUrl('view', ['record' => $newVersion]));
-                        }
-                    })
-                    ->requiresConfirmation()
-                    ->modalDescription('This will create a new draft version based on this form version, including all form elements.'),
+                //         // Redirect to build the new version
+                //         if (Gate::allows('form-developer')) {
+                //             return redirect()->to('/forms/form-versions/' . $newVersion->id . '/build');
+                //         } else {
+                //             return redirect()->to(FormVersionResource::getUrl('view', ['record' => $newVersion]));
+                //         }
+                //     })
+                //     ->requiresConfirmation()
+                //     ->modalDescription('This will create a new draft version based on this form version, including all form elements.'),
                 Tables\Actions\Action::make('archive')
                     ->label('Archive')
                     ->icon('heroicon-o-archive-box-arrow-down')


### PR DESCRIPTION
## What changes did you make? 

Disable form version duplication by commenting out the frontend code for it

## Why did you make these changes?

ADO bugs 3302 and 3303 were discovered in the current implementation for duplicating a form version in Klamm. As a temporary measure, we have decided to disable this feature (code commented out) until we can investigate and resolve the issues. The current workaround for this is to download/export the form JSON from the current form version and import it into a newly created form version.

## What alternatives did you consider?

None

### Checklist

- [X] **I have assigned at least one reviewer**
- [X] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
