### PR TITLE
Set ToggleButtons with null value to 'never'

### DIFF
--- a/database/migrations/2026_07_02_150324_fix_toggle_defaults.php
+++ b/database/migrations/2026_07_02_150324_fix_toggle_defaults.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $columns = [
+            'visible_web',
+            'visible_pdf',
+            'is_required',
+            'is_read_only',
+        ];
+
+        // Update all null or false values to 'never' for the specified columns
+        foreach ($columns as $col) {
+            DB::table('form_elements')
+                ->where(function ($query) use ($col) {
+                    $query->whereNull($col)
+                        ->orWhere($col, false)
+                        ->orWhere($col, 'false');
+                })
+                ->update([$col => 'never']);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $columns = [
+            'visible_web',
+            'visible_pdf',
+            'is_required',
+            'is_read_only',
+        ];
+
+        // Revert 'never' values back to null for the specified columns
+        foreach ($columns as $col) {
+            DB::table('form_elements')
+                ->where($col, 'never')
+                ->update([$col => null]);
+        }
+    }
+};


### PR DESCRIPTION
## What changes did you make? 

Set `null` values in visibility, required, and read-only form element properties to `'never'`

## Why did you make these changes?

Previous updates to these toggles updated existing form elements properties from `false` to `null`, instead of `'never'`

## What alternatives did you consider?

None

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
