### PR TITLE
ADO-3788, ADO-3789 Form importer fix

### DIFF
--- a/app/Jobs/ImportFormVersionElementsJob.php
+++ b/app/Jobs/ImportFormVersionElementsJob.php
@@ -923,6 +923,7 @@ class ImportFormVersionElementsJob implements ShouldQueue
 
             if (isset($dataBinding['dataBindingPath'])) {
                 $dataBindingInfo = [
+                    'source' => $dataBinding['source'] ?? null,
                     'path' => $dataBinding['dataBindingPath'],
                     'type' => $dataBinding['dataBindingType'] ?? 'jsonpath'
                 ];
@@ -931,6 +932,7 @@ class ImportFormVersionElementsJob implements ShouldQueue
         // Format 2: direct dataBinding string (legacy support)
         elseif (isset($element['dataBinding']) && is_string($element['dataBinding'])) {
             $dataBindingInfo = [
+                'source' => $element['source'] ?? null, // Replace with actual field name
                 'path' => $element['dataBinding'],
                 'type' => 'jsonpath'
             ];
@@ -941,6 +943,7 @@ class ImportFormVersionElementsJob implements ShouldQueue
             $firstBinding = reset($element['dataBindings']);
             if ($firstBinding && isset($firstBinding['path'])) {
                 $dataBindingInfo = [
+                    'source' => $firstBinding['source'] ?? null,
                     'path' => $firstBinding['path'],
                     'type' => 'jsonpath'
                 ];
@@ -949,6 +952,7 @@ class ImportFormVersionElementsJob implements ShouldQueue
         // Format 4: binding_ref (alternative format)
         elseif (isset($element['binding_ref']) && is_string($element['binding_ref'])) {
             $dataBindingInfo = [
+                'source' => $element['source'] ?? null, // Replace with actual field name
                 'path' => $element['binding_ref'],
                 'type' => 'jsonpath'
             ];
@@ -958,6 +962,7 @@ class ImportFormVersionElementsJob implements ShouldQueue
             $first = reset($element['databindings']);
             if (is_array($first) && isset($first['path'])) {
                 $dataBindingInfo = [
+                    'source' => $first['source'] ?? null,
                     'path' => $first['path'],
                     'type' => $first['type'] ?? 'jsonpath',
                 ];
@@ -973,7 +978,10 @@ class ImportFormVersionElementsJob implements ShouldQueue
     private function createDataBinding($formElement, array $dataBindingInfo, $formVersion): void
     {
         try {
-            $formDataSource = $formVersion->formDataSources()->first();
+            $formDataSourceName = $dataBindingInfo['source'];
+            $formDataSource = $formVersion->formDataSources()
+                ->where('form_data_sources.name', $formDataSourceName)
+                ->first();
 
             if (!$formDataSource) {
                 $formDataSource = \App\Models\FormMetadata\FormDataSource::firstOrCreate([
@@ -990,6 +998,7 @@ class ImportFormVersionElementsJob implements ShouldQueue
 
                 $formVersion->formDataSources()->attach($formDataSource->id, ['order' => 1]);
             }
+
             \App\Models\FormBuilding\FormElementDataBinding::create([
                 'form_element_id' => $formElement->id,
                 'form_data_source_id' => $formDataSource->id,

--- a/app/Jobs/ImportFormVersionElementsJob.php
+++ b/app/Jobs/ImportFormVersionElementsJob.php
@@ -8,12 +8,15 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Foundation\Bus\Dispatchable;
 use App\Models\FormBuilding\FormElement;
 use App\Events\FormVersionUpdateEvent;
+use App\Models\FormBuilding\FormElementDataBinding;
 use App\Models\FormBuilding\FormScript;
 use App\Models\FormBuilding\StyleSheet;
+use App\Models\FormMetadata\FormDataSource;
 
 class ImportFormVersionElementsJob implements ShouldQueue
 {
@@ -978,36 +981,41 @@ class ImportFormVersionElementsJob implements ShouldQueue
     private function createDataBinding($formElement, array $dataBindingInfo, $formVersion): void
     {
         try {
-            $formDataSourceName = $dataBindingInfo['source'];
+            DB::transaction(function () use ($formElement, $dataBindingInfo, $formVersion) {
+                $formDataSourceName = $dataBindingInfo['source'];
+
             $formDataSource = $formVersion->formDataSources()
                 ->where('form_data_sources.name', $formDataSourceName)
                 ->first();
 
             if (!$formDataSource) {
-                $formDataSource = \App\Models\FormMetadata\FormDataSource::firstOrCreate([
-                    'name' => 'Imported Data Source',
-                    'type' => 'json',
-                ], [
-                    'description' => 'Auto-created data source for imported form elements',
-                    'endpoint' => null,
-                    'params' => null,
-                    'body' => null,
-                    'headers' => null,
-                    'host' => null,
-                ]);
+                    $defaultDataSource = 'Imported Data Source';
 
-                $formVersion->formDataSources()->attach($formDataSource->id, ['order' => 1]);
+                    $formDataSource = FormDataSource::firstOrCreate([
+                            'name' => $defaultDataSource,
+                        'type' => 'json',
+                    ], [
+                        'description' => 'Auto-created data source for imported form elements',
+                        'endpoint' => null,
+                        'params' => null,
+                        'body' => null,
+                        'headers' => null,
+                        'host' => null,
+                    ]);
+
+                    $formVersion->formDataSources()->syncWithoutDetaching($formDataSource->id, ['order' => 1]);
             }
 
-            \App\Models\FormBuilding\FormElementDataBinding::create([
+                FormElementDataBinding::updateOrCreate([
                 'form_element_id' => $formElement->id,
                 'form_data_source_id' => $formDataSource->id,
                 'path' => $dataBindingInfo['path'],
                 'condition' => $dataBindingInfo['condition'] ?? null,
                 'order' => 1,
             ]);
+            });
         } catch (\Exception $e) {
-            Log::warning('Failed to create data binding for imported element', [
+            Log::error('Failed to create data binding for imported element.', [
                 'element_id' => $formElement->id,
                 'data_binding_info' => $dataBindingInfo,
                 'error' => $e->getMessage()

--- a/app/Jobs/ImportFormVersionElementsJob.php
+++ b/app/Jobs/ImportFormVersionElementsJob.php
@@ -18,6 +18,8 @@ use App\Models\FormBuilding\FormScript;
 use App\Models\FormBuilding\StyleSheet;
 use App\Models\FormMetadata\FormDataSource;
 
+use Filament\Notifications\Notification;
+
 class ImportFormVersionElementsJob implements ShouldQueue
 {
     use Dispatchable;
@@ -29,6 +31,8 @@ class ImportFormVersionElementsJob implements ShouldQueue
     protected $schemaContent;
     protected $cacheKey;
     protected $userId;
+
+    private $defaultDataSourceError = false;
 
     public function __construct($formVersionId, $schemaContent, $cacheKey, $userId)
     {
@@ -910,6 +914,14 @@ class ImportFormVersionElementsJob implements ShouldQueue
             }
         }
 
+        if ($this->defaultDataSourceError) {
+            Notification::make()
+                ->title("Failed to create the default data source 'Imported Data Source'")
+                ->body("Please reseed the form_data_sources table using the following command: sail artisan db:seed --class=FormDataSourceSeeder")
+                ->warning()
+                ->send();
+        }
+
         return $processedElements;
     }
 
@@ -991,6 +1003,8 @@ class ImportFormVersionElementsJob implements ShouldQueue
             if (!$formDataSource) {
                     $defaultDataSource = 'Imported Data Source';
 
+                    // Specific catch for creating the default data source
+                    try {
                     $formDataSource = FormDataSource::firstOrCreate([
                             'name' => $defaultDataSource,
                         'type' => 'json',
@@ -1002,6 +1016,17 @@ class ImportFormVersionElementsJob implements ShouldQueue
                         'headers' => null,
                         'host' => null,
                     ]);
+                    } catch (\Exception $e) {
+                        Log::warning('Failed to create the default data source "{source}". Please reseed the form_data_sources table'
+                            . ' using the following command: sail artisan db:seed --class=FormDataSourceSeeder', [
+                            'source' => $defaultDataSource,
+                            'error' => $e->getMessage(),
+                        ]);
+
+                        $this->defaultDataSourceError = true;
+
+                        throw $e; // ensure transaction rolls back
+                    }
 
                     $formVersion->formDataSources()->syncWithoutDetaching($formDataSource->id, ['order' => 1]);
             }
@@ -1015,7 +1040,7 @@ class ImportFormVersionElementsJob implements ShouldQueue
             ]);
             });
         } catch (\Exception $e) {
-            Log::error('Failed to create data binding for imported element.', [
+            Log::warning('Failed to create data binding for imported element.', [
                 'element_id' => $formElement->id,
                 'data_binding_info' => $dataBindingInfo,
                 'error' => $e->getMessage()

--- a/app/Jobs/ImportFormVersionElementsJob.php
+++ b/app/Jobs/ImportFormVersionElementsJob.php
@@ -819,49 +819,49 @@ class ImportFormVersionElementsJob implements ShouldQueue
                 $formElement = null;
 
                 if ($type === \App\Models\FormBuilding\ContainerFormElement::class) {
-                    $containerModel = \App\Models\FormBuilding\ContainerFormElement::create($attributes['attributes']);
+                    $containerModel = \App\Models\FormBuilding\ContainerFormElement::updateOrCreate($attributes['attributes']);
                     $elementData['elementable_id'] = $containerModel->id;
                     $formElement = FormElement::create($elementData);
                 } else if ($type === \App\Models\FormBuilding\TextInputFormElement::class) {
-                    $textInputModel = \App\Models\FormBuilding\TextInputFormElement::create($attributes['attributes']);
+                    $textInputModel = \App\Models\FormBuilding\TextInputFormElement::updateOrCreate($attributes['attributes']);
                     $elementData['elementable_id'] = $textInputModel->id;
                     $formElement = FormElement::create($elementData);
                 } else if ($type === \App\Models\FormBuilding\TextareaInputFormElement::class) {
-                    $textareModel = \App\Models\FormBuilding\TextareaInputFormElement::create($attributes['attributes']);
+                    $textareModel = \App\Models\FormBuilding\TextareaInputFormElement::updateOrCreate($attributes['attributes']);
                     $elementData['elementable_id'] = $textareModel->id;
                     $formElement = FormElement::create($elementData);
                 } elseif ($type === \App\Models\FormBuilding\TextInfoFormElement::class) {
-                    $textInfoModel = \App\Models\FormBuilding\TextInfoFormElement::create($attributes['attributes']);
+                    $textInfoModel = \App\Models\FormBuilding\TextInfoFormElement::updateOrCreate($attributes['attributes']);
                     $elementData['elementable_id'] = $textInfoModel->id;
                     $formElement = FormElement::create($elementData);
                 } else if ($type === \App\Models\FormBuilding\DateSelectInputFormElement::class) {
-                    $dateSelectModel = \App\Models\FormBuilding\DateSelectInputFormElement::create($attributes['attributes']);
+                    $dateSelectModel = \App\Models\FormBuilding\DateSelectInputFormElement::updateOrCreate($attributes['attributes']);
                     $elementData['elementable_id'] = $dateSelectModel->id;
                     $formElement = FormElement::create($elementData);
                 } else if ($type === \App\Models\FormBuilding\CheckboxInputFormElement::class) {
-                    $checkboxInputModel = \App\Models\FormBuilding\CheckboxInputFormElement::create($attributes['attributes']);
+                    $checkboxInputModel = \App\Models\FormBuilding\CheckboxInputFormElement::updateOrCreate($attributes['attributes']);
                     $elementData['elementable_id'] = $checkboxInputModel->id;
                     $formElement = FormElement::create($elementData);
                 } else if ($type === \App\Models\FormBuilding\SelectInputFormElement::class) {
-                    $selectModel = \App\Models\FormBuilding\SelectInputFormElement::create($attributes['attributes']);
+                    $selectModel = \App\Models\FormBuilding\SelectInputFormElement::updateOrCreate($attributes['attributes']);
                     $elementData['elementable_id'] = $selectModel->id;
                     $formElement = FormElement::create($elementData);
                     $this->createSelectOptions($selectModel, $options);
                 } elseif ($type === \App\Models\FormBuilding\RadioInputFormElement::class) {
-                    $radioModel = \App\Models\FormBuilding\RadioInputFormElement::create($attributes['attributes']);
+                    $radioModel = \App\Models\FormBuilding\RadioInputFormElement::updateOrCreate($attributes['attributes']);
                     $elementData['elementable_id'] = $radioModel->id;
                     $formElement = FormElement::create($elementData);
                     $this->createRadioOptions($radioModel, $options);
                 } else if ($type === \App\Models\FormBuilding\NumberInputFormElement::class) {
-                    $numberInputModel = \App\Models\FormBuilding\NumberInputFormElement::create($attributes['attributes']);
+                    $numberInputModel = \App\Models\FormBuilding\NumberInputFormElement::updateOrCreate($attributes['attributes']);
                     $elementData['elementable_id'] = $numberInputModel->id;
                     $formElement = FormElement::create($elementData);
                 } else if ($type === \App\Models\FormBuilding\ButtonInputFormElement::class) {
-                    $buttonModel = \App\Models\FormBuilding\ButtonInputFormElement::create($attributes['attributes']);
+                    $buttonModel = \App\Models\FormBuilding\ButtonInputFormElement::updateOrCreate($attributes['attributes']);
                     $elementData['elementable_id'] = $buttonModel->id;
                     $formElement = FormElement::create($elementData);
                 } else if ($type === \App\Models\FormBuilding\HTMLFormElement::class) {
-                    $htmlModel = \App\Models\FormBuilding\HTMLFormElement::create($attributes['attributes']);
+                    $htmlModel = \App\Models\FormBuilding\HTMLFormElement::updateOrCreate($attributes['attributes']);
                     $elementData['elementable_id'] = $htmlModel->id;
                     $formElement = FormElement::create($elementData);
                 } else {

--- a/app/Jobs/ImportFormVersionElementsJob.php
+++ b/app/Jobs/ImportFormVersionElementsJob.php
@@ -797,6 +797,8 @@ class ImportFormVersionElementsJob implements ShouldQueue
                     'help_text' => $attributes['help_text'] ?? '',
                     'is_read_only' => $attributes['is_read_only'] ? true : false,
                     'custom_read_only' => $attributes['is_read_only'] ? true : false,
+                    'visible_web' => $attributes['visible_web'] ?? true,
+                    'visible_pdf' => $attributes['visible_pdf'] ?? true,
                     'is_required' => $attributes['is_required'] ?? false,
                     'save_on_submit' => $attributes['save_on_submit'] ?? true,
                 ];
@@ -806,14 +808,6 @@ class ImportFormVersionElementsJob implements ShouldQueue
                     'imported' => true,
                     'import_source' => 'template',
                 ];
-
-                $elementData['visible_pdf'] = !(
-                    isset($element['pdfStyles']['display']) && $element['pdfStyles']['display'] === 'none'
-                );
-
-                $elementData['visible_web'] = !(
-                    isset($element['webStyles']['display']) && $element['webStyles']['display'] === 'none'
-                );
 
                 $formElement = null;
 

--- a/app/Jobs/ImportFormVersionElementsJob.php
+++ b/app/Jobs/ImportFormVersionElementsJob.php
@@ -704,10 +704,14 @@ class ImportFormVersionElementsJob implements ShouldQueue
                         'select-input' => \App\Models\FormBuilding\SelectInputFormElement::class,
                         'checkbox' => \App\Models\FormBuilding\CheckboxInputFormElement::class,
                         'checkbox-input' => \App\Models\FormBuilding\CheckboxInputFormElement::class,
+                        'checkbox-group' => \App\Models\FormBuilding\CheckboxGroupFormElement::class,
+                        'checkbox-group-input' => \App\Models\FormBuilding\CheckboxGroupFormElement::class,
                         'date' => \App\Models\FormBuilding\DateSelectInputFormElement::class,
                         'date-select-input' => \App\Models\FormBuilding\DateSelectInputFormElement::class,
                         'number' => \App\Models\FormBuilding\NumberInputFormElement::class,
                         'number-input' => \App\Models\FormBuilding\NumberInputFormElement::class,
+                        'currency' => \App\Models\FormBuilding\CurrencyInputFormElement::class,
+                        'currency-input' => \App\Models\FormBuilding\CurrencyInputFormElement::class,
                         'html' => \App\Models\FormBuilding\HTMLFormElement::class,
                         'text-info' => \App\Models\FormBuilding\TextInfoFormElement::class,
                         'button' => \App\Models\FormBuilding\ButtonInputFormElement::class,
@@ -842,6 +846,10 @@ class ImportFormVersionElementsJob implements ShouldQueue
                     $checkboxInputModel = \App\Models\FormBuilding\CheckboxInputFormElement::updateOrCreate($attributes['attributes']);
                     $elementData['elementable_id'] = $checkboxInputModel->id;
                     $formElement = FormElement::create($elementData);
+                } else if ($type === \App\Models\FormBuilding\CheckboxGroupFormElement::class) {
+                    $checkboxGroupModel = \App\Models\FormBuilding\CheckboxGroupFormElement::updateOrCreate($attributes['attributes']);
+                    $elementData['elementable_id'] = $checkboxGroupModel->id;
+                    $formElement = FormElement::create($elementData);
                 } else if ($type === \App\Models\FormBuilding\SelectInputFormElement::class) {
                     $selectModel = \App\Models\FormBuilding\SelectInputFormElement::updateOrCreate($attributes['attributes']);
                     $elementData['elementable_id'] = $selectModel->id;
@@ -855,6 +863,10 @@ class ImportFormVersionElementsJob implements ShouldQueue
                 } else if ($type === \App\Models\FormBuilding\NumberInputFormElement::class) {
                     $numberInputModel = \App\Models\FormBuilding\NumberInputFormElement::updateOrCreate($attributes['attributes']);
                     $elementData['elementable_id'] = $numberInputModel->id;
+                    $formElement = FormElement::create($elementData);
+                } else if ($type === \App\Models\FormBuilding\CurrencyInputFormElement::class) {
+                    $currencyInputModel = \App\Models\FormBuilding\CurrencyInputFormElement::updateOrCreate($attributes['attributes']);
+                    $elementData['elementable_id'] = $currencyInputModel->id;
                     $formElement = FormElement::create($elementData);
                 } else if ($type === \App\Models\FormBuilding\ButtonInputFormElement::class) {
                     $buttonModel = \App\Models\FormBuilding\ButtonInputFormElement::updateOrCreate($attributes['attributes']);
@@ -996,26 +1008,26 @@ class ImportFormVersionElementsJob implements ShouldQueue
             DB::transaction(function () use ($formElement, $dataBindingInfo, $formVersion) {
                 $formDataSourceName = $dataBindingInfo['source'];
 
-            $formDataSource = $formVersion->formDataSources()
-                ->where('form_data_sources.name', $formDataSourceName)
-                ->first();
+                $formDataSource = $formVersion->formDataSources()
+                    ->where('form_data_sources.name', $formDataSourceName)
+                    ->first();
 
-            if (!$formDataSource) {
+                if (!$formDataSource) {
                     $defaultDataSource = 'Imported Data Source';
 
                     // Specific catch for creating the default data source
                     try {
-                    $formDataSource = FormDataSource::firstOrCreate([
+                        $formDataSource = FormDataSource::firstOrCreate([
                             'name' => $defaultDataSource,
-                        'type' => 'json',
-                    ], [
-                        'description' => 'Auto-created data source for imported form elements',
-                        'endpoint' => null,
-                        'params' => null,
-                        'body' => null,
-                        'headers' => null,
-                        'host' => null,
-                    ]);
+                            'type' => 'json',
+                        ], [
+                            'description' => 'Auto-created data source for imported form elements',
+                            'endpoint' => null,
+                            'params' => null,
+                            'body' => null,
+                            'headers' => null,
+                            'host' => null,
+                        ]);
                     } catch (\Exception $e) {
                         Log::warning('Failed to create the default data source "{source}". Please reseed the form_data_sources table'
                             . ' using the following command: sail artisan db:seed --class=FormDataSourceSeeder', [
@@ -1029,15 +1041,15 @@ class ImportFormVersionElementsJob implements ShouldQueue
                     }
 
                     $formVersion->formDataSources()->syncWithoutDetaching($formDataSource->id, ['order' => 1]);
-            }
+                }
 
                 FormElementDataBinding::updateOrCreate([
-                'form_element_id' => $formElement->id,
-                'form_data_source_id' => $formDataSource->id,
-                'path' => $dataBindingInfo['path'],
-                'condition' => $dataBindingInfo['condition'] ?? null,
-                'order' => 1,
-            ]);
+                    'form_element_id' => $formElement->id,
+                    'form_data_source_id' => $formDataSource->id,
+                    'path' => $dataBindingInfo['path'],
+                    'condition' => $dataBindingInfo['condition'] ?? null,
+                    'order' => 1,
+                ]);
             });
         } catch (\Exception $e) {
             Log::warning('Failed to create data binding for imported element.', [
@@ -1056,9 +1068,11 @@ class ImportFormVersionElementsJob implements ShouldQueue
             'TextInfoFormElements' => \App\Models\FormBuilding\TextInfoFormElement::class,
             'DateSelectInputFormElements' => \App\Models\FormBuilding\DateSelectInputFormElement::class,
             'CheckboxInputFormElements' => \App\Models\FormBuilding\CheckboxInputFormElement::class,
+            'CheckboxGroupFormElements' => \App\Models\FormBuilding\CheckboxGroupFormElement::class,
             'SelectInputFormElements' => \App\Models\FormBuilding\SelectInputFormElement::class,
             'RadioInputFormElements' => \App\Models\FormBuilding\RadioInputFormElement::class,
             'NumberInputFormElements' => \App\Models\FormBuilding\NumberInputFormElement::class,
+            'CurrencyInputFormElements' => \App\Models\FormBuilding\CurrencyInputFormElement::class,
             'ButtonInputFormElements' => \App\Models\FormBuilding\ButtonInputFormElement::class,
             'HTMLFormElements' => \App\Models\FormBuilding\HTMLFormElement::class,
             'ContainerFormElements' => \App\Models\FormBuilding\ContainerFormElement::class,

--- a/database/seeders/FormDataSourceSeeder.php
+++ b/database/seeders/FormDataSourceSeeder.php
@@ -4,6 +4,8 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
 
 class FormDataSourceSeeder extends Seeder
 {
@@ -13,10 +15,10 @@ class FormDataSourceSeeder extends Seeder
      */
     public function run()
     {
-        \DB::table('form_data_sources')->delete();
+        DB::table('form_data_sources')->delete();
 
-        \DB::table('form_data_sources')->insert(array (
-            0 => 
+        DB::table('form_data_sources')->insert(array(
+            0 =>
             array(
                 'id' => 1,
                 'name' => 'Case',
@@ -27,7 +29,7 @@ class FormDataSourceSeeder extends Seeder
                 'headers' => '{"Authorization":"Bearer @@token@@"}',
                 'host' => 'SIEBEL_ICM_API_HOST',
             ),
-            1 => 
+            1 =>
             array(
                 'id' => 2,
                 'name' => 'Contact',
@@ -38,7 +40,7 @@ class FormDataSourceSeeder extends Seeder
                 'headers' => '{"Authorization":"Bearer @@token@@"}',
                 'host' => 'SIEBEL_ICM_API_HOST',
             ),
-            2 => 
+            2 =>
             array(
                 'id' => 3,
                 'name' => 'Service Request',
@@ -49,7 +51,7 @@ class FormDataSourceSeeder extends Seeder
                 'headers' => '{"Authorization":"Bearer @@token@@"}',
                 'host' => 'SIEBEL_ICM_API_HOST',
             ),
-            3 => 
+            3 =>
             array(
                 'id' => 4,
                 'name' => 'Benefit Plan',
@@ -60,7 +62,7 @@ class FormDataSourceSeeder extends Seeder
                 'headers' => '{"Authorization":"Bearer @@token@@"}',
                 'host' => 'SIEBEL_ICM_API_HOST',
             ),
-            4 => 
+            4 =>
             array(
                 'id' => 5,
                 'name' => 'Case Review',
@@ -71,7 +73,7 @@ class FormDataSourceSeeder extends Seeder
                 'headers' => '{"Authorization":"Bearer @@token@@"}',
                 'host' => 'SIEBEL_ICM_API_HOST',
             ),
-            5 => 
+            5 =>
             array(
                 'id' => 6,
                 'name' => 'Incident',
@@ -82,7 +84,7 @@ class FormDataSourceSeeder extends Seeder
                 'headers' => '{"Authorization":"Bearer @@token@@"}',
                 'host' => 'SIEBEL_ICM_API_HOST',
             ),
-            6 => 
+            6 =>
             array(
                 'id' => 7,
                 'name' => 'Service Order',
@@ -93,7 +95,7 @@ class FormDataSourceSeeder extends Seeder
                 'headers' => '{"Authorization":"Bearer @@token@@"}',
                 'host' => 'SIEBEL_ICM_API_HOST',
             ),
-            7 => 
+            7 =>
             array(
                 'id' => 8,
                 'name' => 'Service Plan',
@@ -104,7 +106,7 @@ class FormDataSourceSeeder extends Seeder
                 'headers' => '{"Authorization":"Bearer @@token@@"}',
                 'host' => 'SIEBEL_ICM_API_HOST',
             ),
-            8 => 
+            8 =>
             array(
                 'id' => 9,
                 'name' => 'Service Provider',
@@ -115,7 +117,7 @@ class FormDataSourceSeeder extends Seeder
                 'headers' => '{"Authorization":"Bearer @@token@@"}',
                 'host' => 'SIEBEL_ICM_API_HOST',
             ),
-            9 => 
+            9 =>
             array(
                 'id' => 10,
                 'name' => 'Transacation Summary',
@@ -127,5 +129,14 @@ class FormDataSourceSeeder extends Seeder
                 'host' => 'SIEBEL_ICM_API_HOST',
             ),
         ));
+
+        // Reset the ID sequence to avoid conflicts with future inserts
+        DB::statement("
+            SELECT setval(
+                pg_get_serial_sequence('form_data_sources', 'id'),
+                COALESCE((SELECT MAX(id) FROM form_data_sources), 0) + 1,
+                false
+            )
+        ");
     }
 }


### PR DESCRIPTION
## What changes did you make? 

Form importer fixes:
- Fix visibility toggles being reset to true on import
- Fix imported data bindings using the first source attached to the form version instead of their actual source
- Fix default fallback "Imported Data Source" not initially being created on fresh installs when an imported source does not exist
  - Make the `FormDataSourceSeeder` also reset the `form_data_sources` table's ID counter when seeding the table to the next available ID after inserting the initial records
  - Add a warning log message and Klamm notification when "Imported Data Source" creation fails
- Update existing form elements during reimport so that data bindings that failed initially can be added
- Add checkbox groups and currency inputs to the importer

## Why did you make these changes?

These fixes fix the following bugs:

- Visibility toggles resetting to true on import
  - The visibility toggles weren't using the imported value to determine their value
- Imported data bindings using the first listed source instead of their actual source
  - The importer was not using the imported data binding sources and was instead setting each data binding's source to the first source attached to the form version
- Default fallback "Imported Data Source" not initially being created on fresh installs
  - The `form_data_sources` table's ID counter wasn’t being updated after the initial records were inserted, so it remained at 1
  - This caused repeated duplicate‑key errors whenever the importer tried to create the default fallback “Imported Data Source,” and the issue persisted until the counter was either auto‑incremented to or manually set to the next valid ID
  - This can now be automatically done without needing to manually run the ID reset SQL query on the `form_data_sources` table by reseeding the table using the following command: `sail artisan db:seed --class=FormDataSourceSeeder`
- Update existing form elements during reimport
  - The importer was skipping elements that shared the same UUID as existing elements from the first import, which prevented reimports from adding data bindings that failed during the initial import
  - This only updates the elements and does not restore soft-deleted elements
  - This change also fixes part of ADO-3790, where reimports did not restore existing elements to match the state in the import file 

## What alternatives did you consider?

None

### Checklist

- [X] **I have assigned at least one reviewer**
- [X] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
