### PR TITLE
ADO 3613 allow field to be readonly/required only after form state is met

### DIFF
--- a/app/Helpers/GeneralTabHelper.php
+++ b/app/Helpers/GeneralTabHelper.php
@@ -86,11 +86,14 @@ class GeneralTabHelper
                     $set('description', $template->description);
                     $set('help_text', $template->help_text);
                     $set('elementable_type', $template->elementable_type);
+                    $set('is_required_toggle', $template->is_required !== null && $template->is_required !== '');
                     $set('is_required', $template->is_required);
+                    $set('is_read_only_toggle', $template->is_read_only !== null && $template->is_read_only !== '');
+                    $set('is_read_only', $template->is_read_only);
                     $set('visible_web', $template->visible_web);
                     $set('visible_pdf', $template->visible_pdf);
                     $set('is_template', false); // New element should not be a template by default
-
+    
                     // Prefill tags
                     if ($template->tags->isNotEmpty()) {
                         $set('tags', $template->tags->pluck('id')->toArray());
@@ -219,8 +222,8 @@ class GeneralTabHelper
                         ->tooltip(fn($get) => $get('reference_id_locked')
                             ? ''
                             : 'Click to unlock and edit the Reference ID. Changing this value may break ICM data bindings.')->action(function ($set, $get) {
-                            $set('reference_id_locked', true);
-                        })
+                                $set('reference_id_locked', true);
+                            })
                 )
                 ->disabled(fn($get) => !$get('reference_id_locked'))
                 ->suffix(function ($get) {
@@ -402,50 +405,50 @@ class GeneralTabHelper
             // For create and view modes
             $elementTypeField = $isCreate
                 ? ToggleButtons::make('elementable_type')
-                ->label(function (?string $state): string {
-                    $elementType = $state ? FormElement::getElementTypeName($state) : '';
-                    if ($elementType) {
-                        return "Element Type: {$elementType}";
-                    } else {
-                        return 'Element Type';
-                    }
-                })
-                ->options(FormElement::getAvailableElementTypes())
-                ->inline()
-                ->icons([
-                    'App\Models\FormBuilding\TextInputFormElement' => 'heroicon-o-pencil-square',
-                    'App\Models\FormBuilding\TextareaInputFormElement' => 'heroicon-o-document-text',
-                    'App\Models\FormBuilding\SelectInputFormElement' => 'heroicon-o-queue-list',
-                    'App\Models\FormBuilding\RadioInputFormElement' => 'heroicon-o-radio',
-                    'App\Models\FormBuilding\CheckboxInputFormElement' => 'heroicon-o-check-circle',
-                    'App\Models\FormBuilding\CheckboxGroupFormElement' => 'heroicon-o-list-bullet',
-                    'App\Models\FormBuilding\DateSelectInputFormElement' => 'heroicon-o-calendar',
-                    'App\Models\FormBuilding\NumberInputFormElement' => 'heroicon-o-calculator',
-                    'App\Models\FormBuilding\CurrencyInputFormElement' => 'heroicon-o-currency-dollar',
-                    'App\Models\FormBuilding\ContainerFormElement' => 'heroicon-o-rectangle-group',
-                    'App\Models\FormBuilding\TextInfoFormElement' => 'heroicon-o-information-circle',
-                    'App\Models\FormBuilding\ButtonInputFormElement' => 'heroicon-o-cursor-arrow-ripple',
-                    'App\Models\FormBuilding\HTMLFormElement' => 'heroicon-o-code-bracket',
-                ])
-                ->required()
-                ->live()
-                ->disabled($disabled || ($disabledCallback && $disabledCallback()))
-                ->afterStateUpdated(function ($state, callable $set) {
-                    // Clear existing elementable data when type changes
-                    $set('elementable_data', []);
-
-                    // Populate with defaults from the new element type
-                    if ($state && class_exists($state)) {
-                        $defaults = self::getElementTypeDefaults($state);
-
-                        if (!empty($defaults)) {
-                            $set('elementable_data', $defaults);
+                    ->label(function (?string $state): string {
+                        $elementType = $state ? FormElement::getElementTypeName($state) : '';
+                        if ($elementType) {
+                            return "Element Type: {$elementType}";
+                        } else {
+                            return 'Element Type';
                         }
-                    }
-                })
+                    })
+                    ->options(FormElement::getAvailableElementTypes())
+                    ->inline()
+                    ->icons([
+                        'App\Models\FormBuilding\TextInputFormElement' => 'heroicon-o-pencil-square',
+                        'App\Models\FormBuilding\TextareaInputFormElement' => 'heroicon-o-document-text',
+                        'App\Models\FormBuilding\SelectInputFormElement' => 'heroicon-o-queue-list',
+                        'App\Models\FormBuilding\RadioInputFormElement' => 'heroicon-o-radio',
+                        'App\Models\FormBuilding\CheckboxInputFormElement' => 'heroicon-o-check-circle',
+                        'App\Models\FormBuilding\CheckboxGroupFormElement' => 'heroicon-o-list-bullet',
+                        'App\Models\FormBuilding\DateSelectInputFormElement' => 'heroicon-o-calendar',
+                        'App\Models\FormBuilding\NumberInputFormElement' => 'heroicon-o-calculator',
+                        'App\Models\FormBuilding\CurrencyInputFormElement' => 'heroicon-o-currency-dollar',
+                        'App\Models\FormBuilding\ContainerFormElement' => 'heroicon-o-rectangle-group',
+                        'App\Models\FormBuilding\TextInfoFormElement' => 'heroicon-o-information-circle',
+                        'App\Models\FormBuilding\ButtonInputFormElement' => 'heroicon-o-cursor-arrow-ripple',
+                        'App\Models\FormBuilding\HTMLFormElement' => 'heroicon-o-code-bracket',
+                    ])
+                    ->required()
+                    ->live()
+                    ->disabled($disabled || ($disabledCallback && $disabledCallback()))
+                    ->afterStateUpdated(function ($state, callable $set) {
+                        // Clear existing elementable data when type changes
+                        $set('elementable_data', []);
+
+                        // Populate with defaults from the new element type
+                        if ($state && class_exists($state)) {
+                            $defaults = self::getElementTypeDefaults($state);
+
+                            if (!empty($defaults)) {
+                                $set('elementable_data', $defaults);
+                            }
+                        }
+                    })
                 : TextInput::make('elementable_type')
-                ->label('Element Type')
-                ->disabled(true);
+                    ->label('Element Type')
+                    ->disabled(true);
         }
 
         // Add tooltip if callback is provided
@@ -478,17 +481,15 @@ class GeneralTabHelper
         $schema[] = $helpTextField;
 
         // Visibility toggles
-        $schema[] = Grid::make(2)
-            ->schema([
-                Toggle::make('visible_web')
-                    ->label('Visible on Web')
-                    ->default(true)
-                    ->disabled($disabled || ($disabledCallback && $disabledCallback())),
-                Toggle::make('visible_pdf')
-                    ->label('Visible on PDF')
-                    ->default(true)
-                    ->disabled($disabled || ($disabledCallback && $disabledCallback())),
-            ]);
+        $visibleWebToggle = Toggle::make('visible_web')
+            ->label('Visible on Web')
+            ->default(true)
+            ->disabled($disabled || ($disabledCallback && $disabledCallback()));
+
+        $visiblePdfToggle = Toggle::make('visible_pdf')
+            ->label('Visible on PDF')
+            ->default(true)
+            ->disabled($disabled || ($disabledCallback && $disabledCallback()));
 
         // Required and Template toggles
         $templateToggle = Toggle::make('is_template')
@@ -503,27 +504,68 @@ class GeneralTabHelper
             });
         }
 
-        $requirementToggle = Toggle::make('is_required')
+        $requirementToggle = Toggle::make('is_required_toggle')
             ->label('Is Required')
-            ->default(false);
+            ->default(false)
+            ->live()
+            ->afterStateHydrated(function (Toggle $component, callable $set, callable $get) {
+                $isRequired = $get('is_required');
+                // Set toggle to true if is_required has any non-null value ('always' or 'portal')
+                if ($isRequired !== null && $isRequired !== '') {
+                    $set('is_required_toggle', true);
+                }
+            });
+
+        $requirementToggleButtons = ToggleButtons::make('is_required')
+            ->label('Required When')
+            ->options([
+                'always' => 'Always',
+                'portal' => 'On Portal Forms'
+            ])
+            ->default('always')
+            ->inline()
+            ->disabled(fn($get) => !$get('is_required_toggle'))
+            ->afterStateHydrated(function (callable $set, callable $get) {
+                $value = $get('is_required');
+                if ($value === null || $value === '') {
+                    $set('is_required', 'always');
+                }
+            });
 
         // For view mode or when disabled callback is true, disable the is_required toggle too
         if ($disabled || ($disabledCallback && $disabledCallback())) {
             $requirementToggle = $requirementToggle->disabled(true);
         }
 
-        $schema[] = Grid::make(2)
-            ->schema([
-                $requirementToggle,
-                $templateToggle,
-            ]);
-
         // Read Only and Save on Submit toggles
-        $readOnlyToggle = Toggle::make('is_read_only')
+        $readOnlyBool = Toggle::make('is_read_only_toggle')
             ->label('Is Read Only')
             ->default(false)
             ->live()
-            ->disabled($disabled || ($disabledCallback && $disabledCallback()));
+            ->disabled($disabled || ($disabledCallback && $disabledCallback()))
+            ->afterStateHydrated(function (Toggle $component, callable $set, callable $get) {
+                $isReadOnly = $get('is_read_only');
+                // Set toggle to true if is_read_only has any non-null value ('always' or 'portal')
+                if ($isReadOnly !== null && $isReadOnly !== '') {
+                    $set('is_read_only_toggle', true);
+                }
+            });
+
+        $readOnlyToggleButtons = ToggleButtons::make('is_read_only')
+            ->label('Read Only When')
+            ->options([
+                'always' => 'Always',
+                'portal' => 'On Portal Forms'
+            ])
+            ->default('always')
+            ->inline()
+            ->disabled(fn($get) => !$get('is_read_only_toggle'))
+            ->afterStateHydrated(function (callable $set, callable $get) {
+                $value = $get('is_read_only');
+                if ($value === null || $value === '') {
+                    $set('is_read_only', 'always');
+                }
+            });
 
         $saveOnSubmitToggle = Toggle::make('save_on_submit')
             ->label('Save on Submit')
@@ -537,13 +579,7 @@ class GeneralTabHelper
             });
         }
 
-        $schema[] = Grid::make(2)
-            ->schema([
-                $readOnlyToggle,
-                $saveOnSubmitToggle,
-            ]);
-
-        $schema[] = Grid::make(1)
+        $customReadOnlyField = Grid::make(1)
             ->schema([
                 TextArea::make('custom_read_only')
                     ->label('Custom Read Only Script')
@@ -604,7 +640,20 @@ class GeneralTabHelper
             }
         }
 
-        $schema[] = $tagsField;
+        // Organize visibility, validation, behaviour, and metadata fields
+        $schema[] = Grid::make(2)
+            ->schema([
+                $visibleWebToggle,
+                $visiblePdfToggle,
+                $requirementToggle,
+                $requirementToggleButtons,
+                $readOnlyBool,
+                $readOnlyToggleButtons,
+                $customReadOnlyField,
+                $templateToggle,
+                $saveOnSubmitToggle,
+                $tagsField->columnSpanFull(),
+            ]);
 
         return $schema;
     }

--- a/app/Models/FormBuilding/FormElement.php
+++ b/app/Models/FormBuilding/FormElement.php
@@ -43,8 +43,6 @@ class FormElement extends Model
     protected $casts = [
         'order' => 'integer',
         'parent_id' => 'integer',
-        'is_read_only' => 'boolean',
-        'is_required' => 'boolean',
         'save_on_submit' => 'boolean',
         'visible_web' => 'boolean',
         'visible_pdf' => 'boolean',
@@ -491,7 +489,7 @@ class FormElement extends Model
         return self::create($elementData);
     }
 
-/**
+    /**
      * Create a currency input form element
      */
     public static function createCurrency(array $elementData, array $currencyData): self
@@ -501,7 +499,7 @@ class FormElement extends Model
         $elementData['elementable_id'] = $currency->id;
 
         return self::create($elementData);
-    }    
+    }
 
     /**
      * Create a date select input form element

--- a/app/Services/FormVersionJsonService.php
+++ b/app/Services/FormVersionJsonService.php
@@ -143,9 +143,11 @@ class FormVersionJsonService
 
         // Append all attached stylesheets to the web CSS
         foreach ($formVersion->styleSheets as $sheet) {
-            if (!$sheet) continue;
+            if (!$sheet)
+                continue;
             $key = $sheet->id ? ('style:' . $sheet->id) : null;
-            if ($key && isset($added[$key])) continue;
+            if ($key && isset($added[$key]))
+                continue;
 
             $css = $sheet->getCssContent() ?? '';
             if ($css !== '') {
@@ -153,7 +155,8 @@ class FormVersionJsonService
                     . "/* Attached stylesheet */\n"
                     . $css;
             }
-            if ($key) $added[$key] = true;
+            if ($key)
+                $added[$key] = true;
         }
 
         if ($webCss !== '') {
@@ -189,9 +192,11 @@ class FormVersionJsonService
 
         // Append all attached form scripts to the web JS
         foreach ($formVersion->formScripts as $script) {
-            if (!$script) continue;
+            if (!$script)
+continue;
             $key = $script->id ? ('script:' . $script->id) : null;
-            if ($key && isset($added[$key])) continue;
+            if ($key && isset($added[$key]))
+continue;
 
             $js = $script->getJsContent() ?? '';
             if ($js !== '') {
@@ -199,7 +204,8 @@ class FormVersionJsonService
                     . "/* Attached form script */\n"
                     . $js;
             }
-            if ($key) $added[$key] = true;
+            if ($key)
+$added[$key] = true;
         }
 
         if ($webJs !== '') {
@@ -250,16 +256,19 @@ class FormVersionJsonService
 
         // 3) Append all attached stylesheets (deduping)
         foreach ($formVersion->styleSheets as $sheet) {
-            if (!$sheet) continue;
+            if (!$sheet)
+continue;
             $key = $sheet->id ? ('style:' . $sheet->id) : null;
-            if ($key && isset($added[$key])) continue;
+            if ($key && isset($added[$key]))
+continue;
 
             $styles[] = [
                 'type' => $sheet->type ?? 'web',
                 'filename' => $sheet->filename,
                 'content' => $sheet->getCssContent() ?? ''
             ];
-            if ($key) $added[$key] = true;
+            if ($key)
+$added[$key] = true;
         }
 
         return $styles;
@@ -296,16 +305,19 @@ class FormVersionJsonService
 
         // 3) Append all attached form scripts (deduping)
         foreach ($formVersion->formScripts as $script) {
-            if (!$script) continue;
+            if (!$script)
+continue;
             $key = $script->id ? ('script:' . $script->id) : null;
-            if ($key && isset($added[$key])) continue;
+            if ($key && isset($added[$key]))
+continue;
 
             $scripts[] = [
                 'type' => $script->type ?? 'web',
                 'filename' => $script->filename,
                 'content' => $script->getJsContent() ?? ''
             ];
-            if ($key) $added[$key] = true;
+            if ($key)
+$added[$key] = true;
         }
 
         return $scripts;
@@ -470,7 +482,7 @@ class FormVersionJsonService
             return $this->transformRepeatableContainerAsGroup($element, $elementData);
         }
 
-        $elementData['containerId'] = (string)($element->id ?? '');
+        $elementData['containerId'] = (string) ($element->id ?? '');
         $elementData['clear_button'] = false;
         $elementData['codeContext'] = [
             'name' => $this->generateCodeContextName($element->name ?? 'container')
@@ -521,7 +533,7 @@ class FormVersionJsonService
         // Transform repeatable container to group format for renderer compatibility
         $elementData['type'] = 'group'; // Override type to group
         $elementData['label'] = $element->elementable?->legend ?? null;
-        $elementData['groupId'] = (string)($element->id ?? '1');
+        $elementData['groupId'] = (string) ($element->id ?? '1');
         $elementData['repeater'] = true; // Always true for repeatable containers
         $elementData['repeaterLabel'] = $element->elementable?->legend ?? null;
         $elementData['repeaterItemLabel'] = $element->elementable?->repeater_item_label;
@@ -588,7 +600,7 @@ class FormVersionJsonService
     protected function transformGroupElement(FormElement $element, array $elementData): array
     {
         $elementData['label'] = $element->elementable?->legend ?? null;
-        $elementData['groupId'] = (string)($element->id ?? '1');
+        $elementData['groupId'] = (string) ($element->id ?? '1');
         $elementData['repeater'] = $element->elementable?->is_repeatable ?? false;
         $elementData['repeaterLabel'] = $element->elementable?->legend ?? null;
         $elementData['repeaterItemLabel'] = $element->elementable?->repeater_item_label;
@@ -767,7 +779,7 @@ class FormVersionJsonService
                 // Add default value for boolean elements
                 $attributes = $this->getElementAttributes($element);
                 if (isset($attributes['default_value'])) {
-                    $elementData['defaultValue'] = (bool)$attributes['default_value'];
+                    $elementData['defaultValue'] = (bool) $attributes['default_value'];
                 }
                 break;
             case 'radio-input':
@@ -851,7 +863,7 @@ class FormVersionJsonService
         if (isset($attributes['required']) && $attributes['required'] || $element->is_required) {
             $validation[] = [
                 'type' => 'required',
-                'value' => (bool)($attributes['required'] ?? $element->is_required),
+                'value' => (bool) ($attributes['required'] ?? $element->is_required),
                 'errorMessage' => $attributes['required_message'] ?? 'This field is required!'
             ];
         }
@@ -860,7 +872,7 @@ class FormVersionJsonService
         if (isset($attributes['min_length'])) {
             $validation[] = [
                 'type' => 'minLength',
-                'value' => (string)$attributes['min_length'],
+                'value' => (string) $attributes['min_length'],
                 'errorMessage' => $attributes['min_length_message'] ?? "Minimum length is {$attributes['min_length']}"
             ];
         }
@@ -868,7 +880,7 @@ class FormVersionJsonService
         if (isset($attributes['max_length'])) {
             $validation[] = [
                 'type' => 'maxLength',
-                'value' => (string)$attributes['max_length'],
+                'value' => (string) $attributes['max_length'],
                 'errorMessage' => $attributes['max_length_message'] ?? "Maximum length is {$attributes['max_length']}"
             ];
         }
@@ -877,7 +889,7 @@ class FormVersionJsonService
         if (isset($attributes['min_value'])) {
             $validation[] = [
                 'type' => 'minValue',
-                'value' => (string)$attributes['min_value'],
+                'value' => (string) $attributes['min_value'],
                 'errorMessage' => $attributes['min_value_message'] ?? "Minimum value is {$attributes['min_value']}"
             ];
         }
@@ -885,7 +897,7 @@ class FormVersionJsonService
         if (isset($attributes['max_value'])) {
             $validation[] = [
                 'type' => 'maxValue',
-                'value' => (string)$attributes['max_value'],
+                'value' => (string) $attributes['max_value'],
                 'errorMessage' => $attributes['max_value_message'] ?? "Maximum value is {$attributes['max_value']}"
             ];
         }
@@ -1086,7 +1098,7 @@ class FormVersionJsonService
     protected function convertKeyValueArrayToObject($keyValueArray): object
     {
         if (!is_array($keyValueArray)) {
-            return (object)[];
+            return (object) [];
         }
 
         $result = [];
@@ -1096,7 +1108,7 @@ class FormVersionJsonService
             }
         }
 
-        return (object)$result;
+        return (object) $result;
     }
 
     /**
@@ -1120,16 +1132,16 @@ class FormVersionJsonService
         }
 
         if (empty($jsonString) || !is_string($jsonString)) {
-            return (object)[];
+            return (object) [];
         }
 
         $decoded = json_decode($jsonString, true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
-            return (object)[];
+            return (object) [];
         }
 
-        return is_array($decoded) ? (object)$decoded : (object)[];
+        return is_array($decoded) ? (object) $decoded : (object) [];
     }
 
     /**
@@ -1151,7 +1163,7 @@ class FormVersionJsonService
             case 'min':
             case 'step':
                 if (is_numeric($value)) {
-                    return [$key, (float)$value];
+                    return [$key, (float) $value];
                 }
                 return [$key, $value];
             case 'dateFormat':

--- a/database/migrations/2026_02_25_191737_add_required_when_and_read_only_when_to_form_elements.php
+++ b/database/migrations/2026_02_25_191737_add_required_when_and_read_only_when_to_form_elements.php
@@ -1,0 +1,96 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Columns to convert: boolean → enum string.
+     */
+    protected array $columns = ['is_required', 'is_read_only'];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Step 1: Add temporary string columns
+        Schema::table('form_elements', function (Blueprint $table) {
+            foreach ($this->columns as $column) {
+                $table->string("{$column}_new")->nullable()->after($column);
+            }
+        });
+
+        // Step 2: Migrate data: true → 'always', false/null → null
+        foreach ($this->columns as $column) {
+            DB::table('form_elements')->chunkById(1000, function ($rows) use ($column) {
+                foreach ($rows as $row) {
+                    $newValue = match ($row->{$column}) {
+                        true => 'always',
+                        default => null,
+                    };
+
+                    DB::table('form_elements')
+                        ->where('id', $row->id)
+                        ->update(["{$column}_new" => $newValue]);
+                }
+            });
+        }
+
+        // Step 3: Drop old boolean columns
+        Schema::table('form_elements', function (Blueprint $table) {
+            foreach ($this->columns as $column) {
+                $table->dropColumn($column);
+            }
+        });
+
+        // Step 4: Rename new columns to original names
+        Schema::table('form_elements', function (Blueprint $table) {
+            foreach ($this->columns as $column) {
+                $table->renameColumn("{$column}_new", $column);
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Step 1: Add temporary boolean columns
+        Schema::table('form_elements', function (Blueprint $table) {
+            foreach ($this->columns as $column) {
+                $table->boolean("{$column}_new")->default(false)->after($column);
+            }
+        });
+
+        // Step 2: Reverse migrate: 'always' → true, null → false
+        foreach ($this->columns as $column) {
+            DB::table('form_elements')->chunkById(1000, function ($rows) use ($column) {
+                foreach ($rows as $row) {
+                    $newValue = $row->{$column} === 'always';
+
+                    DB::table('form_elements')
+                        ->where('id', $row->id)
+                        ->update(["{$column}_new" => $newValue]);
+                }
+            });
+        }
+
+        // Step 3: Drop enum columns
+        Schema::table('form_elements', function (Blueprint $table) {
+            foreach ($this->columns as $column) {
+                $table->dropColumn($column);
+            }
+        });
+
+        // Step 4: Rename boolean columns back
+        Schema::table('form_elements', function (Blueprint $table) {
+            foreach ($this->columns as $column) {
+                $table->renameColumn("{$column}_new", $column);
+            }
+        });
+    }
+};


### PR DESCRIPTION
## What changes did you make? 

Added sets of toggle buttons `Allowed` and `Portal` that are available after readonly/required is true.

This change converts the `is_required` and `is_read_only` columns of `form_elements` from `bool` to `enum`, and **requires migration**. It works with Kiln regardless of whether the accompanying Kiln changes have been applied or not.

## Why did you make these changes?

ADO 3613

## What alternatives did you consider?

Considered creating new columns in `form_elements` for the enum, but that value being non-null would always mean `is_required`/`is_read_only` was true, making it redundant.

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
