### PR TITLE
ADO-3749 Limit repeater instances

### DIFF
--- a/app/Livewire/FormElementTreeBuilder.php
+++ b/app/Livewire/FormElementTreeBuilder.php
@@ -390,7 +390,7 @@ class FormElementTreeBuilder extends BaseWidget implements HasForms
         // But convert null values to empty strings for text fields that the user might want to clear
         $textFields = ['labelText', 'placeholder', 'helperText', 'mask', 'maskErrorMessage', 'content', 'legend', 'repeater_item_label'];
         $numericFields = ['min', 'max', 'step', 'defaultValue', 'maxCount', 'rows', 'cols', 'order'];
-        $nullableFields = ['level'];
+        $nullableFields = ['level', 'defaultSelected'];
 
         $filteredElementableData = [];
         foreach ($elementableData as $key => $value) {
@@ -559,7 +559,7 @@ class FormElementTreeBuilder extends BaseWidget implements HasForms
         // But convert null values to empty strings for text fields that the user might want to clear
         $textFields = ['labelText', 'placeholder', 'helperText', 'mask', 'maskErrorMessage', 'content', 'legend', 'repeater_item_label'];
         $numericFields = ['min', 'max', 'step', 'defaultValue', 'maxCount', 'rows', 'cols', 'order'];
-        $nullableFields = ['level'];
+        $nullableFields = ['level', 'defaultSelected'];
 
         $filteredElementableData = [];
         foreach ($elementableData as $key => $value) {

--- a/app/Livewire/FormElementTreeBuilder.php
+++ b/app/Livewire/FormElementTreeBuilder.php
@@ -389,7 +389,7 @@ class FormElementTreeBuilder extends BaseWidget implements HasForms
         // Filter out null values from elementable data to let model defaults apply
         // But convert null values to empty strings for text fields that the user might want to clear
         $textFields = ['labelText', 'placeholder', 'helperText', 'mask', 'maskErrorMessage', 'content', 'legend', 'repeater_item_label'];
-        $numericFields = ['min', 'max', 'step', 'defaultValue', 'maxCount', 'rows', 'cols', 'order'];
+        $numericFields = ['min', 'max', 'step', 'defaultValue', 'maxCount', 'rows', 'cols', 'order', 'min_repeats', 'max_repeats'];
         $nullableFields = ['level', 'defaultSelected'];
 
         $filteredElementableData = [];
@@ -558,7 +558,7 @@ class FormElementTreeBuilder extends BaseWidget implements HasForms
         // Filter out null values from elementable data to let model defaults apply
         // But convert null values to empty strings for text fields that the user might want to clear
         $textFields = ['labelText', 'placeholder', 'helperText', 'mask', 'maskErrorMessage', 'content', 'legend', 'repeater_item_label'];
-        $numericFields = ['min', 'max', 'step', 'defaultValue', 'maxCount', 'rows', 'cols', 'order'];
+        $numericFields = ['min', 'max', 'step', 'defaultValue', 'maxCount', 'rows', 'cols', 'order', 'min_repeats', 'max_repeats'];
         $nullableFields = ['level', 'defaultSelected'];
 
         $filteredElementableData = [];

--- a/app/Models/FormBuilding/ContainerFormElement.php
+++ b/app/Models/FormBuilding/ContainerFormElement.php
@@ -2,16 +2,20 @@
 
 namespace App\Models\FormBuilding;
 
+use App\Filament\Forms\Helpers\NumericRules;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Filament\Forms\Components\Actions\Action;
 use App\Helpers\SchemaHelper;
+use Filament\Forms\Get;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
+
+use Closure;
 
 class ContainerFormElement extends Model
 {
@@ -21,6 +25,8 @@ class ContainerFormElement extends Model
         'container_type',
         'is_repeatable',
         'repeater_item_label',
+        'min_repeats',
+        'max_repeats',
         'legend',
         'enableVarSub',
         'level'
@@ -28,6 +34,8 @@ class ContainerFormElement extends Model
 
     protected $casts = [
         'is_repeatable' => 'boolean',
+        'min_repeats' => 'integer',
+        'max_repeats' => 'integer',
     ];
 
     protected $attributes = [
@@ -35,33 +43,103 @@ class ContainerFormElement extends Model
         'is_repeatable' => false,
     ];
 
+    protected static function formatInteger(string $target): Closure
+    {
+        return function ($state, callable $set, Get $get) use ($target) {
+            if ($state === null) return;
+
+            $raw = trim((string) $state);
+
+            // Do not "fix" scientific notation or thousands separators; let validation reject them.
+            if (preg_match('/[eE, ]/', $raw)) {
+                return;
+            }
+
+            // Strip everything except digits
+            $digits = preg_replace('/\D/', '', $raw) ?? '';
+
+            // Remove leading zeros
+            $digits = ltrim($digits, '0');
+
+            // If nothing remains (e.g., input was "0", "000", "-", etc.), normalize to null
+            if ($digits === '') {
+                $set($target, null);
+                return;
+            }
+
+            // Positive integer (no sign), no leading zeros
+            $set($target, $digits);
+        };
+    }
+
     /**
      * Get the Filament form schema for this element type.
      */
     public static function getFilamentSchema(bool $disabled = false): array
     {
+        $noSci = 'not_regex:/[eE]/'; // forbid scientific notation
+
         return [
             Fieldset::make('Container Settings')
                 ->schema([
                     Select::make('elementable_data.container_type')
                         ->label('Container Type')
+                        ->columnSpan(2)
                         ->options(static::getContainerTypes())
                         ->default('section')
                         ->required(true)
                         ->disabled($disabled),
                     Toggle::make('elementable_data.is_repeatable')
                         ->label('Repeatable')
+                        ->columnSpan(2)
                         ->helperText('Allow users to add multiple instances of this container')
                         ->default(false)
                         ->live()
                         ->disabled($disabled),
                     TextInput::make('elementable_data.repeater_item_label')
                         ->label('Repeater Item Label')
+                        ->columnSpan(2)
                         ->helperText('Label for individual repeater items (e.g., "Item", "Entry")')
                         ->disabled($disabled)
                         ->visible(fn(callable $get) => $get('elementable_data.is_repeatable')),
+                    TextInput::make('elementable_data.min_repeats')
+                        ->label('Minimum Repeats')
+                        ->integer()
+                        ->nullable()
+                        ->minValue(1)
+                        ->live(onBlur: true)
+                        ->afterStateUpdated(self::formatInteger('elementable_data.min_repeats'))
+                        ->rule($noSci)
+                        ->rule(NumericRules::compareWith(
+                            minPath: null,
+                            maxPath: 'elementable_data.max_repeats',
+                            options: [
+                                // Ensure error message always show integers
+                                'format' => fn(float $n) => number_format($n, 0, '.', ''),
+                            ]
+                        ))
+                        ->disabled($disabled)
+                        ->visible(fn(callable $get) => $get('elementable_data.is_repeatable')),
+                    TextInput::make('elementable_data.max_repeats')
+                        ->label('Maximum Repeats')
+                        ->integer()
+                        ->nullable()
+                        ->minValue(1)
+                        ->live(onBlur: true)
+                        ->afterStateUpdated(self::formatInteger('elementable_data.max_repeats'))
+                        ->rule($noSci)
+                        ->rule(NumericRules::compareWith(
+                            minPath: 'elementable_data.min_repeats',
+                            maxPath: null,
+                            options: [
+                                // Ensure error message always show integers
+                                'format' => fn(float $n) => number_format($n, 0, '.', ''),
+                            ]
+                        ))
+                        ->disabled($disabled)
+                        ->visible(fn(callable $get) => $get('elementable_data.is_repeatable')),
                 ])
-                ->columns(1),
+                ->columns(2),
             Fieldset::make('Label')
                 ->schema([
                     Select::make('elementable_data.level')
@@ -113,6 +191,8 @@ class ContainerFormElement extends Model
             'container_type' => $this->container_type,
             'is_repeatable' => $this->is_repeatable,
             'repeater_item_label' => $this->repeater_item_label,
+            'min_repeats' => $this->min_repeats,
+            'max_repeats' => $this->max_repeats,
             'legend' => $this->legend,
             'enableVarSub' => $this->enableVarSub,
             'level' => $this->level,
@@ -144,6 +224,8 @@ class ContainerFormElement extends Model
             'legend' => '',
             'enableVarSub' => false,
             'repeater_item_label' => '',
+            'min_repeats' => null,
+            'max_repeats' => null,
             'level' => null,
         ];
     }

--- a/app/Services/FormVersionJsonService.php
+++ b/app/Services/FormVersionJsonService.php
@@ -193,10 +193,10 @@ class FormVersionJsonService
         // Append all attached form scripts to the web JS
         foreach ($formVersion->formScripts as $script) {
             if (!$script)
-continue;
+                continue;
             $key = $script->id ? ('script:' . $script->id) : null;
             if ($key && isset($added[$key]))
-continue;
+                continue;
 
             $js = $script->getJsContent() ?? '';
             if ($js !== '') {
@@ -205,7 +205,7 @@ continue;
                     . $js;
             }
             if ($key)
-$added[$key] = true;
+                $added[$key] = true;
         }
 
         if ($webJs !== '') {
@@ -257,10 +257,10 @@ $added[$key] = true;
         // 3) Append all attached stylesheets (deduping)
         foreach ($formVersion->styleSheets as $sheet) {
             if (!$sheet)
-continue;
+                continue;
             $key = $sheet->id ? ('style:' . $sheet->id) : null;
             if ($key && isset($added[$key]))
-continue;
+                continue;
 
             $styles[] = [
                 'type' => $sheet->type ?? 'web',
@@ -268,7 +268,7 @@ continue;
                 'content' => $sheet->getCssContent() ?? ''
             ];
             if ($key)
-$added[$key] = true;
+                $added[$key] = true;
         }
 
         return $styles;
@@ -306,10 +306,10 @@ $added[$key] = true;
         // 3) Append all attached form scripts (deduping)
         foreach ($formVersion->formScripts as $script) {
             if (!$script)
-continue;
+                continue;
             $key = $script->id ? ('script:' . $script->id) : null;
             if ($key && isset($added[$key]))
-continue;
+                continue;
 
             $scripts[] = [
                 'type' => $script->type ?? 'web',
@@ -317,7 +317,7 @@ continue;
                 'content' => $script->getJsContent() ?? ''
             ];
             if ($key)
-$added[$key] = true;
+                $added[$key] = true;
         }
 
         return $scripts;
@@ -536,7 +536,9 @@ $added[$key] = true;
         $elementData['groupId'] = (string) ($element->id ?? '1');
         $elementData['repeater'] = true; // Always true for repeatable containers
         $elementData['repeaterLabel'] = $element->elementable?->legend ?? null;
-        $elementData['repeaterItemLabel'] = $element->elementable?->repeater_item_label;
+        $elementData['repeaterItemLabel'] = $element->elementable?->repeater_item_label ?? null;
+        $elementData['minRepeats'] = $element->elementable?->min_repeats ?? null;
+        $elementData['maxRepeats'] = $element->elementable?->max_repeats ?? null;
         $elementData['clear_button'] = $element->elementable?->clear_button ?? false;
         $elementData['codeContext'] = [
             'name' => $this->generateCodeContextName($element->name ?? 'group')
@@ -603,7 +605,9 @@ $added[$key] = true;
         $elementData['groupId'] = (string) ($element->id ?? '1');
         $elementData['repeater'] = $element->elementable?->is_repeatable ?? false;
         $elementData['repeaterLabel'] = $element->elementable?->legend ?? null;
-        $elementData['repeaterItemLabel'] = $element->elementable?->repeater_item_label;
+        $elementData['repeaterItemLabel'] = $element->elementable?->repeater_item_label ?? null;
+        $elementData['minRepeats'] = $element->elementable?->min_repeats ?? null;
+        $elementData['maxRepeats'] = $element->elementable?->max_repeats ?? null;
         $elementData['clear_button'] = $element->elementable?->clear_button ?? false;
         $elementData['codeContext'] = [
             'name' => $this->generateCodeContextName($element->name ?? 'group')

--- a/database/migrations/2026_03_12_174057_add_repeater_min_max_to_container_form_elements_table.php
+++ b/database/migrations/2026_03_12_174057_add_repeater_min_max_to_container_form_elements_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('container_form_elements', function (Blueprint $table) {
+            $table->integer('min_repeats')->nullable()->after('repeater_item_label');
+            $table->integer('max_repeats')->nullable()->after('min_repeats');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('container_form_elements', function (Blueprint $table) {
+            $table->dropColumn(['min_repeats', 'max_repeats']);
+        });
+    }
+};


### PR DESCRIPTION
## What changes did you make? 

- Added the checkbox group's default selected attribute to the null values filters (missing)
- Added support for min and max instance limits in repeaters

## Why did you make these changes?

- The checkbox group fix was added since it was missing
- ADO-3749: Add support for min and max instance limits in repeaters

## What alternatives did you consider?

None

### Checklist

- [X] **I have assigned at least one reviewer**
- [X] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
