### PR TITLE
ADO-3781 Fix number and currency input's field constraint validations

### DIFF
--- a/app/Filament/Forms/Helpers/NumericRules.php
+++ b/app/Filament/Forms/Helpers/NumericRules.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Filament\Forms\Helpers;
+
+
+use Closure;
+use Filament\Forms\Get;
+
+class NumericRules
+{
+    /**
+     * Returns a Filament closure rule that compares the current numeric field
+     * against optional min/max fields in the form state. Works robustly with Livewire partial
+     * validation (on blur) because it reads sibling values from $get (form state).
+     *
+     * @param  string|null  $minPath   Dot-notated path to the min field (e.g., 'elementable_data.min') or null to skip.
+     * @param  string|null  $maxPath   Dot-notated path to the max field (e.g., 'elementable_data.max') or null to skip.
+     * @param  array{
+     *     // Custom messages; you can localize or pass trans() here:
+     *     msgLessThanMin?: string,  // message when current < min
+     *     msgGreaterThanMax?: string, // message when current > max
+     * } $options
+     *
+     * @return Closure(Get): Closure(string, mixed, Closure): void
+     */
+
+    public static function compareWith(?string $minPath, ?string $maxPath, array $options = []): Closure
+    {
+        $defaults = [
+            // When both min & max are present and the value is out of range:
+            'msgBetween' => __('The :attribute must be between :min and :max.'),
+
+            // When only min is present (or you want distinct messages regardless):
+            'msgLessThanMin' => __('The :attribute must be greater than or equal to the minimum value :min.'),
+
+            // When only max is present (or you want distinct messages regardless):
+            'msgGreaterThanMax' => __('The :attribute must be less than or equal to the maximum value :max.'),
+
+            // Optional number formatting for messages (e.g., show 2 decimals).
+            // Signature: fn(float $n): string
+            'format' => null, // e.g., fn (float $n) => number_format($n, 2, '.', '')
+        ];
+        $opts = array_replace($defaults, $options);
+
+        $fmt = $opts['format'] instanceof Closure
+            ? $opts['format']
+            : (function (float $n): string {
+                return (string) $n;
+            });
+
+        return function (Get $get) use ($minPath, $maxPath, $opts, $fmt) {
+            return function (string $attribute, $value, Closure $fail) use ($get, $minPath, $maxPath, $opts, $fmt) {
+                if ($value === null || $value === '') {
+                    // Let 'nullable' / 'required' handle empties; nothing to compare.
+                    return;
+                }
+
+                $current = (float) $value;
+
+                // Pull sibling values (if any)
+                $minRaw = $minPath ? $get($minPath) : null;
+                $maxRaw = $maxPath ? $get($maxPath) : null;
+
+                $hasMin = ($minRaw !== null && $minRaw !== '');
+                $hasMax = ($maxRaw !== null && $maxRaw !== '');
+
+                // If both min and max exist, do a single between check.
+                if ($hasMin && $hasMax) {
+                    $min = (float) $minRaw;
+                    $max = (float) $maxRaw;
+
+                    // Optionally normalize order if min > max (defensive)
+                    if ($min > $max) {
+                        [$min, $max] = [$max, $min];
+                    }
+
+                    $inRange = ($current >= $min && $current <= $max);
+
+                    if (! $inRange) {
+                        $message = $opts['msgBetween'];
+
+                        // Replace placeholders with formatted values (if present in the string)
+                        $message = strtr($message, [
+                            ':min' => $fmt($min),
+                            ':max' => $fmt($max),
+                        ]);
+
+                        $fail($message);
+                    }
+
+                    return; // We’re done—single combined message for the between check.
+                }
+
+                // If only min exists → check lower bound
+                if ($hasMin) {
+                    $min = (float) $minRaw;
+
+                    $ok = ($current >= $min);
+                    if (! $ok) {
+                        $message = $opts['msgLessThanMin'];
+                        // If you want to show the concrete min value, support :min here too:
+                        $message = strtr($message, [
+                            ':min' => $fmt($min),
+                        ]);
+                        $fail($message);
+                        return;
+                    }
+                }
+
+                // If only max exists → check upper bound
+                if ($hasMax) {
+                    $max = (float) $maxRaw;
+
+                    $ok = ($current <= $max);
+                    if (! $ok) {
+                        $message = $opts['msgGreaterThanMax'];
+                        // If you want to show the concrete max value, support :max here too:
+                        $message = strtr($message, [
+                            ':max' => $fmt($max),
+                        ]);
+                        $fail($message);
+                        return;
+                    }
+                }
+            };
+        };
+    }
+}

--- a/app/Models/FormBuilding/CurrencyInputFormElement.php
+++ b/app/Models/FormBuilding/CurrencyInputFormElement.php
@@ -2,14 +2,15 @@
 
 namespace App\Models\FormBuilding;
 
+use App\Filament\Forms\Helpers\NumericRules;
 use App\Helpers\SchemaHelper;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
-use Filament\Forms\Get;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\TextInput;
+
 use Closure;
 
 class CurrencyInputFormElement extends Model
@@ -36,83 +37,100 @@ class CurrencyInputFormElement extends Model
     protected $attributes = [
         'hideLabel' => false,
     ];
+
     /*
      * Format the value as currency
     */
-    protected static function formatCurrency(string $target): \Closure
+    protected static function formatCurrency(string $target): Closure
     {
-        return function ($state, callable $set) use ($target) {
+        return function ($state, callable $set) use ($target): void {
             if ($state === null) return;
 
             $raw = trim((string) $state);
 
-            // Normalize incomplete forms to 0.00
-            if (in_array($raw, ['-', '.', '-.'], true)) {
+            // Reject sci-notation, commas, or spaces (let validation show error)
+            if (preg_match('/[eE, ]/', $raw)) {
+                return;
+            }
+
+            // Collapse lone sign/dot or all-zero forms to "0.00"
+            $isZeroish = static function (string $s): bool {
+                $s = trim($s);
+                if ($s === '') return false;
+
+                // remove leading sign
+                $s = ltrim($s, "+-");
+
+                // empty after sign or just a dot -> zero-ish
+                if ($s === '' || $s === '.') return true;
+
+                // keep only digits and a single dot
+                $clean = preg_replace('/[^\d.]/', '', $s) ?? '';
+                if ($clean === '' || substr_count($clean, '.') > 1) return false;
+
+                // if all remaining digits are zeros, it's zero-ish
+                $digitsOnly = str_replace('.', '', $clean);
+                return $digitsOnly !== '' && preg_match('/^0+$/', $digitsOnly) === 1;
+            };
+
+            if ($isZeroish($raw)) {
                 $set($target, '0.00');
                 return;
             }
 
-            // Only allow plain decimals: optional leading '-', digits, optional single dot, digits
-            // (Rejects scientific notation, commas, spaces, letters, etc.)
-            if (!preg_match('/^-?\d*\.?\d*$/', $raw)) {
-                return; // let validation flag invalid format
+            // Shape check: optional sign, digits, optional single dot and digits
+            // (allows ".5", "5.", "-.5", etc.)
+            if (!preg_match('/^[+-]?\d*(?:\.\d*)?$/', $raw)) {
+                // Not a plain numeric string -> leave it; validation will flag it.
+                return;
             }
 
-            // Separate sign and body
-            $neg = str_starts_with($raw, '-');
-            $body = ltrim($raw, '-');
+            // Extract sign once; operate on a signless body
+            $neg  = ($raw !== '' && $raw[0] === '-');
+            $body = ltrim($raw, '+-');
 
-            // Split into integer and fractional parts
-            $int = $body;
+            // Split into integer + fractional segments
+            $int  = $body;
             $frac = '';
             if (strpos($body, '.') !== false) {
                 [$int, $frac] = explode('.', $body, 2);
             }
 
-            // Trim leading zeros in the integer part but keep at least one
+            // Normalize integer: strip extra leading zeros, keep at least one '0'
             $int = ltrim($int, '0');
-            if ($int === '') {
-                $int = '0';
-            }
+            if ($int === '') $int = '0';
 
-            // If no fractional part → pad to 2 decimals
+            // Fraction handling:
+            // - If <= 2 digits: pad to exactly 2
+            // - If > 2 digits: leave as-is (no rounding/trimming)
             if ($frac === '') {
-                $out = ($neg && $int === '0') ? '0.00' : (($neg ? '-' : '') . $int . '.00');
-                $set($target, $out);
-                return;
+                $frac = '00';
+            } else {
+                $len = strlen($frac);
+                if ($len === 1) {
+                    $frac = str_pad($frac, 2, '0'); // '5' -> '50'
+                } elseif ($len >= 3) {
+                    // leave as-is
+                } // len == 2 -> keep as-is
             }
 
-            // If 1 fractional digit → pad to 2
-            if (preg_match('/^\d$/', $frac)) {
-                $out = ($neg && $int === '0' && $frac === '0')
-                    ? '0.00'
-                    : (($neg ? '-' : '') . $int . '.' . $frac . '0');
-                $set($target, $out);
-                return;
+            // Final negative-zero normalization:
+            // If magnitude is exactly zero (int == '0' and fraction all zeros),
+            // drop the negative sign.
+            $isZeroMagnitude = ($int === '0') && preg_match('/^0+$/', $frac) === 1;
+            $prefix = ($neg && !$isZeroMagnitude) ? '-' : '';
+
+            // Build output
+            // - For <= 2 original fraction, it's exactly 2 now.
+            // - For > 2, it's unchanged as typed.
+            $out = $int . '.' . $frac;
+
+            // Ensure canonical "0.00" for true zero when <= 2 frac
+            if ($isZeroMagnitude && strlen($frac) <= 2) {
+                $out = '0.00';
             }
 
-            // If exactly 2 fractional digits → keep as-is (normalize -0.00)
-            if (preg_match('/^\d{2}$/', $frac)) {
-                $out = ($neg ? '-' : '') . $int . '.' . $frac;
-                if ($out === '-0.00') $out = '0.00';
-                $set($target, $out);
-                return;
-            }
-
-            // More than 2 fractional digits:
-            // - If extras are all zeros, trim to 2 (e.g., 0.2500 → 0.25)
-            // - Else leave unchanged (validation should flag), and DO NOT round
-            if (strlen($frac) > 2) {
-                $first2 = substr($frac, 0, 2);
-                $extra  = substr($frac, 2);
-                if (preg_match('/^0+$/', $extra)) {
-                    $out = ($neg ? '-' : '') . $int . '.' . $first2;
-                    if ($out === '-0.00') $out = '0.00';
-                    $set($target, $out);
-                }
-                // else: non-zero beyond 2 decimals → do nothing (let validation show error)
-                return;
-            }
+            $set($target, $prefix . $out);
         };
     }
 
@@ -121,7 +139,6 @@ class CurrencyInputFormElement extends Model
      */
     public static function getFilamentSchema(bool $disabled = false): array
     {
-
         $noSci = 'not_regex:/[eE]/'; // forbid scientific notation
         $currencyRegex = 'regex:/^-?\d+(\.\d{1,2})?$/';
 
@@ -132,7 +149,6 @@ class CurrencyInputFormElement extends Model
                     ->schema([
                         SchemaHelper::getPlaceholderTextField($disabled)
                             ->columnSpan(3),
-
                         TextInput::make('elementable_data.defaultValue')
                             ->label('Default Value')
                             ->numeric()
@@ -140,22 +156,16 @@ class CurrencyInputFormElement extends Model
                             ->step(.01)
                             ->live(onBlur: true)
                             ->afterStateUpdated(self::formatCurrency('elementable_data.defaultValue'))
-                            // Keep your base rules; add min/max comparisons only if present
-                            ->rules(function (Get $get) use ($currencyRegex, $noSci) {
-                                $rules = ['numeric', $currencyRegex, $noSci];
-
-                                if (filled($get('elementable_data.min'))) {
-                                    $rules[] = 'gte:elementable_data.min';
-                                }
-                                if (filled($get('elementable_data.max'))) {
-                                    $rules[] = 'lte:elementable_data.max';
-                                }
-
-                                return $rules;
-                            })
+                            ->rules([$currencyRegex, $noSci])
+                            ->rule(NumericRules::compareWith(
+                                minPath: 'elementable_data.min',
+                                maxPath: 'elementable_data.max',
+                                options: [
+                                    'format' => fn(float $n) => number_format($n, 2, '.', ''),
+                                ]
+                            ))
                             ->columnSpan(1)
                             ->disabled($disabled),
-
                         TextInput::make('elementable_data.min')
                             ->label('Minimum Value')
                             ->numeric()
@@ -163,19 +173,16 @@ class CurrencyInputFormElement extends Model
                             ->step(.01)
                             ->live(onBlur: true)
                             ->afterStateUpdated(self::formatCurrency('elementable_data.min'))
-                            ->rules(function (Get $get) use ($currencyRegex, $noSci) {
-                                $rules = ['numeric', $currencyRegex, $noSci];
-
-                                // Only enforce min <= max if max is provided
-                                if (filled($get('elementable_data.max'))) {
-                                    $rules[] = 'lte:elementable_data.max';
-                                }
-
-                                return $rules;
-                            })
+                            ->rules([$currencyRegex, $noSci])
+                            ->rule(NumericRules::compareWith(
+                                minPath: null,
+                                maxPath: 'elementable_data.max',
+                                options: [
+                                    'format' => fn(float $n) => number_format($n, 2, '.', ''),
+                                ]
+                            ))
                             ->columnSpan(1)
                             ->disabled($disabled),
-
                         TextInput::make('elementable_data.max')
                             ->label('Maximum Value')
                             ->numeric()
@@ -183,16 +190,14 @@ class CurrencyInputFormElement extends Model
                             ->step(.01)
                             ->live(onBlur: true)
                             ->afterStateUpdated(self::formatCurrency('elementable_data.max'))
-                            ->rules(function (Get $get) use ($currencyRegex, $noSci) {
-                                $rules = ['numeric', $currencyRegex, $noSci];
-
-                                // Only enforce max >= min if min is provided
-                                if (filled($get('elementable_data.min'))) {
-                                    $rules[] = 'gte:elementable_data.min';
-                                }
-
-                                return $rules;
-                            })
+                            ->rules([$currencyRegex, $noSci])
+                            ->rule(NumericRules::compareWith(
+                                minPath: 'elementable_data.min',
+                                maxPath: null,
+                                options: [
+                                    'format' => fn(float $n) => number_format($n, 2, '.', ''),
+                                ]
+                            ))
                             ->columnSpan(1)
                             ->disabled($disabled),
                     ])

--- a/app/Models/FormBuilding/NumberInputFormElement.php
+++ b/app/Models/FormBuilding/NumberInputFormElement.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\FormBuilding;
 
+use App\Filament\Forms\Helpers\NumericRules;
 use App\Helpers\SchemaHelper;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -55,98 +56,90 @@ class NumberInputFormElement extends Model
             $mask = strtolower((string) ($get('elementable_data.maskType') ?? 'integer')); // 'integer' | 'decimal'
 
             // Do not "fix" scientific notation or thousands separators; let validation reject them.
-            if (preg_match('/[eE, ]/', $raw)) {
+            if (preg_match('/[eE, ]/', $state)) {
                 return;
             }
 
             // Treat "-", "-0", "-0.0", etc. as zero (both modes)
-            if ($raw === '-' || preg_match('/^-\s*0*(?:\.0*)?$/', $raw)) {
+
+            $isZeroish = static function (string $s): bool {
+                $s = trim($s);
+                if ($s === '') return false;
+
+                $s = ltrim($s, "+-");
+                if ($s === '' || $s === '.') return true;
+
+                $clean = preg_replace('/[^\d.]/', '', $s) ?? '';
+                if ($clean === '' || substr_count($clean, '.') > 1) return false;
+
+                $digitsOnly = str_replace('.', '', $clean);
+                return $digitsOnly !== '' && preg_match('/^0+$/', $digitsOnly) === 1;
+            };
+
+            if ($isZeroish($raw)) {
                 $set($target, '0');
                 return;
             }
 
+            // Only allow plain numeric form at this stage
+            if (!preg_match('/^[+-]?\d*(?:\.\d*)?$/', $raw)) {
+                // Not a plain numeric string → leave it; validation will flag it.
+                return;
+            }
+
+            // Extract sign once; operate on a signless body
+            $sign = ($raw !== '' && $raw[0] === '-') ? '-' : '';
+            $body = ltrim($raw, '+-');
+
+            // INTEGER MODE (string-only truncation; no numeric conversions)
             if ($mask === 'integer') {
-                // ---- INTEGER MODE (truncate; do not round), negatives allowed ----
-                // If it's not numeric at all, leave it for validation.
-                if (!is_numeric($raw)) return;
+                // take integer part before any dot
+                $int = explode('.', $body, 2)[0] ?? '';
 
-                // Keep sign if present
-                $sign = ($raw !== '' && $raw[0] === '-') ? '-' : '';
-                $body = ltrim($raw, '-');
-
-                // Keep digits and dot; then take the integer part before any dot
-                $tmp = preg_replace('/[^0-9.]/', '', $body) ?? '';
-                $int = explode('.', $tmp, 2)[0] ?? '';
-                $int = preg_replace('/\D/', '', $int) ?? ''; // safety
+                // strip leading zeros; keep at least one '0'
                 $int = ltrim($int, '0');
+                if ($int === '') {
+                    $int = '0';
+                }
 
-                // Empty integer part becomes 0
-                if ($int === '') $int = '0';
-
-                // Avoid "-0"
-                if ($int === '0') $sign = '';
+                // avoid "-0"
+                if ($int === '0') {
+                    $sign = '';
+                }
 
                 $set($target, $sign . $int);
                 return;
             }
 
-            // ---- DECIMAL MODE (no forced rounding), negatives allowed ----
-            // Normalize incomplete forms to zero-ish decimal
-            if (in_array($raw, ['.', '-.'], true)) {
-                $set($target, '0');
-                return;
-            }
+            // DECIMAL MODE (string-only, unlimited decimals, trim extras)
+            if (strpos($body, '.') !== false) {
+                [$int, $frac] = explode('.', $body, 2);
 
-            // If not numeric at all, let validation handle it.
-            if (!is_numeric($raw)) return;
-
-            // Keep only one leading '-' and only the first '.'
-            $val = preg_replace('/[^\d.\-]/', '', $raw) ?? '';
-            $val = preg_replace('/(?!^)-/', '', $val) ?? '';     // remove extra '-' not at start
-            $val = preg_replace('/\.(?=.*\.)/', '', $val) ?? ''; // keep only first '.'
-
-            // If empty or just "-", normalize to 0
-            if ($val === '' || $val === '-') {
-                $set($target, '0');
-                return;
-            }
-
-            $sign = ($val[0] === '-') ? '-' : '';
-            $tmp  = ltrim($val, '-');
-
-            if (strpos($tmp, '.') !== false) {
-                [$int, $frac] = explode('.', $tmp, 2);
-
-                // sanitize integer and fractional parts
-                $int  = preg_replace('/\D/', '', $int) ?? '';
-                $frac = preg_replace('/\D/', '', $frac) ?? '';
-
-                // Normalize leading zeros in integer part
+                // normalize leading zeros in integer part
                 $int = ltrim($int, '0');
                 if ($int === '') $int = '0';
 
-                // Trim trailing zeros in fractional part; drop dot if empty
+                // trim trailing zeros in fractional part; drop the dot if empty
                 $frac = rtrim($frac, '0');
 
-                $normalized = $frac === ''
-                    ? $sign . $int
-                    : $sign . $int . '.' . $frac;
+                $out = ($frac === '') ? $int : ($int . '.' . $frac);
             } else {
-                // No dot: integer-like in decimal context
-                $int = preg_replace('/\D/', '', $tmp) ?? '';
+                // integer-like in decimal context
+                $int = preg_replace('/\D/', '', $body) ?? '';
                 $int = ltrim($int, '0');
                 if ($int === '') $int = '0';
-                $normalized = $sign . $int;
+                $out = $int;
             }
 
-            // Normalize "-0"
-            if ($normalized === '-0') {
-                $normalized = '0';
+            // avoid "-0"
+            if ($out === '0') {
+                $sign = '';
             }
 
-            $set($target, $normalized);
+            $set($target, $sign . $out);
         };
     }
+
 
     /**
      * Get the Filament form schema for this element type.
@@ -176,18 +169,14 @@ class NumberInputFormElement extends Model
                             ->afterStateUpdated(self::formatNumberByMask('elementable_data.defaultValue'))
                             ->rules(function (Get $get) use ($isDecimal, $noSci, $plainDecimal) {
                                 $rules = $isDecimal($get)
-                                    ? ['nullable', 'numeric', $noSci, $plainDecimal]
-                                    : ['nullable', 'integer'];
-
-                                if (filled($get('elementable_data.min'))) {
-                                    $rules[] = 'gte:elementable_data.min';
-                                }
-                                if (filled($get('elementable_data.max'))) {
-                                    $rules[] = 'lte:elementable_data.max';
-                                }
-
+                                    ? ['numeric', $noSci, $plainDecimal]
+                                    : ['integer'];
                                 return $rules;
                             })
+                            ->rule(NumericRules::compareWith(
+                                minPath: 'elementable_data.min',
+                                maxPath: 'elementable_data.max',
+                            ))
                             ->columnSpan(2)
                             ->disabled($disabled),
                         TextInput::make('elementable_data.min')
@@ -199,16 +188,14 @@ class NumberInputFormElement extends Model
                             ->afterStateUpdated(self::formatNumberByMask('elementable_data.min'))
                             ->rules(function (Get $get) use ($isDecimal, $noSci, $plainDecimal) {
                                 $rules = $isDecimal($get)
-                                    ? ['nullable', 'numeric', $noSci, $plainDecimal]
-                                    : ['nullable', 'integer'];
-
-                                // Only require min <= max if max is provided
-                                if (filled($get('elementable_data.max'))) {
-                                    $rules[] = 'lte:elementable_data.max';
-                                }
-
+                                    ? ['numeric', $noSci, $plainDecimal]
+                                    : ['integer'];
                                 return $rules;
                             })
+                            ->rule(NumericRules::compareWith(
+                                minPath: null,
+                                maxPath: 'elementable_data.max',
+                            ))
                             ->columnSpan(2)
                             ->disabled($disabled),
                         TextInput::make('elementable_data.max')
@@ -220,16 +207,14 @@ class NumberInputFormElement extends Model
                             ->afterStateUpdated(self::formatNumberByMask('elementable_data.max'))
                             ->rules(function (Get $get) use ($isDecimal, $noSci, $plainDecimal) {
                                 $rules = $isDecimal($get)
-                                    ? ['nullable', 'numeric', $noSci, $plainDecimal]
-                                    : ['nullable', 'integer'];
-
-                                // Only require max >= min if min is provided
-                                if (filled($get('elementable_data.min'))) {
-                                    $rules[] = 'gte:elementable_data.min';
-                                }
-
+                                    ? ['numeric', $noSci, $plainDecimal]
+                                    : ['integer'];
                                 return $rules;
                             })
+                            ->rule(NumericRules::compareWith(
+                                minPath: 'elementable_data.min',
+                                maxPath: null,
+                            ))
                             ->columnSpan(2)
                             ->disabled($disabled),
                         ToggleButtons::make('elementable_data.maskType')
@@ -257,8 +242,7 @@ class NumberInputFormElement extends Model
                                     }
                                 } else {
                                     // Decimal mode: keep or set a reasonable decimal step
-                                    $currentStep = $get('elementable_data.step');
-                                    $set('elementable_data.step', filled($currentStep) ? $currentStep : 0.01);
+                                    $set('elementable_data.step', 0.01);
                                 }
                             }),
                         TextInput::make('elementable_data.step')
@@ -268,7 +252,7 @@ class NumberInputFormElement extends Model
                             ->default(1)
                             ->live(onBlur: true)
                             // Ensure UI "step" attribute makes sense (1 for integer; any step otherwise)
-                            ->step(fn(Get $get) => $isDecimal($get) ? null : 1)
+                            ->step(fn(Get $get) => $isDecimal($get) ? "any" : 1)
                             ->afterStateUpdated(self::formatNumberByMask('elementable_data.step'))
                             // Validation: integer & >=1 in integer mode; numeric & >0 in decimal mode
                             ->rule(fn(Get $get) => $isDecimal($get)


### PR DESCRIPTION
## What changes did you make? 

- Simplified the formatting functions applied to the number and currency inputs’ property fields
- Fix number and currency inputs' field constraint validations using a working reusable helper comparison function
  - Helper comparison function added to its own helper file for numeric rules

## Why did you make these changes?

The original constraint validations (<= and >= — gte and lte in Filament) on the number and currency inputs’ property fields were failing because the formatting functions applied to those fields were converting the values into strings. Instead of using the default gte and lte rules, a custom comparison function was created that would convert the formatted number strings back into numbers and perform the constraint validations.

## What alternatives did you consider?

None

### Checklist

- [X] **I have assigned at least one reviewer**
- [X] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
