### PR TITLE
ADO 4194 fix 500 error when searching Forms table

### DIFF
--- a/app/Filament/Forms/Resources/FormResource.php
+++ b/app/Filament/Forms/Resources/FormResource.php
@@ -545,8 +545,6 @@ class FormResource extends Resource
                     ->label('Migration 2025 Status')
                     ->badge()
                     ->toggleable()
-                    ->sortable()
-                    ->searchable()
                     ->getStateUsing(fn($record) => $record->migration2025_status)
                     ->color(function ($state) {
                         return match ($state) {

--- a/database/seeders/FormTagSeeder.php
+++ b/database/seeders/FormTagSeeder.php
@@ -13,8 +13,6 @@ class FormTagSeeder extends Seeder
      */
     public function run(): void
     {
-        FormTag::truncate();
-
         $tags = [
             'BCMailPlus',
             'MySS',
@@ -24,10 +22,14 @@ class FormTagSeeder extends Seeder
             'JAWS',
             'MIS',
             'ServiceCanada',
+            'storeXML',
+            'Digital Signature',
+            'migration2025',
+            'CHEFSCandidate',
         ];
 
         foreach ($tags as $tag) {
-            FormTag::create(['name' => $tag]);
+            FormTag::firstOrCreate(['name' => $tag]);
         }
     }
 }


### PR DESCRIPTION
## What changes did you make? 
Added currently existing `FormTag` values from production to the `FormTagSeeder` so that code in the `FormsResource` that assumes the `migration2025_status` tag exists can function

### Instructions
Run `sail artisan db:seed --class=FormTagSeeder`. The seeder is non-destructive and should be safe on all environments

## Why did you make these changes?
[ADO 4194](https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/4194/)
The 500 error occurs because the Forms resource table assumes that the `migration2025_status` tag exists.

## What alternatives did you consider?

None

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**