### PR TITLE
ADO-3781 Add formatting and validation to the number and currency input's fields

### DIFF
--- a/app/Models/FormBuilding/CurrencyInputFormElement.php
+++ b/app/Models/FormBuilding/CurrencyInputFormElement.php
@@ -7,9 +7,10 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Filament\Forms\Get;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\TextInput;
-use Filament\Forms\Components\ToggleButtons;
+use Closure;
 
 class CurrencyInputFormElement extends Model
 {
@@ -35,12 +36,95 @@ class CurrencyInputFormElement extends Model
     protected $attributes = [
         'hideLabel' => false,
     ];
+    /*
+     * Format the value as currency
+    */
+    protected static function formatCurrency(string $target): \Closure
+    {
+        return function ($state, callable $set) use ($target) {
+            if ($state === null) return;
+
+            $raw = trim((string) $state);
+
+            // Normalize incomplete forms to 0.00
+            if (in_array($raw, ['-', '.', '-.'], true)) {
+                $set($target, '0.00');
+                return;
+            }
+
+            // Only allow plain decimals: optional leading '-', digits, optional single dot, digits
+            // (Rejects scientific notation, commas, spaces, letters, etc.)
+            if (!preg_match('/^-?\d*\.?\d*$/', $raw)) {
+                return; // let validation flag invalid format
+            }
+
+            // Separate sign and body
+            $neg = str_starts_with($raw, '-');
+            $body = ltrim($raw, '-');
+
+            // Split into integer and fractional parts
+            $int = $body;
+            $frac = '';
+            if (strpos($body, '.') !== false) {
+                [$int, $frac] = explode('.', $body, 2);
+            }
+
+            // Trim leading zeros in the integer part but keep at least one
+            $int = ltrim($int, '0');
+            if ($int === '') {
+                $int = '0';
+            }
+
+            // If no fractional part → pad to 2 decimals
+            if ($frac === '') {
+                $out = ($neg && $int === '0') ? '0.00' : (($neg ? '-' : '') . $int . '.00');
+                $set($target, $out);
+                return;
+            }
+
+            // If 1 fractional digit → pad to 2
+            if (preg_match('/^\d$/', $frac)) {
+                $out = ($neg && $int === '0' && $frac === '0')
+                    ? '0.00'
+                    : (($neg ? '-' : '') . $int . '.' . $frac . '0');
+                $set($target, $out);
+                return;
+            }
+
+            // If exactly 2 fractional digits → keep as-is (normalize -0.00)
+            if (preg_match('/^\d{2}$/', $frac)) {
+                $out = ($neg ? '-' : '') . $int . '.' . $frac;
+                if ($out === '-0.00') $out = '0.00';
+                $set($target, $out);
+                return;
+            }
+
+            // More than 2 fractional digits:
+            // - If extras are all zeros, trim to 2 (e.g., 0.2500 → 0.25)
+            // - Else leave unchanged (validation should flag), and DO NOT round
+            if (strlen($frac) > 2) {
+                $first2 = substr($frac, 0, 2);
+                $extra  = substr($frac, 2);
+                if (preg_match('/^0+$/', $extra)) {
+                    $out = ($neg ? '-' : '') . $int . '.' . $first2;
+                    if ($out === '-0.00') $out = '0.00';
+                    $set($target, $out);
+                }
+                // else: non-zero beyond 2 decimals → do nothing (let validation show error)
+                return;
+            }
+        };
+    }
 
     /**
      * Get the Filament form schema for this element type.
      */
     public static function getFilamentSchema(bool $disabled = false): array
     {
+
+        $noSci = 'not_regex:/[eE]/'; // forbid scientific notation
+        $currencyRegex = 'regex:/^-?\d+(\.\d{1,2})?$/';
+
         return array_merge(
             SchemaHelper::getCommonCarbonFields($disabled),
             [
@@ -48,20 +132,68 @@ class CurrencyInputFormElement extends Model
                     ->schema([
                         SchemaHelper::getPlaceholderTextField($disabled)
                             ->columnSpan(3),
+
                         TextInput::make('elementable_data.defaultValue')
                             ->label('Default Value')
                             ->numeric()
+                            ->nullable()
                             ->step(.01)
+                            ->live(onBlur: true)
+                            ->afterStateUpdated(self::formatCurrency('elementable_data.defaultValue'))
+                            // Keep your base rules; add min/max comparisons only if present
+                            ->rules(function (Get $get) use ($currencyRegex, $noSci) {
+                                $rules = ['numeric', $currencyRegex, $noSci];
+
+                                if (filled($get('elementable_data.min'))) {
+                                    $rules[] = 'gte:elementable_data.min';
+                                }
+                                if (filled($get('elementable_data.max'))) {
+                                    $rules[] = 'lte:elementable_data.max';
+                                }
+
+                                return $rules;
+                            })
+                            ->columnSpan(1)
                             ->disabled($disabled),
+
                         TextInput::make('elementable_data.min')
                             ->label('Minimum Value')
                             ->numeric()
+                            ->nullable()
                             ->step(.01)
+                            ->live(onBlur: true)
+                            ->afterStateUpdated(self::formatCurrency('elementable_data.min'))
+                            ->rules(function (Get $get) use ($currencyRegex, $noSci) {
+                                $rules = ['numeric', $currencyRegex, $noSci];
+
+                                // Only enforce min <= max if max is provided
+                                if (filled($get('elementable_data.max'))) {
+                                    $rules[] = 'lte:elementable_data.max';
+                                }
+
+                                return $rules;
+                            })
+                            ->columnSpan(1)
                             ->disabled($disabled),
+
                         TextInput::make('elementable_data.max')
                             ->label('Maximum Value')
                             ->numeric()
+                            ->nullable()
                             ->step(.01)
+                            ->live(onBlur: true)
+                            ->afterStateUpdated(self::formatCurrency('elementable_data.max'))
+                            ->rules(function (Get $get) use ($currencyRegex, $noSci) {
+                                $rules = ['numeric', $currencyRegex, $noSci];
+
+                                // Only enforce max >= min if min is provided
+                                if (filled($get('elementable_data.min'))) {
+                                    $rules[] = 'gte:elementable_data.min';
+                                }
+
+                                return $rules;
+                            })
+                            ->columnSpan(1)
                             ->disabled($disabled),
                     ])
                     ->columns(3),

--- a/app/Models/FormBuilding/NumberInputFormElement.php
+++ b/app/Models/FormBuilding/NumberInputFormElement.php
@@ -7,9 +7,11 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Filament\Forms\Get;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\ToggleButtons;
+use Closure;
 
 class NumberInputFormElement extends Model
 {
@@ -42,10 +44,122 @@ class NumberInputFormElement extends Model
     ];
 
     /**
+     * Format the number input according to the selected mask type (integer or decimal)
+     */
+    protected static function formatNumberByMask(string $target): Closure
+    {
+        return function ($state, callable $set, Get $get) use ($target) {
+            if ($state === null) return;
+
+            $raw  = trim((string) $state);
+            $mask = strtolower((string) ($get('elementable_data.maskType') ?? 'integer')); // 'integer' | 'decimal'
+
+            // Do not "fix" scientific notation or thousands separators; let validation reject them.
+            if (preg_match('/[eE, ]/', $raw)) {
+                return;
+            }
+
+            // Treat "-", "-0", "-0.0", etc. as zero (both modes)
+            if ($raw === '-' || preg_match('/^-\s*0*(?:\.0*)?$/', $raw)) {
+                $set($target, '0');
+                return;
+            }
+
+            if ($mask === 'integer') {
+                // ---- INTEGER MODE (truncate; do not round), negatives allowed ----
+                // If it's not numeric at all, leave it for validation.
+                if (!is_numeric($raw)) return;
+
+                // Keep sign if present
+                $sign = ($raw !== '' && $raw[0] === '-') ? '-' : '';
+                $body = ltrim($raw, '-');
+
+                // Keep digits and dot; then take the integer part before any dot
+                $tmp = preg_replace('/[^0-9.]/', '', $body) ?? '';
+                $int = explode('.', $tmp, 2)[0] ?? '';
+                $int = preg_replace('/\D/', '', $int) ?? ''; // safety
+                $int = ltrim($int, '0');
+
+                // Empty integer part becomes 0
+                if ($int === '') $int = '0';
+
+                // Avoid "-0"
+                if ($int === '0') $sign = '';
+
+                $set($target, $sign . $int);
+                return;
+            }
+
+            // ---- DECIMAL MODE (no forced rounding), negatives allowed ----
+            // Normalize incomplete forms to zero-ish decimal
+            if (in_array($raw, ['.', '-.'], true)) {
+                $set($target, '0');
+                return;
+            }
+
+            // If not numeric at all, let validation handle it.
+            if (!is_numeric($raw)) return;
+
+            // Keep only one leading '-' and only the first '.'
+            $val = preg_replace('/[^\d.\-]/', '', $raw) ?? '';
+            $val = preg_replace('/(?!^)-/', '', $val) ?? '';     // remove extra '-' not at start
+            $val = preg_replace('/\.(?=.*\.)/', '', $val) ?? ''; // keep only first '.'
+
+            // If empty or just "-", normalize to 0
+            if ($val === '' || $val === '-') {
+                $set($target, '0');
+                return;
+            }
+
+            $sign = ($val[0] === '-') ? '-' : '';
+            $tmp  = ltrim($val, '-');
+
+            if (strpos($tmp, '.') !== false) {
+                [$int, $frac] = explode('.', $tmp, 2);
+
+                // sanitize integer and fractional parts
+                $int  = preg_replace('/\D/', '', $int) ?? '';
+                $frac = preg_replace('/\D/', '', $frac) ?? '';
+
+                // Normalize leading zeros in integer part
+                $int = ltrim($int, '0');
+                if ($int === '') $int = '0';
+
+                // Trim trailing zeros in fractional part; drop dot if empty
+                $frac = rtrim($frac, '0');
+
+                $normalized = $frac === ''
+                    ? $sign . $int
+                    : $sign . $int . '.' . $frac;
+            } else {
+                // No dot: integer-like in decimal context
+                $int = preg_replace('/\D/', '', $tmp) ?? '';
+                $int = ltrim($int, '0');
+                if ($int === '') $int = '0';
+                $normalized = $sign . $int;
+            }
+
+            // Normalize "-0"
+            if ($normalized === '-0') {
+                $normalized = '0';
+            }
+
+            $set($target, $normalized);
+        };
+    }
+
+    /**
      * Get the Filament form schema for this element type.
      */
     public static function getFilamentSchema(bool $disabled = false): array
     {
+
+        $isDecimal = fn(Get $get) => strtolower($get('elementable_data.maskType') ?? 'integer') === 'decimal';
+
+        $noSci = 'not_regex:/[eE]/';                       // forbid scientific notation
+        $plainDecimal = 'regex:/^-?\d+(\.\d+)?$/';         // allow optional leading '-', digits, and one dot
+
+
         return array_merge(
             SchemaHelper::getCommonCarbonFields($disabled),
             [
@@ -56,19 +170,66 @@ class NumberInputFormElement extends Model
                         TextInput::make('elementable_data.defaultValue')
                             ->label('Default Value')
                             ->numeric()
-                            ->step(fn ($get) => $get('elementable_data.step') ?? 1)
+                            ->nullable()
+                            ->step(fn(Get $get) => $get('elementable_data.step') ?? 1)
+                            ->live(onBlur: true)
+                            ->afterStateUpdated(self::formatNumberByMask('elementable_data.defaultValue'))
+                            ->rules(function (Get $get) use ($isDecimal, $noSci, $plainDecimal) {
+                                $rules = $isDecimal($get)
+                                    ? ['nullable', 'numeric', $noSci, $plainDecimal]
+                                    : ['nullable', 'integer'];
+
+                                if (filled($get('elementable_data.min'))) {
+                                    $rules[] = 'gte:elementable_data.min';
+                                }
+                                if (filled($get('elementable_data.max'))) {
+                                    $rules[] = 'lte:elementable_data.max';
+                                }
+
+                                return $rules;
+                            })
                             ->columnSpan(2)
                             ->disabled($disabled),
                         TextInput::make('elementable_data.min')
                             ->label('Minimum Value')
                             ->numeric()
-                            ->step(fn ($get) => $get('elementable_data.step') ?? 1)
+                            ->nullable()
+                            ->step(fn(Get $get) => $get('elementable_data.step') ?? 1)
+                            ->live(onBlur: true)
+                            ->afterStateUpdated(self::formatNumberByMask('elementable_data.min'))
+                            ->rules(function (Get $get) use ($isDecimal, $noSci, $plainDecimal) {
+                                $rules = $isDecimal($get)
+                                    ? ['nullable', 'numeric', $noSci, $plainDecimal]
+                                    : ['nullable', 'integer'];
+
+                                // Only require min <= max if max is provided
+                                if (filled($get('elementable_data.max'))) {
+                                    $rules[] = 'lte:elementable_data.max';
+                                }
+
+                                return $rules;
+                            })
                             ->columnSpan(2)
                             ->disabled($disabled),
                         TextInput::make('elementable_data.max')
                             ->label('Maximum Value')
                             ->numeric()
-                            ->step(fn ($get) => $get('elementable_data.step') ?? 1)
+                            ->nullable()
+                            ->step(fn(Get $get) => $get('elementable_data.step') ?? 1)
+                            ->live(onBlur: true)
+                            ->afterStateUpdated(self::formatNumberByMask('elementable_data.max'))
+                            ->rules(function (Get $get) use ($isDecimal, $noSci, $plainDecimal) {
+                                $rules = $isDecimal($get)
+                                    ? ['nullable', 'numeric', $noSci, $plainDecimal]
+                                    : ['nullable', 'integer'];
+
+                                // Only require max >= min if min is provided
+                                if (filled($get('elementable_data.min'))) {
+                                    $rules[] = 'gte:elementable_data.min';
+                                }
+
+                                return $rules;
+                            })
                             ->columnSpan(2)
                             ->disabled($disabled),
                         ToggleButtons::make('elementable_data.maskType')
@@ -80,24 +241,48 @@ class NumberInputFormElement extends Model
                             ->inline()
                             ->default('integer')
                             ->live()
-                            ->columnSpan(2)
-                            ->afterStateUpdated(function ($state, callable $set) {
-                                $stepValues = [
-                                    'integer' => 1,
-                                    'decimal' => 0.01,
-                                ];
-                                $set('elementable_data.step', $stepValues[$state] ?? 1);
+                            ->columnSpan(3)
+                            ->afterStateUpdated(function (string $state, callable $set, Get $get) {
+                                if ($state === 'integer') {
+                                    // Force step = 1 for integer mode
+                                    $set('elementable_data.step', 1);
+
+                                    // Coerce existing values to integers (if set)
+                                    foreach (['defaultValue', 'min', 'max'] as $key) {
+                                        $path = "elementable_data.$key";
+                                        $val = $get($path);
+                                        if (filled($val)) {
+                                            $set($path, (int) round((float) $val));
+                                        }
+                                    }
+                                } else {
+                                    // Decimal mode: keep or set a reasonable decimal step
+                                    $currentStep = $get('elementable_data.step');
+                                    $set('elementable_data.step', filled($currentStep) ? $currentStep : 0.01);
+                                }
                             }),
                         TextInput::make('elementable_data.step')
+                            ->required()
                             ->label('Step Size')
                             ->numeric()
                             ->default(1)
-                            ->minValue(0)
-                            ->live()
-                            ->columnSpan(4)
+                            ->live(onBlur: true)
+                            // Ensure UI "step" attribute makes sense (1 for integer; any step otherwise)
+                            ->step(fn(Get $get) => $isDecimal($get) ? null : 1)
+                            ->afterStateUpdated(self::formatNumberByMask('elementable_data.step'))
+                            // Validation: integer & >=1 in integer mode; numeric & >0 in decimal mode
+                            ->rule(fn(Get $get) => $isDecimal($get)
+                                ? [
+                                    'numeric',
+                                    'gt:0',
+                                    $noSci,
+                                    'regex:/^\d+(\.\d+)?$/',      // only digits and one dot
+                                ]
+                                : ['integer', 'min:1'])
+                            ->columnSpan(3)
                             ->disabled($disabled),
                     ])
-                    ->columns(3),
+                    ->columns(6),
             ]
         );
     }


### PR DESCRIPTION
## What changes did you make? 

Add formatting and validation to the number and currency input's fields

- Number Input
  - Validation
    - Default value, min value, max value, and step must be integers or decimals based on the selected mask type
      - Decimals should auto convert to integers (remove the decimals)
    - Max > min value and min < default < max if values are set
    - Ensure step is positive: step > 0 if decimal, step = min 1
  - Formatting
    - Do not allow scientific notation for numbers (no 'e' or 'E')
    - On blur: Auto add a 0 if no digit before the '.' (only if decimal) and remove extra leading and trailing 0s
- Currency Input
  - Validation
    - Default value, min value, and max value must be decimals with 2 decimals
    - Max > min value and min < default < max if values are set
  - Formatting
    - Do not allow scientific notation for numbers (no 'e' or 'E')
    - On blur: Auto add a 0 if no digit before the '.' (only if decimal), remove extra leading and trailing 0s (remove trailing 0s beyond 2 decimals), and pad with 0s to two decimals

## Why did you make these changes?

No formatting and constraint validations existed on the number and currency input's default value, min value, max value, and step (only for number inputs) fields. Therefore, improper values and constraints were allowed to be submitted, such as max < min, default value < min, number input's default value/min/max/step being decimals with an integer mask, and currency input's default value/min/max having more than 2 decimals (improper currency).

## What alternatives did you consider?

**Please review this and consider whether you’d like these additional behaviours implemented. They can be included as long as you’re comfortable with the associated caveats.** 

Input masking was originally considered to prevent invalid number entry, but this would make the input text rather than number inputs, which would ignore the input's step attribute and require manually adding the auto-masking and validation that come with number inputs. This is already handled by the input validations I added, so there is no need for the masking.

For the formatting of decimal numbers in a number input's fields when the mask is decimal and in a currency input's fields, I chose to keep the extra non-0 decimals instead of truncating/removing them (to 2 decimals for currency and the number of decimals in the step for decimal number) to let the user know they entered extra digits. This was mainly for cases where you accidentally pressed a neighbouring digit or held the number key a bit too long and ended up with an extra digit in the middle of the decimals, as truncating the decimals would allow the incorrect number to be accepted if you didn't pay attention to the final value (i.e. for currency, '0.995' would be truncated to '0.99' when you meant to type '0.95').

### Checklist

- [X] **I have assigned at least one reviewer**
- [X] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
